### PR TITLE
Fix output col distinct issue

### DIFF
--- a/src/main/scala/org/apache/spark/sql/TiStrategy.scala
+++ b/src/main/scala/org/apache/spark/sql/TiStrategy.scala
@@ -313,7 +313,6 @@ class TiStrategy(context: SQLContext) extends Strategy with Logging {
 
         val output = (groupingExpressions ++ pushdownAggregates.map(x => toAlias(x)))
           .map(_.toAttribute)
-          .distinct
 
         aggregate.AggUtils.planAggregateWithoutDistinct(
           groupingExpressions,


### PR DESCRIPTION
We can not modify the output result here. If so, it may cause misplacement in some test case.

e.g. in tpch
```scala
val q1 = spark.sql(
      """select
        |   sum(l_quantity) as sum_qty,
        |   avg(l_quantity) as avg_qty
        |from
        |   lineitem
        |group by
        |   l_returnflag,
        |   l_linestatus
        |order by
        |   l_returnflag,
        |   l_linestatus
      """.stripMargin)
```