### PR TITLE
fix_type_case

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tikv-client-lib-java"]
+	path = tikv-client-lib-java
+	url = https://github.com/pingcap/tikv-client-lib-java.git

--- a/bin/build-client.sh
+++ b/bin/build-client.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+BASEDIR=$(dirname "$0")/../
+
+git submodule update --init --recursive
+
+cd ${BASEDIR}/tikv-client-lib-java
+mvn clean install
+

--- a/bin/build-client.sh
+++ b/bin/build-client.sh
@@ -2,7 +2,7 @@
 
 BASEDIR=$(dirname "$0")/../
 
-git submodule update --init --recursive
+git submodule update --init --recursive --remote --merge
 
 cd ${BASEDIR}/tikv-client-lib-java
 mvn clean install

--- a/src/main/scala/com/pingcap/tispark/BasicExpression.scala
+++ b/src/main/scala/com/pingcap/tispark/BasicExpression.scala
@@ -21,7 +21,6 @@ import com.google.proto4pingcap.ByteString
 import com.pingcap.tikv.expression.{TiColumnRef, TiConstant, TiExpr}
 import org.apache.spark.sql.catalyst.expressions.{Add, Alias, AttributeReference, Divide, EqualTo, Expression, GreaterThan, GreaterThanOrEqual, IsNotNull, LessThan, LessThanOrEqual, Literal, Multiply, Not, Remainder, Subtract}
 import org.apache.spark.sql.types._
-import org.apache.spark.unsafe.types.UTF8String
 
 object BasicExpression {
   implicit def stringToByteString(str: String): ByteString = ByteString.copyFromUtf8(str)
@@ -55,6 +54,7 @@ object BasicExpression {
         case DateType => new Date(MILLISEC_PER_DAY * value.asInstanceOf[Int]).toString
         case TimestampType => new Timestamp(value.asInstanceOf[Long])
         case StringType => value.toString
+        case _: DecimalType => value.asInstanceOf[Decimal].toBigDecimal.bigDecimal
         case _ => value
       }
     }

--- a/src/main/scala/com/pingcap/tispark/TiUtils.scala
+++ b/src/main/scala/com/pingcap/tispark/TiUtils.scala
@@ -20,7 +20,6 @@ import com.pingcap.tikv.types._
 import org.apache.spark.sql
 import org.apache.spark.sql.catalyst.expressions.aggregate._
 import org.apache.spark.sql.catalyst.expressions.{Expression, NamedExpression}
-import org.apache.spark.sql.types
 import org.apache.spark.sql.types.{DataType, DataTypes}
 
 

--- a/src/main/scala/com/pingcap/tispark/TiUtils.scala
+++ b/src/main/scala/com/pingcap/tispark/TiUtils.scala
@@ -18,9 +18,10 @@ package com.pingcap.tispark
 
 import com.pingcap.tikv.types._
 import org.apache.spark.sql
-import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.expressions.aggregate._
-import org.apache.spark.sql.types.DataType
+import org.apache.spark.sql.catalyst.expressions.{Expression, NamedExpression}
+import org.apache.spark.sql.types
+import org.apache.spark.sql.types.{DataType, DataTypes}
 
 
 object TiUtils {
@@ -43,21 +44,13 @@ object TiUtils {
   }
 
   def isSupportedBasicExpression(expr: Expression) = {
-    !BasicExpression.convertToTiExpr(expr).isEmpty
+    BasicExpression.convertToTiExpr(expr).fold(false) {_.isSupportedExpr}
   }
 
-  def isSupportedProjection(expr: Expression): Boolean = {
-    expr.find(child => !isSupportedBasicExpression(child)).isEmpty
-  }
+  def isSupportedFilter(expr: Expression): Boolean = isSupportedBasicExpression(expr)
 
-  def isSupportedFilter(expr: Expression): Boolean = {
-    isSupportedBasicExpression(expr)
-  }
-
-  // 1. if contains UDF / functions that cannot be folded
-  def isSupportedGroupingExpr(expr: Expression): Boolean = {
-    isSupportedBasicExpression(expr)
-  }
+  // if contains UDF / functions that cannot be folded
+  def isSupportedGroupingExpr(expr: NamedExpression): Boolean = isSupportedBasicExpression(expr)
 
   // convert tikv-java client FieldType to Spark DataType
   def toSparkDataType(tp: TiDataType): DataType = {
@@ -65,7 +58,8 @@ object TiUtils {
       case _: RawBytesType => sql.types.BinaryType
       case _: BytesType => sql.types.StringType
       case _: IntegerType => sql.types.LongType
-      case _: DecimalType => sql.types.DoubleType
+      case _: RealType => sql.types.DoubleType
+      case _: DecimalType => DataTypes.createDecimalType(tp.getLength, tp.getDecimal)
       case _: TimestampType => sql.types.TimestampType
       case _: DateType => sql.types.DateType
     }
@@ -76,7 +70,8 @@ object TiUtils {
       case _: sql.types.BinaryType => DataTypeFactory.of(Types.TYPE_BLOB)
       case _: sql.types.StringType => DataTypeFactory.of(Types.TYPE_VARCHAR)
       case _: sql.types.LongType => DataTypeFactory.of(Types.TYPE_LONG)
-      case _: sql.types.DoubleType => DataTypeFactory.of(Types.TYPE_NEW_DECIMAL)
+      case _: sql.types.DoubleType => DataTypeFactory.of(Types.TYPE_DOUBLE)
+      case _: sql.types.DecimalType => DataTypeFactory.of(Types.TYPE_NEW_DECIMAL)
       case _: sql.types.TimestampType => DataTypeFactory.of(Types.TYPE_TIMESTAMP)
       case _: sql.types.DateType => DataTypeFactory.of(Types.TYPE_DATE)
     }


### PR DESCRIPTION
1. fix type cast by converting spark argument types
2. add client as submodule
not using maven module is because client is used by all and not a part of tispark

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tispark/22)
<!-- Reviewable:end -->
