### PR TITLE
Fix Aggregation push down NPE issue

### DIFF
--- a/src/main/scala/org/apache/spark/sql/TiStrategy.scala
+++ b/src/main/scala/org/apache/spark/sql/TiStrategy.scala
@@ -94,6 +94,8 @@ class TiStrategy(context: SQLContext) extends Strategy with Logging {
                                dagRequest: TiDAGRequest): SparkPlan = {
     val table = source.table
     dagRequest.setTableInfo(table)
+    // Need to resolve column info after add aggregation push downs
+    dagRequest.resolve()
     if (dagRequest.getFields.isEmpty) {
       dagRequest.addRequiredColumn(TiColumnRef.create(table.getColumns.get(0).getName))
     }
@@ -342,9 +344,6 @@ class TiStrategy(context: SQLContext) extends Strategy with Logging {
     }.distinct
 
     aggregationToDAGRequest(groupingExpressions, pushdownAggregates, source, dagReq)
-    // Need to resolve column info after add aggregation push downs
-    dagReq.setTableInfo(source.table)
-    dagReq.resolve()
 
     val rewrittenResultExpression = resultExpressions.map(
       expr =>

--- a/src/main/scala/org/apache/spark/sql/TiStrategy.scala
+++ b/src/main/scala/org/apache/spark/sql/TiStrategy.scala
@@ -342,6 +342,9 @@ class TiStrategy(context: SQLContext) extends Strategy with Logging {
     }.distinct
 
     aggregationToDAGRequest(groupingExpressions, pushdownAggregates, source, dagReq)
+    // Need to resolve column info after add aggregation push downs
+    dagReq.setTableInfo(source.table)
+    dagReq.resolve()
 
     val rewrittenResultExpression = resultExpressions.map(
       expr =>


### PR DESCRIPTION
We need to resolve the `TiColumnRef` after creating them from `pushdownAggregates`.
Should fix https://github.com/pingcap/tispark/issues/162