### PR TITLE
Minor modification of TiHandle RDD print info

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/TiStrategy.scala
+++ b/core/src/main/scala/org/apache/spark/sql/TiStrategy.scala
@@ -257,7 +257,8 @@ class TiStrategy(context: SQLContext) extends Strategy with Logging {
     }
 
     dagRequest.addRanges(scanPlan.getKeyRanges)
-    scanPlan.getFilters.asScala.foreach { dagRequest.addFilter }
+    if (!allowIndexDoubleRead())
+      scanPlan.getFilters.asScala.foreach { dagRequest.addFilter }
     if (scanPlan.isIndexScan) {
       dagRequest.setIndexInfo(scanPlan.getIndex)
       // need to set isDoubleRead to true for dagRequest in case of double read

--- a/core/src/main/scala/org/apache/spark/sql/TiStrategy.scala
+++ b/core/src/main/scala/org/apache/spark/sql/TiStrategy.scala
@@ -257,12 +257,13 @@ class TiStrategy(context: SQLContext) extends Strategy with Logging {
     }
 
     dagRequest.addRanges(scanPlan.getKeyRanges)
-    if (!allowIndexDoubleRead())
-      scanPlan.getFilters.asScala.foreach { dagRequest.addFilter }
     if (scanPlan.isIndexScan) {
       dagRequest.setIndexInfo(scanPlan.getIndex)
       // need to set isDoubleRead to true for dagRequest in case of double read
       dagRequest.setIsDoubleRead(scanPlan.isDoubleRead)
+    }
+    if (!scanPlan.isDoubleRead) {
+      scanPlan.getFilters.asScala.foreach { dagRequest.addFilter }
     }
     dagRequest.setTableInfo(source.table)
     dagRequest

--- a/tikv-client/src/main/java/com/pingcap/tikv/meta/TiDAGRequest.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/meta/TiDAGRequest.java
@@ -755,6 +755,11 @@ public class TiDAGRequest implements Serializable {
       sb.append(Joiner.on(", ").skipNulls().join(getFilters()));
     }
 
+    if (getDowngradeFilters().size() != 0) {
+      sb.append(", Downgrade filter: ");
+      sb.append(Joiner.on(", ").skipNulls().join(getDowngradeFilters()));
+    }
+
     if (getAggregates().size() != 0) {
       sb.append(", Aggregates: ");
       sb.append(Joiner.on(", ").skipNulls().join(getAggregates()));


### PR DESCRIPTION
1. Remove useless filter for double read cases.
2. Improve `TiDAGRequest`'s toString.