### PR TITLE
Decrease size function call times

### DIFF
--- a/tikv-client/src/main/java/com/pingcap/tikv/util/KeyRangeUtils.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/util/KeyRangeUtils.java
@@ -138,7 +138,8 @@ public class KeyRangeUtils {
     Key lowMin = toRawKey(first.getStart(), true);
     Key upperMax = toRawKey(first.getEnd(), false);
 
-    for (int i = 1; i < ranges.size(); i++) {
+    int rangeSize = ranges.size();
+    for (int i = 1; i < rangeSize; i++) {
       KeyRange keyRange = ranges.get(i);
       Key start = toRawKey(keyRange.getStart(), true);
       Key end = toRawKey(keyRange.getEnd(), false);


### PR DESCRIPTION
Suppose calling`ranges.size()` takes `O(N)` in time complexity, the for loop below will take up to `O(N^2)` time.
Decrease this call to remain `O(N)` time complexity.