### PR TITLE
Add switch for disble pushdown expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Below configurations can be put together with spark-defaults.conf or passed in t
 | spark.tispark.table.scan_concurrency |  512 | Maximal threads for table scan (shared among tasks inside each JVM) |
 | spark.tispark.request.command.priority |  "Low" | "Low", "Normal", "High" which impacts resource to get in TiKV. Low is recommended for not disturbing OLTP workload |
 | spark.tispark.coprocess.streaming |  false | Whether to use streaming for response fetching |
+| spark.tispark.plan.unsupported_pushdown_exprs |  "" | A comma separated list of expressions. In case you have very old version of TiKV, you might disable some of the expression push-down if not supported |
 
 
 ## Quick start

--- a/src/main/scala/com/pingcap/tispark/TiConfigConst.scala
+++ b/src/main/scala/com/pingcap/tispark/TiConfigConst.scala
@@ -32,4 +32,5 @@ object TiConfigConst {
   val REQUEST_ISOLATION_LEVEL: String = "spark.tispark.request.isolation.level"
   val ALLOW_INDEX_DOUBLE_READ: String = "spark.tispark.plan.allow_index_double_read"
   val COPROCESS_STREAMING: String = "spark.tispark.coprocess.streaming"
+  val UNSUPPORTED_PUSHDOWN_EXPR: String = "spark.tispark.plan.unsupported_pushdown_exprs"
 }

--- a/src/main/scala/org/apache/spark/sql/TiStrategy.scala
+++ b/src/main/scala/org/apache/spark/sql/TiStrategy.scala
@@ -42,7 +42,7 @@ import scala.collection.{JavaConversions, mutable}
 // have multiple plan to pushdown
 class TiStrategy(context: SQLContext) extends Strategy with Logging {
   val sqlConf: SQLConf = context.conf
-  val blacklist: ExpressionBlacklist = {
+  def blacklist: ExpressionBlacklist = {
     val blacklistString = sqlConf.getConfString(TiConfigConst.UNSUPPORTED_PUSHDOWN_EXPR, "")
     new ExpressionBlacklist(blacklistString)
   }

--- a/src/main/scala/org/apache/spark/sql/TiStrategy.scala
+++ b/src/main/scala/org/apache/spark/sql/TiStrategy.scala
@@ -366,7 +366,8 @@ object TiAggregationProjection {
     // Only push down aggregates projection when all filters can be applied and
     // all projection expressions are column references
     case PhysicalOperation(projects, filters, rel @ LogicalRelation(source: TiDBRelation, _, _))
-        if projects.forall(_.isInstanceOf[Attribute]) => Some((filters, rel, source, projects))
+        if projects.forall(_.isInstanceOf[Attribute]) =>
+      Some((filters, rel, source, projects))
     case _ => Option.empty[ReturnType]
   }
 }

--- a/src/main/scala/org/apache/spark/sql/TiStrategy.scala
+++ b/src/main/scala/org/apache/spark/sql/TiStrategy.scala
@@ -15,7 +15,7 @@
 
 package org.apache.spark.sql
 
-import com.pingcap.tikv.expression.{TiByItem, TiColumnRef, TiExpr}
+import com.pingcap.tikv.expression.{aggregate => _, _}
 import com.pingcap.tikv.meta.TiDAGRequest
 import com.pingcap.tikv.meta.TiDAGRequest.PushDownType
 import com.pingcap.tikv.predicates.ScanBuilder
@@ -42,6 +42,10 @@ import scala.collection.{JavaConversions, mutable}
 // have multiple plan to pushdown
 class TiStrategy(context: SQLContext) extends Strategy with Logging {
   val sqlConf: SQLConf = context.conf
+  val blacklist: ExpressionBlacklist = {
+    val blacklistString = sqlConf.getConfString(TiConfigConst.UNSUPPORTED_PUSHDOWN_EXPR, "")
+    new ExpressionBlacklist(blacklistString)
+  }
 
   def allowAggregationPushdown(): Boolean = {
     sqlConf.getConfString(TiConfigConst.ALLOW_AGG_PUSHDOWN, "true").toBoolean
@@ -158,7 +162,7 @@ class TiStrategy(context: SQLContext) extends Strategy with Logging {
 
     val (pushdownFilters: Seq[Expression], residualFilters: Seq[Expression]) =
       filterPredicates.partition(
-        (expression: Expression) => TiUtils.isSupportedFilter(expression, source)
+        (expression: Expression) => TiUtils.isSupportedFilter(expression, source, blacklist)
       )
 
     val residualFilter: Option[Expression] =
@@ -247,12 +251,19 @@ class TiStrategy(context: SQLContext) extends Strategy with Logging {
           groupingExpressions,
           aggregateExpressions,
           resultExpressions,
-          TiAggregationProjection(filters, _, `source`, projects)
+          TiAggregationProjection(filterExpressions, _, `source`, projectExpressions)
           )
-          if groupingExpressions.forall(TiUtils.isSupportedGroupingExpr(_, source)) &&
-            aggregateExpressions.forall(TiUtils.isSupportedAggregate(_, source)) &&
-            allowAggregationPushdown && !aggregateExpressions.exists(_.isDistinct) =>
-        var dagReq: TiDAGRequest = filterToDAGRequest(filters, source)
+          // Aggregation can be pushed down iff:
+          // 1. Config enables aggregates push-down
+          // 2. all filters can be pushed down
+          // 3. all aggregation and group expressions can be pushed down
+          // 4. non aggregates are in distinct mode
+          if allowAggregationPushdown &&
+            filterExpressions.forall(TiUtils.isSupportedFilter(_, source, blacklist)) &&
+            groupingExpressions.forall(TiUtils.isSupportedGroupingExpr(_, source, blacklist)) &&
+            aggregateExpressions.forall(TiUtils.isSupportedAggregate(_, source, blacklist)) &&
+            !aggregateExpressions.exists(_.isDistinct) =>
+        var dagReq: TiDAGRequest = filterToDAGRequest(filterExpressions, source)
         val residualAggregateExpressions = aggregateExpressions.map { aggExpr =>
           aggExpr.aggregateFunction match {
             // here aggExpr is the original AggregationExpression
@@ -323,7 +334,7 @@ class TiStrategy(context: SQLContext) extends Strategy with Logging {
         val output = (pushdownAggregates.map(x => toAlias(x)) ++ groupingExpressions)
           .map(_.toAttribute)
 
-        val projectSeq: Seq[Attribute] = projects.asInstanceOf[Seq[Attribute]]
+        val projectSeq: Seq[Attribute] = projectExpressions.asInstanceOf[Seq[Attribute]]
         projectSeq.foreach(attr => dagReq.addRequiredColumn(TiColumnRef.create(attr.name)))
 
         aggregate.AggUtils.planAggregateWithoutDistinct(
@@ -355,9 +366,7 @@ object TiAggregationProjection {
     // Only push down aggregates projection when all filters can be applied and
     // all projection expressions are column references
     case PhysicalOperation(projects, filters, rel @ LogicalRelation(source: TiDBRelation, _, _))
-        if projects.forall(_.isInstanceOf[Attribute]) &&
-          filters.forall(TiUtils.isSupportedFilter(_, source)) =>
-      Some((filters, rel, source, projects))
+        if projects.forall(_.isInstanceOf[Attribute]) => Some((filters, rel, source, projects))
     case _ => Option.empty[ReturnType]
   }
 }


### PR DESCRIPTION
Some user encountered problem that a specific expressions are not allowed to pushdown since TiKV version too old.
Add comma separated list for configuration allow user to feed blacklist of expression.
List is simple class name for Expression. For example, "And, Or, Not"
Refer to https://github.com/pingcap/tikv-client-lib-java/pull/187

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tispark/117)
<!-- Reviewable:end -->
