### PR TITLE
Change downgrade index scan range merge logic

### DIFF
--- a/tikv-client/src/main/java/com/pingcap/tikv/util/KeyRangeUtils.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/util/KeyRangeUtils.java
@@ -25,7 +25,6 @@ import com.pingcap.tikv.kvproto.Coprocessor;
 import com.pingcap.tikv.kvproto.Coprocessor.KeyRange;
 
 import java.util.List;
-import java.util.Set;
 
 import static com.pingcap.tikv.key.Key.toRawKey;
 
@@ -70,7 +69,7 @@ public class KeyRangeUtils {
     }
 
     ByteString prefix = startKey.size() > endKey.size() ?
-                        startKey.substring(0, i) : endKey.substring(0, i);
+        startKey.substring(0, i) : endKey.substring(0, i);
     ByteString newStartKey = startKey;
     ByteString newEndKey;
     for (int j = 0; j < splitFactor; j++) {
@@ -97,7 +96,7 @@ public class KeyRangeUtils {
    * Build a Coprocessor Range with CLOSED_OPEN endpoints
    *
    * @param startKey startKey
-   * @param endKey endKey
+   * @param endKey   endKey
    * @return a CLOSED_OPEN range for coprocessor
    */
   public static KeyRange makeCoprocRange(ByteString startKey, ByteString endKey) {
@@ -119,9 +118,15 @@ public class KeyRangeUtils {
       throw new TiClientInternalException("range must be CLOSED_OPEN");
     }
     return makeCoprocRange(range.lowerEndpoint().toByteString(),
-                           range.upperEndpoint().toByteString());
+        range.upperEndpoint().toByteString());
   }
 
+  /**
+   * Merge potential discrete ranges into one large range.
+   *
+   * @param ranges the range list to merge
+   * @return the minimal range which encloses all ranges in this range list.
+   */
   public static List<KeyRange> mergeRanges(List<KeyRange> ranges) {
     if (ranges == null || ranges.isEmpty() || ranges.size() == 1) {
       return ranges;

--- a/tikv-client/src/main/java/com/pingcap/tikv/util/KeyRangeUtils.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/util/KeyRangeUtils.java
@@ -126,18 +126,14 @@ public class KeyRangeUtils {
     if (ranges == null || ranges.isEmpty() || ranges.size() == 1) {
       return ranges;
     }
-
-    // Merge discrete ranges into one complete big range
-    ByteString start = ranges.get(0).getStart();
-    ByteString end = ranges.get(ranges.size() - 1).getEnd();
+    RangeSet<Key> rangeSet = TreeRangeSet.create();
+    for (KeyRange keyRange : ranges) {
+      Range<Key> range = makeRange(keyRange.getStart(), keyRange.getEnd());
+      rangeSet.add(range);
+    }
 
     ImmutableList.Builder<KeyRange> rangeBuilder = ImmutableList.builder();
-    rangeBuilder.add(
-        KeyRange.newBuilder()
-        .setStart(start)
-        .setEnd(end)
-        .build()
-    );
+    rangeBuilder.add(makeCoprocRange(rangeSet.span()));
     return rangeBuilder.build();
   }
 

--- a/tikv-client/src/main/java/com/pingcap/tikv/util/KeyRangeUtils.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/util/KeyRangeUtils.java
@@ -127,18 +127,17 @@ public class KeyRangeUtils {
       return ranges;
     }
 
-    RangeSet<Key> rangeSet = TreeRangeSet.create();
-    for (KeyRange keyRange : ranges) {
-      Range<Key> range = makeRange(keyRange.getStart(), keyRange.getEnd());
-      rangeSet.add(range);
-    }
+    // Merge discrete ranges into one complete big range
+    ByteString start = ranges.get(0).getStart();
+    ByteString end = ranges.get(ranges.size() - 1).getEnd();
 
-    Set<Range<Key>> mergedRanges = rangeSet.asRanges();
     ImmutableList.Builder<KeyRange> rangeBuilder = ImmutableList.builder();
-    for (Range<Key> range : mergedRanges) {
-      rangeBuilder.add(makeCoprocRange(range));
-    }
-
+    rangeBuilder.add(
+        KeyRange.newBuilder()
+        .setStart(start)
+        .setEnd(end)
+        .build()
+    );
     return rangeBuilder.build();
   }
 


### PR DESCRIPTION
Merge originally potential discrete ranges into one complete big range in downgraded scan. Original merge logic cannot deal well with highly discrete ranges, and result in an expensive multi-range point scan on TiKV, which may cause too much pressure on TiKV.