### PR TITLE
Move null time out of test data

### DIFF
--- a/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
@@ -18,14 +18,14 @@ package org.apache.spark.sql
 class IssueTestSuite extends BaseTiSparkSuite {
 
   // https://github.com/pingcap/tispark/issues/262
-  test("NPE when decoding datetime") {
+  test("NPE when decoding datetime,date,timestamp") {
     tidbStmt.execute("DROP TABLE IF EXISTS `tmp_debug`")
     tidbStmt.execute(
-      "CREATE TABLE `tmp_debug` (\n  `sign_time` datetime DEFAULT NULL\n) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;"
+      "CREATE TABLE `tmp_debug` (\n  `tp_datetime` datetime DEFAULT NULL, `tp_date` date DEFAULT NULL, `tp_timestamp` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP\n) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;"
     )
-    tidbStmt.execute("INSERT INTO `tmp_debug` VALUES ('0000-00-00 00:00:00')")
+    tidbStmt.execute("INSERT INTO `tmp_debug` VALUES ('0000-00-00 00:00:00','0000-00-00','0000-00-00 00:00:00')")
     refreshConnections()
-    assert(execDBTSAndJudge("select * from tmp_debug"))
+    spark.sql("select * from tmp_debug").collect()
   }
 
   // https://github.com/pingcap/tispark/issues/255


### PR DESCRIPTION
Since null `datetime`,`date`,`timestamp` will impact default JDBC behavior, which in our case, some invalid time like `000-00-00` will be converted to null(specified in JDBC url as`zeroDateTimeBehavior=convertToNull`,see more about this [here](https://dev.mysql.com/doc/connector-j/5.1/en/connector-j-reference-configuration-properties.html)`) in expression evaluation, but actually they should not appear in the result record.

As we need to make sure https://github.com/pingcap/tispark/pull/265 and https://github.com/pingcap/tispark/pull/261 both work, along with minimal impact to other integration test cases, I removed invalid date data out of test data and add single test cases for such issue.