### PR TITLE
don't push down datetime and timestamp

### DIFF
--- a/integtest/src/main/scala/com/pingcap/spark/TestCase.scala
+++ b/integtest/src/main/scala/com/pingcap/spark/TestCase.scala
@@ -591,7 +591,9 @@ class TestCase(val prop: Properties) extends LazyLogging {
 
   private def testSql(dbName: String, sql: String): Unit = {
     spark.init(dbName)
+    spark_jdbc.init(dbName)
     execSparkAndShow(sql)
+    execSparkJDBCAndShow(sql)
   }
 
   private def test(dbName: String, testCases: ArrayBuffer[(String, String)], compareNeeded: Boolean): Unit = {

--- a/src/main/scala/com/pingcap/tispark/TiUtils.scala
+++ b/src/main/scala/com/pingcap/tispark/TiUtils.scala
@@ -22,10 +22,10 @@ import com.pingcap.tikv.expression.{ExpressionBlacklist, TiExpr}
 import com.pingcap.tikv.kvproto.Kvrpcpb.{CommandPri, IsolationLevel}
 import com.pingcap.tikv.meta.{TiColumnInfo, TiTableInfo}
 import com.pingcap.tikv.types._
-import org.apache.spark.sql.{SparkSession, TiStrategy}
 import org.apache.spark.sql.catalyst.expressions.aggregate._
 import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Expression, Literal, NamedExpression}
 import org.apache.spark.sql.types.{DataType, DataTypes, MetadataBuilder, StructField, StructType}
+import org.apache.spark.sql.{SparkSession, TiStrategy}
 import org.apache.spark.{SparkConf, sql}
 
 import scala.collection.JavaConversions._
@@ -80,7 +80,10 @@ object TiUtils {
         // bit/duration type is not allowed to be pushed down
         case attr: AttributeReference if nameTypeMap.contains(attr.name) =>
           val head = nameTypeMap.get(attr.name).head
-          return !head.isInstanceOf[BitType] && head.getTypeCode != Types.TYPE_DURATION
+          return !head.isInstanceOf[BitType] &&
+            head.getTypeCode != Types.TYPE_DURATION &&
+            head.getTypeCode != Types.TYPE_TIMESTAMP &&
+            head.getTypeCode != Types.TYPE_DATETIME
         // TODO:Currently we do not support literal null type push down
         // when TiConstant is ready to support literal null or we have other
         // options, remove this.


### PR DESCRIPTION
fix #124 

When we push datetime and timestamp down to coprocessor, it will be confusing since they have different timezones in storage. One of the best solution is not to push them down at all, just like what spark does.