### PR TITLE
Eliminates these repeated computation in multi aggregations query

### DIFF
--- a/src/main/scala/org/apache/spark/sql/TiStrategy.scala
+++ b/src/main/scala/org/apache/spark/sql/TiStrategy.scala
@@ -180,11 +180,18 @@ class TiStrategy(context: SQLContext) extends Strategy with Logging {
   // and then we don't return (don't planLater) and plan the remaining all at once
   private def doPlan(source: TiDBRelation, plan: LogicalPlan): Seq[SparkPlan] = {
 
-    val aliasMap = mutable.HashMap[Expression, Alias]()
+    val aliasMap = mutable.HashMap[(Boolean,Expression), Alias]()
     val avgPushdownRewriteMap = mutable.HashMap[ExprId, List[AggregateExpression]]()
     val avgFinalRewriteMap = mutable.HashMap[ExprId, List[AggregateExpression]]()
 
-    def toAlias(expr: Expression) = aliasMap.getOrElseUpdate(expr, Alias(expr, expr.toString)())
+    def toAlias(expr: AggregateExpression) =
+      if (!expr.deterministic) {
+        Alias(expr, expr.toString())()
+      } else {
+        aliasMap.getOrElseUpdate(
+          (expr.deterministic, expr.canonicalized), Alias(expr, expr.toString)()
+        )
+      }
 
     def newAggregate(aggFunc: AggregateFunction,
                      originalAggExpr: AggregateExpression) =
@@ -266,7 +273,7 @@ class TiStrategy(context: SQLContext) extends Strategy with Logging {
           aggExpr =>
             avgPushdownRewriteMap
               .getOrElse(aggExpr.resultId, List(aggExpr))
-        }
+        }.distinct
 
         selReq = aggregationToSelectRequest(groupingExpressions,
           pushdownAggregates,
@@ -296,14 +303,13 @@ class TiStrategy(context: SQLContext) extends Strategy with Logging {
           }.asInstanceOf[NamedExpression]
         )
 
-        val output = (groupingExpressions ++ pushdownAggregates.map(x => toAlias(x))).map(_.toAttribute)
+        val output = (groupingExpressions ++ pushdownAggregates.map(x => toAlias(x))).map(_.toAttribute).distinct
 
         aggregate.AggUtils.planAggregateWithoutDistinct(
           groupingExpressions,
           residualAggregateExpressions,
           rewrittenResultExpression,
           toCoprocessorRDD(source, output, selReq))
-
       case _ => Nil
     }
   }


### PR DESCRIPTION
When more than one aggregation are requested in one query, tispark will push down some aggregations repeatedly, like `count(number#0L)` in the following example.

```scala
scala> spark.sql ("select count(number),avg(number) from person").explain
== Physical Plan ==
*HashAggregate(keys=[], functions=[sum(count(number#0L)#42L), sum(sum(number#0L)#43L), sum(count(number#0L)#45L)])
+- Exchange SinglePartition
   +- *HashAggregate(keys=[], functions=[partial_sum(count(number#0L)#42L), partial_sum(sum(number#0L)#43L), partial_sum(count(number#0L)#45L)])
      +- Scan CoprocessorRDD[count(number#0L)#42L,sum(number#0L)#43L,count(number#0L)#45L]
```

This PR eliminates these repeated computation:

```scala
scala> spark.sql ("select count(number),avg(number) from person").explain()
== Physical Plan ==
*HashAggregate(keys=[], functions=[sum(count(number#0L)#20L), sum(sum(number#0L)#21L), sum(count(number#0L)#20L)])
+- Exchange SinglePartition
   +- *HashAggregate(keys=[], functions=[partial_sum(count(number#0L)#20L), partial_sum(sum(number#0L)#21L), partial_sum(count(number#0L)#20L)])
      +- Scan CoprocessorRDD[count(number#0L)#20L,sum(number#0L)#21L]
```