### PR TITLE
Limit recursive call depth

### DIFF
--- a/tikv-client/src/main/java/com/pingcap/tikv/operation/iterator/DAGIterator.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/operation/iterator/DAGIterator.java
@@ -3,6 +3,7 @@ package com.pingcap.tikv.operation.iterator;
 import com.pingcap.tidb.tipb.Chunk;
 import com.pingcap.tidb.tipb.DAGRequest;
 import com.pingcap.tidb.tipb.SelectResponse;
+import com.pingcap.tikv.TiConfiguration;
 import com.pingcap.tikv.TiSession;
 import com.pingcap.tikv.exception.GrpcNeedRegionRefreshException;
 import com.pingcap.tikv.exception.TiClientInternalException;
@@ -25,7 +26,7 @@ public abstract class DAGIterator<T> extends CoprocessIterator<T> {
   private ExecutorCompletionService<Iterator<SelectResponse>> streamingService;
   private ExecutorCompletionService<SelectResponse> dagService;
   private SelectResponse response;
-  private static final int MAX_PROCESS_DEPTH = 5;
+  private static final int MAX_PROCESS_DEPTH = 3;
 
   private Iterator<SelectResponse> responseIterator;
 

--- a/tikv-client/src/main/java/com/pingcap/tikv/operation/iterator/DAGIterator.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/operation/iterator/DAGIterator.java
@@ -153,7 +153,7 @@ public abstract class DAGIterator<T> extends CoprocessIterator<T> {
 
   private SelectResponse process(RangeSplitter.RegionTask regionTask, int curDepth) {
     if (curDepth > MAX_PROCESS_DEPTH) {
-      return null;
+      throw new RuntimeException("Request failed after " + curDepth + " region refresh operation, abort.");
     }
     List<Coprocessor.KeyRange> ranges = regionTask.getRanges();
     TiRegion region = regionTask.getRegion();


### PR DESCRIPTION
In order to avoid stack overflow in some extreme cases, like we constructed the wrong DAGRequest/Range, TiKV may throw other error and cause `GrpcNeedRegionRefreshException` in `DAGIterator`, which recursively calls `process` again and again and forever won't recover. 

Fix this by limit the depth of such call.