### PR TITLE
 Add requestOrder flag to indicate whether the output should be compared in order

### DIFF
--- a/integtest/src/main/scala/com/pingcap/spark/TestCase.scala
+++ b/integtest/src/main/scala/com/pingcap/spark/TestCase.scala
@@ -224,10 +224,6 @@ class TestCase(val prop: Properties) extends LazyLogging {
                                  sql: String,
                                  sparkJDBC: List[List[Any]],
                                  tiSpark: List[List[Any]]): Unit = {
-//    if (compResult(sparkJDBC, tiSpark, sql.contains(" order by "))) {
-//      return
-//    }
-
     try {
       logger.info(s"Dump diff for JDBC Spark $sqlName \n")
       writeResult(sql, sparkJDBC, sqlName + ".result.jdbc")
@@ -242,10 +238,6 @@ class TestCase(val prop: Properties) extends LazyLogging {
                         sql: String,
                         tiDb: List[List[Any]],
                         tiSpark: List[List[Any]]): Unit = {
-//    if (compResult(tiDb, tiSpark, sql.contains(" order by "))) {
-//      return
-//    }
-
     try {
       logger.info(s"Dump diff for TiSpark $sqlName \n")
       writeResult(sql, tiDb, sqlName + ".result.tidb")

--- a/integtest/src/main/scala/com/pingcap/spark/TestIndex.scala
+++ b/integtest/src/main/scala/com/pingcap/spark/TestIndex.scala
@@ -54,14 +54,14 @@ class TestIndex(prop: Properties) extends TestCase(prop) {
   ) ++ ARITHMETIC_CONSTANT
 
   protected val DATE_DATA: List[String] = List[String](
-    "'2017-10-30'",
-    "'2017-11-02'"
+    "date '2017-10-30'",
+    "date '2017-11-02'"
   )
 
   protected val DATETIME_DATA: List[String] = List[String](
-    "'2017-11-02 00:00:00'",
-    "'2017-11-02 08:47:43'",
-    "'2017-09-07 11:11:11'"
+    "timestamp '2017-11-02 00:00:00'",
+    "timestamp '2017-11-02 08:47:43'",
+    "timestamp '2017-09-07 11:11:11'"
   )
 
   // TODO: Eliminate these bugs
@@ -118,11 +118,11 @@ class TestIndex(prop: Properties) extends TestCase(prop) {
   }
 
   def testFullDataTable(list: List[String]): Unit = {
-    val startTime = System.currentTimeMillis()
     var count = 0
     for (sql <- list) {
       try {
         count += 1
+        val startTime = System.currentTimeMillis()
         execAllAndJudge(sql)
         logger.info(
           "Running num: " + count + " sql took " + (System


### PR DESCRIPTION
Since TiSpark does not guarantee retrieved data in order in most cases.
@ilovesoup PTAL