### PR TITLE
Fix group by without aggregates

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/TiStrategy.scala
+++ b/core/src/main/scala/org/apache/spark/sql/TiStrategy.scala
@@ -362,15 +362,25 @@ class TiStrategy(context: SQLContext) extends Strategy with Logging {
 
     projectionTiRefs ++ filterTiRefs foreach { dagReq.addRequiredColumn }
 
-    val aggregateArributes =
+    val aggregateAttributes =
       aggregateExpressions.map(expr => aliasPushedPartialResult(expr).toAttribute)
     val groupAttributes = groupingExpressions.map(_.toAttribute)
-    val output = (aggregateArributes ++ groupAttributes)
+
+    // output of Coprocessor plan should contain all references within
+    // aggregates and group by expressions
+    val output = (aggregateAttributes ++ groupAttributes)
 
     val groupExpressionMap = groupingExpressions.map(expr => expr.exprId -> expr.toAttribute).toMap
-    val rewrittenResultExpressions = resultExpressions.map { expr =>
-      expr
-        .transform {
+
+    // resultExpression might refer to some of the group by expressions
+    // Those expressions originally refer to table columns but now it refers to
+    // results of coprocessor.
+    // For example, select a + 1 from t group by a + 1
+    // expression a + 1 has been pushed down to coprocessor
+    // and in turn a + 1 in projection should be replaced by
+    // reference of coprocessor output entirely
+    val rewrittenResultExpressions = resultExpressions.map {
+        _.transform {
           case e: NamedExpression => groupExpressionMap.getOrElse(e.exprId, e)
         }
         .asInstanceOf[NamedExpression]

--- a/core/src/main/scala/org/apache/spark/sql/TiStrategy.scala
+++ b/core/src/main/scala/org/apache/spark/sql/TiStrategy.scala
@@ -380,10 +380,9 @@ class TiStrategy(context: SQLContext) extends Strategy with Logging {
     // and in turn a + 1 in projection should be replaced by
     // reference of coprocessor output entirely
     val rewrittenResultExpressions = resultExpressions.map {
-        _.transform {
-          case e: NamedExpression => groupExpressionMap.getOrElse(e.exprId, e)
-        }
-        .asInstanceOf[NamedExpression]
+      _.transform {
+        case e: NamedExpression => groupExpressionMap.getOrElse(e.exprId, e)
+      }.asInstanceOf[NamedExpression]
     }
 
     aggregate.AggUtils.planAggregateWithoutDistinct(

--- a/core/src/test/scala/org/apache/spark/sql/expression/Aggregate0Suite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/Aggregate0Suite.scala
@@ -42,7 +42,11 @@ class Aggregate0Suite extends BaseTiSparkSuite {
     "select tp_char from full_data_type_table  group by (tp_char)  order by tp_char ",
     "select tp_longtext from full_data_type_table  group by (tp_longtext)  order by tp_longtext ",
     "select tp_varchar from full_data_type_table  group by (tp_varchar)  order by tp_varchar ",
-    "select tp_datetime from full_data_type_table  group by (tp_datetime)  order by tp_datetime "
+    "select tp_datetime from full_data_type_table  group by (tp_datetime)  order by tp_datetime ",
+    "select 999 + tp_int + sum(tp_int + 999) from full_data_type_table  group by tp_int + 999 order by 1",
+    "select 999 + tp_int + sum(tp_int) from full_data_type_table  group by tp_int + 999 order by 1",
+    "select 999 + tp_int+sum(tp_int), tp_int + 999 + 1 from full_data_type_table  group by tp_int + 999 order by 1,2",
+    "select tp_int + 999+1 from full_data_type_table group by tp_int + 999 order by 1"
   )
 
   allCases foreach { query =>

--- a/core/src/test/scala/org/apache/spark/sql/expression/ArithmeticAgg0Suite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/ArithmeticAgg0Suite.scala
@@ -35,8 +35,8 @@ class ArithmeticAgg0Suite extends BaseTiSparkSuite {
     // Below two cases will causes overflow if no predicates applied
     // While Spark does not check overflow for types other than decimal
     // TiKV will do the check and throw exception
-    "select avg(tp_bigint) from full_data_type_table where tp_bigint < 10000000 and tp_bigint > -100000000",
-    "select sum(tp_bigint) from full_data_type_table where tp_bigint < 10000000 and tp_bigint > -100000000",
+    "select avg(tp_bigint) from full_data_type_table",
+    "select sum(tp_bigint) from full_data_type_table",
     "select sum(tp_decimal) from full_data_type_table",
     "select sum(tp_mediumint) from full_data_type_table",
     "select abs(tp_float) from full_data_type_table",

--- a/core/src/test/scala/org/apache/spark/sql/expression/ArithmeticAgg0Suite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/ArithmeticAgg0Suite.scala
@@ -32,9 +32,6 @@ class ArithmeticAgg0Suite extends BaseTiSparkSuite {
     "select sum(tp_smallint) from full_data_type_table",
     "select sum(tp_float) from full_data_type_table",
     "select avg(tp_char) from full_data_type_table",
-    // Below two cases will causes overflow if no predicates applied
-    // While Spark does not check overflow for types other than decimal
-    // TiKV will do the check and throw exception
     "select avg(tp_bigint) from full_data_type_table",
     "select sum(tp_bigint) from full_data_type_table",
     "select sum(tp_decimal) from full_data_type_table",

--- a/core/src/test/scala/org/apache/spark/sql/expression/ArithmeticAgg0Suite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/ArithmeticAgg0Suite.scala
@@ -32,8 +32,11 @@ class ArithmeticAgg0Suite extends BaseTiSparkSuite {
     "select sum(tp_smallint) from full_data_type_table",
     "select sum(tp_float) from full_data_type_table",
     "select avg(tp_char) from full_data_type_table",
-    "select avg(tp_bigint) from full_data_type_table",
-    "select sum(tp_bigint) from full_data_type_table",
+    // Below two cases will causes overflow if no predicates applied
+    // While Spark does not check overflow for types other than decimal
+    // TiKV will do the check and throw exception
+    "select avg(tp_bigint) from full_data_type_table where tp_bigint < 10000000 and tp_bigint > -100000000",
+    "select sum(tp_bigint) from full_data_type_table where tp_bigint < 10000000 and tp_bigint > -100000000",
     "select sum(tp_decimal) from full_data_type_table",
     "select sum(tp_mediumint) from full_data_type_table",
     "select abs(tp_float) from full_data_type_table",


### PR DESCRIPTION
When a group by issued without aggregates, Spark has contract that in the result expressions, there will be attributes referring back directly to input schema before aggregation. Those attributes are not dealt with correctly by replacing with TiKV output attributes.
Refer to https://github.com/pingcap/tispark/issues/232

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tispark/237)
<!-- Reviewable:end -->
