### PR TITLE
Fix Average on bigint overflow

### DIFF
--- a/core/src/main/scala/com/pingcap/tispark/TiUtils.scala
+++ b/core/src/main/scala/com/pingcap/tispark/TiUtils.scala
@@ -45,7 +45,7 @@ object TiUtils {
                            tiDBRelation: TiDBRelation,
                            blacklist: ExpressionBlacklist): Boolean = {
     aggExpr.aggregateFunction match {
-      case Average(_) | Sum(_) | Count(_) | Min(_) | Max(_) =>
+      case Average(_) | Sum(_) | RewriteSum(_) | Count(_) | Min(_) | Max(_) =>
         !aggExpr.isDistinct &&
           aggExpr.aggregateFunction.children
             .forall(isSupportedBasicExpression(_, tiDBRelation, blacklist))

--- a/core/src/main/scala/com/pingcap/tispark/TiUtils.scala
+++ b/core/src/main/scala/com/pingcap/tispark/TiUtils.scala
@@ -45,7 +45,7 @@ object TiUtils {
                            tiDBRelation: TiDBRelation,
                            blacklist: ExpressionBlacklist): Boolean = {
     aggExpr.aggregateFunction match {
-      case Average(_) | Sum(_) | RewriteSum(_) | Count(_) | Min(_) | Max(_) =>
+      case Average(_) | Sum(_) | PromotedSum(_) | Count(_) | Min(_) | Max(_) =>
         !aggExpr.isDistinct &&
           aggExpr.aggregateFunction.children
             .forall(isSupportedBasicExpression(_, tiDBRelation, blacklist))

--- a/core/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/PromotedSum.scala
+++ b/core/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/PromotedSum.scala
@@ -21,8 +21,10 @@ import org.apache.spark.sql.catalyst.util.TypeUtils
 import org.apache.spark.sql.types._
 
 @ExpressionDescription(
-  usage = "_FUNC_(expr) - Returns the sum calculated from values of a group.")
-case class RewriteSum(child: Expression) extends DeclarativeAggregate {
+  usage =
+    "_FUNC_(expr) - Returns the sum calculated from values of a group. Result type is promoted to double/decimal."
+)
+case class PromotedSum(child: Expression) extends DeclarativeAggregate {
 
   override def children: Seq[Expression] = child :: Nil
 

--- a/core/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/RewriteSum.scala
+++ b/core/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/RewriteSum.scala
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2017 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.expressions.aggregate
+
+import org.apache.spark.sql.catalyst.analysis.TypeCheckResult
+import org.apache.spark.sql.catalyst.expressions.{Add, AttributeReference, Cast, Coalesce, Expression, ExpressionDescription, Literal}
+import org.apache.spark.sql.catalyst.util.TypeUtils
+import org.apache.spark.sql.types._
+
+@ExpressionDescription(
+  usage = "_FUNC_(expr) - Returns the sum calculated from values of a group.")
+case class RewriteSum(child: Expression) extends DeclarativeAggregate {
+
+  override def children: Seq[Expression] = child :: Nil
+
+  override def nullable: Boolean = true
+
+  // Return data type.
+  override def dataType: DataType = resultType
+
+  override def inputTypes: Seq[AbstractDataType] = Seq(NumericType)
+
+  override def checkInputDataTypes(): TypeCheckResult =
+    TypeUtils.checkForNumericExpr(child.dataType, "function sum")
+
+  private lazy val resultType = child.dataType match {
+    case DecimalType.Fixed(precision, scale) =>
+      DecimalType.bounded(precision + 10, scale)
+    case _ => DoubleType
+  }
+
+  private lazy val sumDataType = resultType
+
+  private lazy val sum = AttributeReference("rewriteSum", sumDataType)()
+
+  private lazy val zero = Cast(Literal(0), sumDataType)
+
+  override lazy val aggBufferAttributes = sum :: Nil
+
+  override lazy val initialValues: Seq[Expression] = Seq(
+    /* sum = */ Literal.create(null, sumDataType)
+  )
+
+  override lazy val updateExpressions: Seq[Expression] = {
+    if (child.nullable) {
+      Seq(
+        /* sum = */
+        Coalesce(Seq(Add(Coalesce(Seq(sum, zero)), Cast(child, sumDataType)), sum))
+      )
+    } else {
+      Seq(
+        /* sum = */
+        Add(Coalesce(Seq(sum, zero)), Cast(child, sumDataType))
+      )
+    }
+  }
+
+  override lazy val mergeExpressions: Seq[Expression] = {
+    Seq(
+      /* sum = */
+      Coalesce(Seq(Add(Coalesce(Seq(sum.left, zero)), sum.right), sum.left))
+    )
+  }
+
+  override lazy val evaluateExpression: Expression = sum
+}

--- a/core/src/test/scala/org/apache/spark/sql/expression/ArithmeticAgg0Suite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/ArithmeticAgg0Suite.scala
@@ -110,8 +110,6 @@ class ArithmeticAgg0Suite extends BaseTiSparkSuite {
   allCases foreach { query =>
     {
       test(query) {
-        if (query.equals("select avg(tp_bigint) from full_data_type_table"))
-          cancel("Average on bigint is pending to be fixed")
         runTest(query, query.replace("full_data_type_table", "full_data_type_table_j"))
       }
     }

--- a/core/src/test/scala/org/apache/spark/sql/expression/index/Between0Suite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/index/Between0Suite.scala
@@ -35,7 +35,9 @@ class Between0Suite extends BaseTiSparkSuite {
   allCases foreach { query =>
     {
       test(query) {
-        if (query.equals("select tp_real from full_data_type_table_idx  where tp_real between 4.44 and 0.5194052764001038 order by id_dt")) cancel("This case is pending to be solved in other PRs")
+        if (query.equals(
+              "select tp_real from full_data_type_table_idx  where tp_real between 4.44 and 0.5194052764001038 order by id_dt"
+            )) cancel("This case is pending to be solved in other PRs")
         runTest(query, query.replace("full_data_type_table_idx", "full_data_type_table_idx_j"))
       }
     }


### PR DESCRIPTION
Rewrite original `Sum(LongType)` expression returning `LongType` which may cause Long overflow in Average cases to another `PromotedSum` expression.