### PR TITLE
[Bug fix]Fix Flen overflow

### DIFF
--- a/src/main/scala/com/pingcap/tispark/TiUtils.scala
+++ b/src/main/scala/com/pingcap/tispark/TiUtils.scala
@@ -62,7 +62,7 @@ object TiUtils {
       case _: BytesType => sql.types.StringType
       case _: IntegerType => sql.types.LongType
       case _: RealType => sql.types.DoubleType
-      case _: DecimalType => DataTypes.createDecimalType(Math.min(Integer.MAX_VALUE, tp.getLength).asInstanceOf[Int], tp.getDecimal)
+      case _: DecimalType => DataTypes.createDecimalType(Math.min(Integer.MAX_VALUE, tp.getLength).asInstanceOf[Int], tp.getDecimal) // we need to make sure that tp.getLength does not result in negative number when casting.
       case _: TimestampType => sql.types.TimestampType
       case _: DateType => sql.types.DateType
     }

--- a/src/main/scala/com/pingcap/tispark/TiUtils.scala
+++ b/src/main/scala/com/pingcap/tispark/TiUtils.scala
@@ -62,7 +62,7 @@ object TiUtils {
       case _: BytesType => sql.types.StringType
       case _: IntegerType => sql.types.LongType
       case _: RealType => sql.types.DoubleType
-      case _: DecimalType => DataTypes.createDecimalType(tp.getLength, tp.getDecimal)
+      case _: DecimalType => DataTypes.createDecimalType(tp.getLength.asInstanceOf[Int], tp.getDecimal)
       case _: TimestampType => sql.types.TimestampType
       case _: DateType => sql.types.DateType
     }

--- a/src/main/scala/com/pingcap/tispark/TiUtils.scala
+++ b/src/main/scala/com/pingcap/tispark/TiUtils.scala
@@ -62,7 +62,7 @@ object TiUtils {
       case _: BytesType => sql.types.StringType
       case _: IntegerType => sql.types.LongType
       case _: RealType => sql.types.DoubleType
-      case _: DecimalType => DataTypes.createDecimalType(tp.getLength.asInstanceOf[Int], tp.getDecimal)
+      case _: DecimalType => DataTypes.createDecimalType(Math.min(Integer.MAX_VALUE, tp.getLength).asInstanceOf[Int], tp.getDecimal)
       case _: TimestampType => sql.types.TimestampType
       case _: DateType => sql.types.DateType
     }

--- a/src/main/scala/com/pingcap/tispark/TiUtils.scala
+++ b/src/main/scala/com/pingcap/tispark/TiUtils.scala
@@ -47,7 +47,9 @@ object TiUtils {
   }
 
   def isSupportedBasicExpression(expr: Expression) = {
-    BasicExpression.convertToTiExpr(expr).fold(false) {_.isSupportedExpr}
+    BasicExpression.convertToTiExpr(expr).fold(false) {
+      _.isSupportedExpr
+    }
   }
 
   def isSupportedFilter(expr: Expression): Boolean = isSupportedBasicExpression(expr)
@@ -62,7 +64,11 @@ object TiUtils {
       case _: BytesType => sql.types.StringType
       case _: IntegerType => sql.types.LongType
       case _: RealType => sql.types.DoubleType
-      case _: DecimalType => DataTypes.createDecimalType(Math.min(Integer.MAX_VALUE, tp.getLength).asInstanceOf[Int], tp.getDecimal) // we need to make sure that tp.getLength does not result in negative number when casting.
+      // we need to make sure that tp.getLength does not result in negative number when casting.
+      case _: DecimalType =>
+        DataTypes.createDecimalType(
+          Math.min(Integer.MAX_VALUE, tp.getLength).asInstanceOf[Int],
+          tp.getDecimal)
       case _: TimestampType => sql.types.TimestampType
       case _: DateType => sql.types.DateType
     }


### PR DESCRIPTION
In some cases, field length may exceed ```Integer.MAX_INT```, so we need to us ```Long``` to store it. References in ```tikv-client-lib-java``` sub-module needs to be updated in order to support type mapping in TiSpark/TiUtils.scala