### PR TITLE
modify test to reduce and format output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ hs_err_pid*
 metastore_db/
 tpch
 .java-version
+/integtest/conf/tispark_config.properties

--- a/integtest/conf/tispark_config.properties
+++ b/integtest/conf/tispark_config.properties
@@ -1,5 +1,7 @@
 tidb.addr=127.0.0.1
 tidb.port=4000
 tidb.user=root
-test.mode=TestDAG
+test.mode=Test
+test.ignore=tpch
+test.sql=select tp_datetime from full_data_type_table
 test.db=tispark_test

--- a/integtest/src/main/scala/com/pingcap/spark/TestCase.scala
+++ b/integtest/src/main/scala/com/pingcap/spark/TestCase.scala
@@ -68,6 +68,7 @@ class TestCase(val prop: Properties) extends LazyLogging {
     "type mismatch",
     "only support precision",
     "Invalid Flag type for TimestampType: 8",
+    "Invalid Flag type for DateTimeType: 8",
     "Decimal scale (18) cannot be greater than precision "
     //    "unknown error Other"
     //    "Error converting access pointsnull"

--- a/integtest/src/main/scala/com/pingcap/spark/TestCase.scala
+++ b/integtest/src/main/scala/com/pingcap/spark/TestCase.scala
@@ -18,6 +18,8 @@
 package com.pingcap.spark
 
 import java.io.File
+import java.sql.Timestamp
+import java.text.SimpleDateFormat
 import java.util.Properties
 
 import com.pingcap.spark.Utils._
@@ -402,9 +404,9 @@ class TestCase(val prop: Properties) extends LazyLogging {
     val isFalse = sparkJDBCRunTimeError || sparkRunTimeError || !compResult(spark_jdbc, spark)
     if (isFalse) {
       if (skipped) {
-        logger.warn(s"TEST SKIPPED.\n")
+        logger.warn(s"Test SKIPPED. #$inlineSQLNumber\n")
       } else {
-        logger.warn(s"TEST FAILED.\n")
+        logger.warn(s"Test Failed. #$inlineSQLNumber\n")
       }
       logger.warn(s"Spark-JDBC output: $spark_jdbc")
       logger.warn(s"Spark output: $spark")
@@ -416,9 +418,9 @@ class TestCase(val prop: Properties) extends LazyLogging {
       }
     } else {
       if (skipped) {
-        logger.warn(s"TEST SKIPPED.\n")
+        logger.warn(s"Test SKIPPED. #$inlineSQLNumber\n")
       } else {
-        logger.info(s"TEST PASSED.\n")
+        logger.info(s"Test PASSED. #$inlineSQLNumber\n")
       }
     }
     isFalse
@@ -458,9 +460,9 @@ class TestCase(val prop: Properties) extends LazyLogging {
     val isFalse = tidbRunTimeError || sparkRunTimeError || !compResult(tidb, spark)
     if (isFalse) {
       if (skipped) {
-        logger.warn(s"TEST SKIPPED.\n")
+        logger.warn(s"Test SKIPPED. #$inlineSQLNumber\n")
       } else {
-        logger.warn(s"TEST FAILED.\n")
+        logger.warn(s"Test Failed. #$inlineSQLNumber\n")
       }
       logger.warn(s"TiDB output: $tidb")
       logger.warn(s"Spark output: $spark")
@@ -471,9 +473,9 @@ class TestCase(val prop: Properties) extends LazyLogging {
       }
     } else {
       if (skipped) {
-        logger.warn(s"TEST SKIPPED.\n")
+        logger.warn(s"Test SKIPPED. #$inlineSQLNumber\n")
       } else {
-        logger.info(s"TEST PASSED.\n")
+        logger.info(s"Test PASSED. #$inlineSQLNumber\n")
       }
     }
     isFalse
@@ -533,7 +535,7 @@ class TestCase(val prop: Properties) extends LazyLogging {
 
     if (isFalse) {
       if (skipped) {
-        logger.warn(s"TEST SKIPPED.\n")
+        logger.warn(s"Test SKIPPED. #$inlineSQLNumber\n")
       }
       if (isTiDBvsSparkFalse) {
         logger.warn(s"TiDB output: $tidb")
@@ -545,19 +547,21 @@ class TestCase(val prop: Properties) extends LazyLogging {
       if (!skipped) {
         if (checkTiDBIgnore(tidb) || checkSparkIgnore(spark) || checkSparkJDBCIgnore(spark_jdbc)) {
           testsSkipped += 1
+          logger.warn(s"Test SKIPPED. #$inlineSQLNumber\n")
         } else {
           testsFailed += 1
           printDiffSparkJDBC(s"inlineTest$inlineSQLNumber", str, spark_jdbc, spark)
           printDiff(s"inlineTest$inlineSQLNumber", str, tidb, spark)
+          logger.warn(s"Test FAILED. #$inlineSQLNumber\n")
         }
       } else {
         return false
       }
     } else {
       if (skipped) {
-        logger.warn(s"TEST SKIPPED.\n")
+        logger.warn(s"Test SKIPPED. #$inlineSQLNumber\n")
       } else {
-        logger.info(s"TEST PASSED.\n")
+        logger.info(s"Test PASSED. #$inlineSQLNumber\n")
       }
     }
     isFalse
@@ -618,11 +622,17 @@ class TestCase(val prop: Properties) extends LazyLogging {
       case d: Number => d.longValue()
     }
 
+    def toString(value: Any): String = {
+      new SimpleDateFormat("yy-MM-dd HH:mm:ss").format(value)
+    }
+
     def compValue(lhs: Any, rhs: Any): Boolean = lhs match {
       case _: Double | _: Float | _: BigDecimal | _: java.math.BigDecimal =>
         Math.abs(toDouble(lhs) - toDouble(rhs)) < 0.01
       case _: Number | _: BigInt | _: java.math.BigInteger =>
         toInteger(lhs) == toInteger(rhs)
+      case _: Timestamp =>
+        toString(lhs) == toString(rhs)
       case _ => lhs == rhs || lhs.toString == rhs.toString
     }
 

--- a/integtest/test_dag.sh
+++ b/integtest/test_dag.sh
@@ -94,7 +94,7 @@ if [ "${mode}" == "Integration" ]; then
         echo "testing...."
         if [ ${showResultStats} = true ]; then
             if [ ${showFailedOnly} = true ]; then
-                filter="hint:\|output:\|Result:\|Elapsed time:\|query on\|FAILED."
+                filter="hint:\|output:\|Result:\|Elapsed time:\|query on\|FAILED.\|file error"
             else
                 filter="hint:\|output:\|Result:\|Elapsed time:\|query on\|FAILED.\|PASSED.\|SKIPPED.\|exception caught"
             fi
@@ -102,7 +102,7 @@ if [ "${mode}" == "Integration" ]; then
             if [ ${showFailedOnly} = true ]; then
                 filter="Tests result:\|Result:\|exception caught.\|FAILED.\|file error"
             else
-                filter="Tests result:\|Result:\|exception caught.\|FAILED.\|PASSED.\|SKIPPED."
+                filter="Tests result:\|Result:\|FAILED.\|PASSED.\|SKIPPED."
             fi
         fi
         ${spark_cmd} ${spark_test_opt} 2>&1 | grep "${filter}"
@@ -130,7 +130,7 @@ elif [ "${mode}" == "QueryOnly" ]; then
         ${spark_cmd} ${spark_debug_opt}
     else
         echo "testing..."
-        ${spark_cmd} ${spark_test_opt} 2>&1 | grep "hint:\|output:\|Result:\|Elapsed time:\|query on\|exception caught"
+        ${spark_cmd} ${spark_test_opt} 2>&1 | grep "hint:\|output:\|Result:\|Elapsed time:\|query on"
     fi
 else
     echo "UnKnown test mode: $mode. Aborting..."


### PR DESCRIPTION
* Too many output in console and generated files.

* Format `Timestamp` to `SimpleDateFormat` to get rid of precision errors

* Add DateTime Flag Type: 8 Exception to ignore list

* Stop tracking config file