### PR TITLE
fix getting next handle when encounter Long.MAX_VALUE

### DIFF
--- a/tikv-client/src/main/java/com/pingcap/tikv/key/Key.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/key/Key.java
@@ -16,14 +16,15 @@
 package com.pingcap.tikv.key;
 
 
-import static com.pingcap.tikv.codec.KeyUtils.formatBytes;
-import static java.util.Objects.requireNonNull;
-
 import com.google.protobuf.ByteString;
 import com.pingcap.tikv.codec.CodecDataOutput;
 import com.pingcap.tikv.types.DataType;
 import com.pingcap.tikv.util.FastByteComparisons;
+
 import java.util.Arrays;
+
+import static com.pingcap.tikv.codec.KeyUtils.formatBytes;
+import static java.util.Objects.requireNonNull;
 
 public class Key implements Comparable<Key> {
   protected static final byte[] TBL_PREFIX = new byte[] {'t'};
@@ -105,6 +106,10 @@ public class Key implements Comparable<Key> {
    * @return encoded results
    */
   public Key next() {
+    return toRawKey(nextValue(value));
+  }
+
+  static byte[] nextValue(byte[] value) {
     int i;
     byte[] newVal = Arrays.copyOf(value, value.length);
     for (i = newVal.length - 1; i >= 0; i--) {
@@ -114,9 +119,9 @@ public class Key implements Comparable<Key> {
       }
     }
     if (i == -1) {
-      return toRawKey(Arrays.copyOf(value, value.length + 1));
+      return Arrays.copyOf(value, value.length + 1);
     } else {
-      return toRawKey(newVal);
+      return newVal;
     }
   }
 

--- a/tikv-client/src/main/java/com/pingcap/tikv/key/RowKey.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/key/RowKey.java
@@ -48,7 +48,7 @@ public class RowKey extends Key {
    * Initializes an imaginary globally MAXIMUM rowKey with tableId.
    */
   private RowKey(long tableId) {
-    super(encodeMaxHandle(tableId));
+    super(encodeBeyondMaxHandle(tableId));
     this.tableId = tableId;
     this.handle = Long.MAX_VALUE;
     this.maxHandleFlag = true;
@@ -66,16 +66,12 @@ public class RowKey extends Key {
     throw new TiExpressionException("Cannot encode row key with non-long type");
   }
 
-  public static RowKey toMaxRowKey(long tableId) {
-    return new RowKey(tableId);
-  }
-
   public static RowKey createMin(long tableId) {
     return toRowKey(tableId, Long.MIN_VALUE);
   }
 
-  public static RowKey createMax(long tableId) {
-    return toMaxRowKey(tableId);
+  public static RowKey createBeyondMax(long tableId) {
+    return new RowKey(tableId);
   }
 
   private static byte[] encode(long tableId, long handle) {
@@ -85,7 +81,7 @@ public class RowKey extends Key {
     return cdo.toBytes();
   }
 
-  private static byte[] encodeMaxHandle(long tableId) {
+  private static byte[] encodeBeyondMaxHandle(long tableId) {
     return nextValue(encode(tableId, Long.MAX_VALUE));
   }
 
@@ -97,7 +93,7 @@ public class RowKey extends Key {
       throw new TiClientInternalException("Handle overflow for Long MAX");
     }
     if (handle == Long.MAX_VALUE) {
-      return toMaxRowKey(tableId);
+      return createBeyondMax(tableId);
     }
     return new RowKey(tableId, handle + 1);
   }
@@ -110,7 +106,7 @@ public class RowKey extends Key {
     return handle;
   }
 
-  public boolean getMaxHandleFlag() {
+  private boolean getMaxHandleFlag() {
     return maxHandleFlag;
   }
 

--- a/tikv-client/src/main/java/com/pingcap/tikv/key/RowKey.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/key/RowKey.java
@@ -16,27 +16,42 @@
 package com.pingcap.tikv.key;
 
 
-import static com.pingcap.tikv.codec.Codec.IntegerCodec.writeLong;
-
 import com.pingcap.tikv.codec.Codec.IntegerCodec;
 import com.pingcap.tikv.codec.CodecDataInput;
 import com.pingcap.tikv.codec.CodecDataOutput;
 import com.pingcap.tikv.exception.TiClientInternalException;
 import com.pingcap.tikv.exception.TiExpressionException;
-import com.pingcap.tikv.util.FastByteComparisons;
 import com.pingcap.tikv.key.RowKey.DecodeResult.Status;
+import com.pingcap.tikv.util.FastByteComparisons;
+
 import java.util.Objects;
+
+import static com.pingcap.tikv.codec.Codec.IntegerCodec.writeLong;
 
 public class RowKey extends Key {
   private static final byte[] REC_PREFIX_SEP = new byte[] {'_', 'r'};
 
   private final long tableId;
   private final long handle;
+  private final boolean maxHandleFlag;
 
   private RowKey(long tableId, long handle) {
     super(encode(tableId, handle));
     this.tableId = tableId;
     this.handle = handle;
+    this.maxHandleFlag = false;
+  }
+
+  /**
+   * The RowKey indicating maximum handle (its value exceeds Long.Max_Value)
+   *
+   * Initializes an imaginary globally MAXIMUM rowKey with tableId.
+   */
+  private RowKey(long tableId) {
+    super(encodeMaxHandle(tableId));
+    this.tableId = tableId;
+    this.handle = Long.MAX_VALUE;
+    this.maxHandleFlag = true;
   }
 
   public static RowKey toRowKey(long tableId, long handle) {
@@ -51,12 +66,16 @@ public class RowKey extends Key {
     throw new TiExpressionException("Cannot encode row key with non-long type");
   }
 
+  public static RowKey toMaxRowKey(long tableId) {
+    return new RowKey(tableId);
+  }
+
   public static RowKey createMin(long tableId) {
     return toRowKey(tableId, Long.MIN_VALUE);
   }
 
   public static RowKey createMax(long tableId) {
-    return toRowKey(tableId, Long.MAX_VALUE);
+    return toMaxRowKey(tableId);
   }
 
   private static byte[] encode(long tableId, long handle) {
@@ -66,11 +85,19 @@ public class RowKey extends Key {
     return cdo.toBytes();
   }
 
+  private static byte[] encodeMaxHandle(long tableId) {
+    return nextValue(encode(tableId, Long.MAX_VALUE));
+  }
+
   @Override
   public RowKey next() {
     long handle = getHandle();
-    if (handle == Long.MAX_VALUE) {
+    boolean maxHandleFlag = getMaxHandleFlag();
+    if (maxHandleFlag) {
       throw new TiClientInternalException("Handle overflow for Long MAX");
+    }
+    if (handle == Long.MAX_VALUE) {
+      return toMaxRowKey(tableId);
     }
     return new RowKey(tableId, handle + 1);
   }
@@ -81,6 +108,10 @@ public class RowKey extends Key {
 
   public long getHandle() {
     return handle;
+  }
+
+  public boolean getMaxHandleFlag() {
+    return maxHandleFlag;
   }
 
   @Override

--- a/tikv-client/src/main/java/com/pingcap/tikv/predicates/ScanAnalyzer.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/predicates/ScanAnalyzer.java
@@ -15,11 +15,6 @@
 
 package com.pingcap.tikv.predicates;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.pingcap.tikv.predicates.PredicateUtils.expressionToIndexRanges;
-import static com.pingcap.tikv.util.KeyRangeUtils.makeCoprocRange;
-import static java.util.Objects.requireNonNull;
-
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.BoundType;
 import com.google.common.collect.Range;
@@ -35,10 +30,16 @@ import com.pingcap.tikv.kvproto.Coprocessor.KeyRange;
 import com.pingcap.tikv.meta.TiIndexColumn;
 import com.pingcap.tikv.meta.TiIndexInfo;
 import com.pingcap.tikv.meta.TiTableInfo;
+
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.pingcap.tikv.predicates.PredicateUtils.expressionToIndexRanges;
+import static com.pingcap.tikv.util.KeyRangeUtils.makeCoprocRange;
+import static java.util.Objects.requireNonNull;
 
 
 public class ScanAnalyzer {
@@ -152,7 +153,7 @@ public class ScanAnalyzer {
 
         if (!r.hasUpperBound()) {
           // INF
-          endKey = RowKey.createMax(table.getId());
+          endKey = RowKey.createBeyondMax(table.getId());
         } else {
           endKey = RowKey.toRowKey(table.getId(), r.upperEndpoint());
           if (r.upperBoundType().equals(BoundType.CLOSED)) {
@@ -168,7 +169,7 @@ public class ScanAnalyzer {
 
     if (ranges.isEmpty()) {
       Key startKey = RowKey.createMin(table.getId());
-      Key endKey = RowKey.createMax(table.getId());
+      Key endKey = RowKey.createBeyondMax(table.getId());
       ranges.add(makeCoprocRange(startKey.toByteString(), endKey.toByteString()));
     }
 

--- a/tikv-client/src/main/java/com/pingcap/tikv/util/KeyRangeUtils.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/util/KeyRangeUtils.java
@@ -98,28 +98,28 @@ public class KeyRangeUtils {
   }
 
   /**
-   * Build a Coprocessor Range with OPEN or CLOSED endpoints
+   * Build a Coprocessor Range with CLOSED_OPEN endpoints
    *
    * @param startKey startKey
    * @param endKey endKey
-   * @return an CLOSED_OPEN range for coprocessor
+   * @return a CLOSED_OPEN range for coprocessor
    */
   public static KeyRange makeCoprocRange(ByteString startKey, ByteString endKey) {
     return KeyRange.newBuilder().setStart(startKey).setEnd(endKey).build();
   }
 
   /**
-   * Build a Coprocessor Range with CLOSED endpoints
+   * Build a Coprocessor Range
    *
    * @param range Range with Comparable endpoints
-   * @return and CLOSED_OPEN range for coprocessor
+   * @return a CLOSED_OPEN range for coprocessor
    */
   public static KeyRange makeCoprocRange(Range<Key> range) {
     if (!range.hasLowerBound() || !range.hasUpperBound()) {
       throw new TiClientInternalException("range is not closed");
     }
     return makeCoprocRange(range.lowerEndpoint().toByteString(),
-                           range.upperEndpoint().next().toByteString());
+                           range.upperEndpoint().toByteString());
   }
 
   public static List<KeyRange> mergeRanges(List<KeyRange> ranges) {

--- a/tikv-client/src/main/java/com/pingcap/tikv/util/KeyRangeUtils.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/util/KeyRangeUtils.java
@@ -16,8 +16,6 @@
 package com.pingcap.tikv.util;
 
 
-import static com.pingcap.tikv.key.Key.toRawKey;
-
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Range;
 import com.google.common.collect.RangeSet;
@@ -29,8 +27,11 @@ import com.pingcap.tikv.exception.TiClientInternalException;
 import com.pingcap.tikv.key.Key;
 import com.pingcap.tikv.kvproto.Coprocessor;
 import com.pingcap.tikv.kvproto.Coprocessor.KeyRange;
+
 import java.util.List;
 import java.util.Set;
+
+import static com.pingcap.tikv.key.Key.toRawKey;
 
 public class KeyRangeUtils {
   public static List<Coprocessor.KeyRange> split(Coprocessor.KeyRange range, int splitFactor) {
@@ -96,16 +97,29 @@ public class KeyRangeUtils {
     return Range.closedOpen(toRawKey(startKey, true), toRawKey(endKey));
   }
 
+  /**
+   * Build a Coprocessor Range with OPEN or CLOSED endpoints
+   *
+   * @param startKey startKey
+   * @param endKey endKey
+   * @return an CLOSED_OPEN range for coprocessor
+   */
   public static KeyRange makeCoprocRange(ByteString startKey, ByteString endKey) {
     return KeyRange.newBuilder().setStart(startKey).setEnd(endKey).build();
   }
 
+  /**
+   * Build a Coprocessor Range with CLOSED endpoints
+   *
+   * @param range Range with Comparable endpoints
+   * @return and CLOSED_OPEN range for coprocessor
+   */
   public static KeyRange makeCoprocRange(Range<Key> range) {
     if (!range.hasLowerBound() || !range.hasUpperBound()) {
       throw new TiClientInternalException("range is not closed");
     }
     return makeCoprocRange(range.lowerEndpoint().toByteString(),
-                           range.upperEndpoint().toByteString());
+                           range.upperEndpoint().next().toByteString());
   }
 
   public static List<KeyRange> mergeRanges(List<KeyRange> ranges) {

--- a/tikv-client/src/main/java/com/pingcap/tikv/util/KeyRangeUtils.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/util/KeyRangeUtils.java
@@ -16,10 +16,7 @@
 package com.pingcap.tikv.util;
 
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Range;
-import com.google.common.collect.RangeSet;
-import com.google.common.collect.TreeRangeSet;
+import com.google.common.collect.*;
 import com.google.protobuf.ByteString;
 import com.pingcap.tikv.codec.CodecDataInput;
 import com.pingcap.tikv.codec.CodecDataOutput;
@@ -116,7 +113,11 @@ public class KeyRangeUtils {
    */
   public static KeyRange makeCoprocRange(Range<Key> range) {
     if (!range.hasLowerBound() || !range.hasUpperBound()) {
-      throw new TiClientInternalException("range is not closed");
+      throw new TiClientInternalException("range is not bounded");
+    }
+    if (range.lowerBoundType().equals(BoundType.OPEN) ||
+        range.upperBoundType().equals(BoundType.CLOSED)) {
+      throw new TiClientInternalException("range must be CLOSED_OPEN");
     }
     return makeCoprocRange(range.lowerEndpoint().toByteString(),
                            range.upperEndpoint().toByteString());

--- a/tikv-client/src/test/java/com/pingcap/tikv/predicates/ScanAnalyzerTest.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/predicates/ScanAnalyzerTest.java
@@ -230,7 +230,7 @@ public class ScanAnalyzerTest {
     ScanAnalyzer.ScanPlan scanPlan = scanBuilder.buildScan(new ArrayList<>(), index, table);
 
     ByteString startKey = RowKey.toRowKey(table.getId(), Long.MIN_VALUE).toByteString();
-    ByteString endKey = RowKey.toMaxRowKey(table.getId()).toByteString();
+    ByteString endKey = RowKey.toBeyondMaxRowKey(table.getId()).toByteString();
 
     assertEquals(1, scanPlan.getKeyRanges().size());
     assertEquals(startKey, scanPlan.getKeyRanges().get(0).getStart());

--- a/tikv-client/src/test/java/com/pingcap/tikv/predicates/ScanAnalyzerTest.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/predicates/ScanAnalyzerTest.java
@@ -103,7 +103,7 @@ public class ScanAnalyzerTest {
     Coprocessor.KeyRange keyRange = keyRanges.get(0);
 
     assertEquals(ByteString.copyFrom(new byte[]{116,-128,0,0,0,0,0,0,6,95,114,0,0,0,0,0,0,0,0}), keyRange.getStart());
-    assertEquals(ByteString.copyFrom(new byte[]{116,-128,0,0,0,0,0,0,6,95,114,-1,-1,-1,-1,-1,-1,-1,-1}), keyRange.getEnd());
+    assertEquals(ByteString.copyFrom(new byte[]{116,-128,0,0,0,0,0,0,6,95,115,0,0,0,0,0,0,0,0}), keyRange.getEnd());
   }
 
   @Test
@@ -230,7 +230,7 @@ public class ScanAnalyzerTest {
     ScanAnalyzer.ScanPlan scanPlan = scanBuilder.buildScan(new ArrayList<>(), index, table);
 
     ByteString startKey = RowKey.toRowKey(table.getId(), Long.MIN_VALUE).toByteString();
-    ByteString endKey = RowKey.toRowKey(table.getId(), Long.MAX_VALUE).toByteString();
+    ByteString endKey = RowKey.toMaxRowKey(table.getId()).toByteString();
 
     assertEquals(1, scanPlan.getKeyRanges().size());
     assertEquals(startKey, scanPlan.getKeyRanges().get(0).getStart());


### PR DESCRIPTION
Coprocessor accepts CLOSED_OPEN ranges. So when handle is Long.MAX_VALUE, the next handle should be acknowledged as well rather than throwing exception.

Also, other ranges we passed to coprocessor should be closed_open.