### PR TITLE
TISPARK-16 fix excessive dag columns

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/TiStrategy.scala
+++ b/core/src/main/scala/org/apache/spark/sql/TiStrategy.scala
@@ -516,10 +516,9 @@ class TiStrategy(context: SQLContext) extends Strategy with Logging {
           groupingExpressions,
           aggregateExpressions,
           resultExpressions,
-          TiAggregationProjection(filters, _, `source`, _)
+          TiAggregationProjection(filters, _, `source`, projects)
           ) if isValidAggregates(groupingExpressions, aggregateExpressions, filters, source) =>
-        val expressions = groupingExpressions ++ aggregateExpressions ++ filters
-        val projectSet = AttributeSet(expressions.flatMap { _.references })
+        val projectSet = AttributeSet((projects ++ filters).flatMap { _.references })
         val tiColumns = buildTiColumnRefFromColumnSet(projectSet, source)
         val dagReq: TiDAGRequest = filterToDAGRequest(tiColumns, filters, source)
         groupAggregateProjection(

--- a/core/src/main/scala/org/apache/spark/sql/TiStrategy.scala
+++ b/core/src/main/scala/org/apache/spark/sql/TiStrategy.scala
@@ -222,14 +222,17 @@ class TiStrategy(context: SQLContext) extends Strategy with Logging {
   }
 
   /**
-    * build a Seq of used TiColumnRef from AttributeSet and bound them to souce table
-    *
-    * @param attributeSet AttributeSet containing projects w/ or w/o filters
-    * @param source source TiDBRelation
-    * @return a Seq of TiColumnRef extracted
-    */
-  def buildTiColumnRefFromColumnSet(attributeSet: AttributeSet, source: TiDBRelation): Seq[TiColumnRef] = {
-    val tiColumnSet: Seq[TiExpression] = attributeSet.toSeq.collect { case BasicExpression(expr) => expr }
+   * build a Seq of used TiColumnRef from AttributeSet and bound them to souce table
+   *
+   * @param attributeSet AttributeSet containing projects w/ or w/o filters
+   * @param source source TiDBRelation
+   * @return a Seq of TiColumnRef extracted
+   */
+  def buildTiColumnRefFromColumnSet(attributeSet: AttributeSet,
+                                    source: TiDBRelation): Seq[TiColumnRef] = {
+    val tiColumnSet: Seq[TiExpression] = attributeSet.toSeq.collect {
+      case BasicExpression(expr) => expr
+    }
     val resolver = new MetaResolver(source.table)
     val tiColumns: Seq[TiColumnRef] = extractTiColumnRefFromExpressions(tiColumnSet)
     tiColumns.foreach { resolver.resolve(_) }
@@ -242,7 +245,7 @@ class TiStrategy(context: SQLContext) extends Strategy with Logging {
     source: TiDBRelation,
     dagRequest: TiDAGRequest = new TiDAGRequest(pushDownType(), timeZoneOffset())
   ): TiDAGRequest = {
-    val tiFilters: Seq[TiExpression] = filters.collect { case BasicExpression(expr)     => expr }
+    val tiFilters: Seq[TiExpression] = filters.collect { case BasicExpression(expr) => expr }
 
     val scanBuilder: ScanAnalyzer = new ScanAnalyzer
 

--- a/core/src/main/scala/org/apache/spark/sql/TiStrategy.scala
+++ b/core/src/main/scala/org/apache/spark/sql/TiStrategy.scala
@@ -413,11 +413,7 @@ class TiStrategy(context: SQLContext) extends Strategy with Logging {
       .map { _.toAttribute.name }
       .map { ColumnRef.create }
 
-    val filterTiRefs = filters
-      .collect { case BasicExpression(tiExpr) => tiExpr }
-      .flatMap { referencedTiColumns }
-
-    projectionTiRefs ++ filterTiRefs foreach { dagReq.addRequiredColumn }
+    projectionTiRefs foreach { dagReq.addRequiredColumn }
 
     aggregationToDAGRequest(groupingExpressions, aggregateExpressions.distinct, source, dagReq)
 

--- a/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
@@ -36,6 +36,9 @@ class IssueTestSuite extends BaseTiSparkSuite {
     tidbStmt.execute("insert into t2 values(2, 201707, 'aa')")
     refreshConnections()
 
+    // Note: Left outer join for DataSet is different from that in mysql.
+    // The result of DataSet[a, b, c] left outer join DataSet[d, b, c]
+    // on join key(b, c) will be DataSet[b, c, a, d]
     val t1_df = spark.sql("select * from t1")
     val t1_group_df = t1_df.groupBy("k1", "k2").agg(sum("c1").alias("c1"))
     val t2_df = spark.sql("select * from t2")

--- a/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
@@ -22,16 +22,20 @@ class IssueTestSuite extends BaseTiSparkSuite {
   test("TISPARK-16 fix excessive dag column") {
     tidbStmt.execute("DROP TABLE IF EXISTS `t1`")
     tidbStmt.execute("DROP TABLE IF EXISTS `t2`")
-    tidbStmt.execute("""CREATE TABLE `t1` (
-                       |         `c1` bigint(20) DEFAULT NULL,
-                       |         `k2` int(20) DEFAULT NULL,
-                       |         `k1` varchar(32) DEFAULT NULL
-                       |         ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin""".stripMargin)
-    tidbStmt.execute("""CREATE TABLE `t2` (
-                       |         `c2` bigint(20) DEFAULT NULL,
-                       |         `k2` int(20) DEFAULT NULL,
-                       |         `k1` varchar(32) DEFAULT NULL
-                       |         ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin""".stripMargin)
+    tidbStmt.execute(
+      """CREATE TABLE `t1` (
+        |         `c1` bigint(20) DEFAULT NULL,
+        |         `k2` int(20) DEFAULT NULL,
+        |         `k1` varchar(32) DEFAULT NULL
+        |         ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin""".stripMargin
+    )
+    tidbStmt.execute(
+      """CREATE TABLE `t2` (
+        |         `c2` bigint(20) DEFAULT NULL,
+        |         `k2` int(20) DEFAULT NULL,
+        |         `k1` varchar(32) DEFAULT NULL
+        |         ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin""".stripMargin
+    )
     tidbStmt.execute("insert into t1 values(1, 201707, 'aa')")
     tidbStmt.execute("insert into t2 values(2, 201707, 'aa')")
     refreshConnections()

--- a/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
@@ -53,7 +53,7 @@ class IssueTestSuite extends BaseTiSparkSuite {
     join_df.show
     val filter_df = join_df.filter(col("c2").isNotNull)
     filter_df.show
-    val project_df = join_df.select("k1", "k2", "c1")
+    val project_df = join_df.select("k1", "k2", "c2")
     project_df.show
   }
 


### PR DESCRIPTION
Heretofore we added both project columns and filter columns into requiredColumns of dagRequest without distinguishing them when aggregations are encountered. When we preform joins with filters, the duplicated columns will affect row decoding and cause offset drift in decoding. 

Fixes by folding those columns beforehand.