### PR TITLE
Fix error handling logic

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/tispark/TiHandleRDD.scala
+++ b/core/src/main/scala/org/apache/spark/sql/tispark/TiHandleRDD.scala
@@ -57,8 +57,9 @@ class TiHandleRDD(val dagRequest: TiDAGRequest,
       private val tiPartition = split.asInstanceOf[TiPartition]
       private val session = TiSessionCache.getSession(tiPartition.appId, tiConf)
       private val snapshot = session.createSnapshot(ts)
-      private val handleIter =
-        snapshot.indexHandleRead(dagRequest, split.asInstanceOf[TiPartition].tasks.asJava)
+      private[this] val tasks = tiPartition.tasks
+
+      private val handleIter = snapshot.indexHandleRead(dagRequest, tasks)
       private val tableId = dagRequest.getTableInfo.getId
       private val regionManager = session.getRegionManager
       private val regionHandleMap = new TLongObjectHashMap[TLongLinkedList]()

--- a/core/src/main/scala/org/apache/spark/sql/tispark/TiRDD.scala
+++ b/core/src/main/scala/org/apache/spark/sql/tispark/TiRDD.scala
@@ -59,9 +59,9 @@ class TiRDD(val dagRequest: TiDAGRequest,
     private val tiPartition = split.asInstanceOf[TiPartition]
     private val session = TiSessionCache.getSession(tiPartition.appId, tiConf)
     private val snapshot = session.createSnapshot(ts)
+    private[this] val tasks = tiPartition.tasks
 
-    private val iterator =
-      snapshot.tableRead(dagRequest, split.asInstanceOf[TiPartition].tasks.asJava)
+    private val iterator = snapshot.tableRead(dagRequest, tasks)
     private val finalTypes = rowTransformer.getTypes.toList
 
     def toSparkRow(row: TiRow): Row = {

--- a/core/src/main/scala/org/apache/spark/sql/tispark/TiRDD.scala
+++ b/core/src/main/scala/org/apache/spark/sql/tispark/TiRDD.scala
@@ -26,7 +26,7 @@ import com.pingcap.tispark.{TiConfigConst, TiPartition, TiSessionCache, TiTableR
 import gnu.trove.list.array.TLongArrayList
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{Row, SparkSession}
-import org.apache.spark.{Partition, TaskContext}
+import org.apache.spark.{Partition, TaskContext, TaskKilledException}
 
 import scala.collection.JavaConversions._
 import scala.collection.JavaConverters._
@@ -75,7 +75,15 @@ class TiRDD(val dagRequest: TiDAGRequest,
       Row.fromSeq(rowArray)
     }
 
-    override def hasNext: Boolean = iterator.hasNext
+    override def hasNext: Boolean = {
+      // Kill the task in case it has been marked as killed. This logic is from
+      // InterruptibleIterator, but we inline it here instead of wrapping the iterator in order
+      // to avoid performance overhead.
+      if (context.isInterrupted()) {
+        throw new TaskKilledException
+      }
+      iterator.hasNext
+    }
 
     override def next(): Row = toSparkRow(iterator.next)
   }

--- a/tikv-client/src/main/java/com/pingcap/tikv/operation/KVErrorHandler.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/operation/KVErrorHandler.java
@@ -147,6 +147,7 @@ public class KVErrorHandler<RespT> implements ErrorHandler<RespT> {
       String otherError = getOtherError.apply(resp);
       if (otherError != null &&
           !otherError.trim().isEmpty()) {
+        logger.warn(String.format("Other error occurred for region [%s]", ctxRegion));
         // Just throw to upper layer to handle
         throw new RuntimeException("Received other error from TiKV:" + otherError);
       }

--- a/tikv-client/src/main/java/com/pingcap/tikv/operation/KVErrorHandler.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/operation/KVErrorHandler.java
@@ -149,7 +149,7 @@ public class KVErrorHandler<RespT> implements ErrorHandler<RespT> {
           !otherError.trim().isEmpty()) {
         logger.warn(String.format("Other error occurred for region [%s]", ctxRegion));
         // Just throw to upper layer to handle
-        throw new RuntimeException("Received other error from TiKV:" + otherError);
+        throw new IllegalStateException("Received other error from TiKV:" + otherError);
       }
     }
   }

--- a/tikv-client/src/main/java/com/pingcap/tikv/operation/KVErrorHandler.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/operation/KVErrorHandler.java
@@ -75,7 +75,7 @@ public class KVErrorHandler<RespT> implements ErrorHandler<RespT> {
   private String getOtherError(RespT resp) {
     if (getOtherError != null) {
       String otherError = getOtherError.apply(resp);
-      return (otherError == null || otherError.trim().equals("")) ? null : otherError;
+      return (otherError == null || otherError.trim().isEmpty()) ? null : otherError;
     }
     return null;
   }

--- a/tikv-client/src/main/java/com/pingcap/tikv/region/RegionStoreClient.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/region/RegionStoreClient.java
@@ -182,7 +182,8 @@ public class RegionStoreClient extends AbstractGRPCClient<TikvBlockingStub, Tikv
             .build();
     KVErrorHandler<Coprocessor.Response> handler =
         new KVErrorHandler<>(
-            regionManager, this, region, resp -> resp.hasRegionError() ? resp.getRegionError() : null);
+            regionManager, this, region, resp -> resp.hasRegionError() ? resp.getRegionError() : null,
+            Coprocessor.Response::getOtherError);
     Coprocessor.Response resp = callWithRetry(TikvGrpc.METHOD_COPROCESSOR, reqToSend, handler);
     return coprocessorHelper(resp);
   }
@@ -202,7 +203,8 @@ public class RegionStoreClient extends AbstractGRPCClient<TikvBlockingStub, Tikv
             regionManager,
             this,
             region,
-            StreamingResponse::getFirstError
+            StreamingResponse::getFirstRegionError,//TODO: handle all errors in streaming respinse
+            StreamingResponse::getFirstOtherError
         );
 
     StreamingResponse responseIterator = callServerStreamingWithRetry(

--- a/tikv-client/src/main/java/com/pingcap/tikv/streaming/StreamingResponse.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/streaming/StreamingResponse.java
@@ -53,13 +53,22 @@ public class StreamingResponse implements Iterable {
     return false;
   }
 
-  public Errorpb.Error getFirstError() {
+  public Errorpb.Error getFirstRegionError() {
     for (Coprocessor.Response response : responseList) {
       if (response.hasRegionError()) {
         return response.getRegionError();
       }
     }
 
+    return null;
+  }
+
+  public String getFirstOtherError() {
+    for (Coprocessor.Response response : responseList) {
+      if (!response.getOtherError().isEmpty()) {
+        return response.getOtherError();
+      }
+    }
     return null;
   }
 


### PR DESCRIPTION
Originally we missed out potential other errors(typically like time out, server is busy etc. from TiVK) and if one `other_error` occurs, we proceed the request as nothing happened, which may result in missing some part of the data.

This pr tries to fix `other_error` handling logic.