### PR TITLE
Refix stale epoch handling

### DIFF
--- a/tikv-client/src/main/java/com/pingcap/tikv/exception/KeyException.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/exception/KeyException.java
@@ -20,6 +20,11 @@ import com.pingcap.tikv.kvproto.Kvrpcpb;
 public class KeyException extends RuntimeException {
   private final Kvrpcpb.KeyError keyErr;
 
+  public KeyException(String errMsg) {
+    super(errMsg);
+    keyErr = null;
+  }
+
   public KeyException(Kvrpcpb.KeyError keyErr) {
     this.keyErr = keyErr;
   }

--- a/tikv-client/src/main/java/com/pingcap/tikv/operation/KVErrorHandler.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/operation/KVErrorHandler.java
@@ -136,7 +136,7 @@ public class KVErrorHandler<RespT> implements ErrorHandler<RespT> {
       } else if (error.hasStaleEpoch()) {
         logger.warn(String.format("Stale Epoch encountered for region [%s]", ctxRegion));
         this.regionManager.onRegionStale(ctxRegion.getId());
-        throw new StatusRuntimeException(Status.fromCode(Status.Code.UNAVAILABLE).withDescription(error.toString()));
+        return false;
       } else if (error.hasServerIsBusy()) {
         logger.warn(String.format("Server is busy for region [%s], reason: %s", ctxRegion, error.getServerIsBusy().getReason()));
         backOffer.doBackOff(BackOffFunction.BackOffFuncType.BoServerBusy,

--- a/tikv-client/src/main/java/com/pingcap/tikv/operation/SchemaInfer.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/operation/SchemaInfer.java
@@ -44,7 +44,7 @@ public class SchemaInfer {
     return new SchemaInfer(dagRequest);
   }
 
-  private SchemaInfer(TiDAGRequest dagRequest) {
+  protected SchemaInfer(TiDAGRequest dagRequest) {
     types = new ArrayList<>();
     extractFieldTypes(dagRequest);
     extractHandleType(dagRequest);

--- a/tikv-client/src/main/java/com/pingcap/tikv/operation/iterator/DAGIterator.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/operation/iterator/DAGIterator.java
@@ -1,5 +1,7 @@
 package com.pingcap.tikv.operation.iterator;
 
+import static com.pingcap.tikv.meta.TiDAGRequest.PushDownType.STREAMING;
+
 import com.pingcap.tidb.tipb.Chunk;
 import com.pingcap.tidb.tipb.DAGRequest;
 import com.pingcap.tidb.tipb.SelectResponse;
@@ -15,19 +17,20 @@ import com.pingcap.tikv.region.TiRegion;
 import com.pingcap.tikv.util.BackOffer;
 import com.pingcap.tikv.util.ConcreteBackOffer;
 import com.pingcap.tikv.util.RangeSplitter;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ExecutorCompletionService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.*;
-import java.util.concurrent.ExecutorCompletionService;
-
-import static com.pingcap.tikv.meta.TiDAGRequest.PushDownType.STREAMING;
 
 public abstract class DAGIterator<T> extends CoprocessIterator<T> {
   private ExecutorCompletionService<Iterator<SelectResponse>> streamingService;
   private ExecutorCompletionService<SelectResponse> dagService;
   private SelectResponse response;
-  private static final int MAX_PROCESS_DEPTH = 3;
   private static final Logger logger = LoggerFactory.getLogger(DAGIterator.class.getName());
 
   private Iterator<SelectResponse> responseIterator;

--- a/tikv-client/src/test/java/com/pingcap/tikv/KVMockServer.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/KVMockServer.java
@@ -27,6 +27,8 @@ import com.pingcap.tikv.key.Key;
 import com.pingcap.tikv.kvproto.Coprocessor;
 import com.pingcap.tikv.kvproto.Errorpb;
 import com.pingcap.tikv.kvproto.Errorpb.Error;
+import com.pingcap.tikv.kvproto.Errorpb.NotLeader;
+import com.pingcap.tikv.kvproto.Errorpb.ServerIsBusy;
 import com.pingcap.tikv.kvproto.Errorpb.StaleEpoch;
 import com.pingcap.tikv.kvproto.Kvrpcpb;
 import com.pingcap.tikv.kvproto.Kvrpcpb.Context;
@@ -326,8 +328,13 @@ public class KVMockServer extends TikvGrpc.TikvImplBase {
       for (Coprocessor.KeyRange keyRange : keyRanges) {
         Integer errorCode = errorMap.remove(keyRange.getStart());
         if (errorCode != null) {
-          errBuilder.setStaleEpoch(StaleEpoch.getDefaultInstance());
-
+          if (STALE_EPOCH == errorCode) {
+            errBuilder.setStaleEpoch(StaleEpoch.getDefaultInstance());
+          } else if (NOT_LEADER == errorCode) {
+            errBuilder.setNotLeader(NotLeader.getDefaultInstance());
+          } else {
+            errBuilder.setServerIsBusy(ServerIsBusy.getDefaultInstance());
+          }
           builderWrap.setRegionError(errBuilder.build());
           break;
         } else {

--- a/tikv-client/src/test/java/com/pingcap/tikv/KVMockServer.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/KVMockServer.java
@@ -23,14 +23,15 @@ import com.google.protobuf.ByteString;
 import com.pingcap.tidb.tipb.Chunk;
 import com.pingcap.tidb.tipb.DAGRequest;
 import com.pingcap.tidb.tipb.SelectResponse;
+import com.pingcap.tikv.key.Key;
 import com.pingcap.tikv.kvproto.Coprocessor;
 import com.pingcap.tikv.kvproto.Errorpb;
 import com.pingcap.tikv.kvproto.Errorpb.Error;
+import com.pingcap.tikv.kvproto.Errorpb.StaleEpoch;
 import com.pingcap.tikv.kvproto.Kvrpcpb;
 import com.pingcap.tikv.kvproto.Kvrpcpb.Context;
 import com.pingcap.tikv.kvproto.TikvGrpc;
 import com.pingcap.tikv.region.TiRegion;
-import com.pingcap.tikv.key.Key;
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
 import io.grpc.Status;
@@ -53,17 +54,17 @@ public class KVMockServer extends TikvGrpc.TikvImplBase {
   private Map<ByteString, Integer> errorMap = new HashMap<>();
 
   // for KV error
-  static final int ABORT = 1;
-  static final int RETRY = 2;
+  public static final int ABORT = 1;
+  public static final int RETRY = 2;
   // for raw client error
-  static final int NOT_LEADER = 3;
-  static final int REGION_NOT_FOUND = 4;
-  static final int KEY_NOT_IN_REGION = 5;
-  static final int STALE_EPOCH = 6;
-  static final int SERVER_IS_BUSY = 7;
-  static final int STALE_COMMAND = 8;
-  static final int STORE_NOT_MATCH = 9;
-  static final int RAFT_ENTRY_TOO_LARGE = 10;
+  public static final int NOT_LEADER = 3;
+  public static final int REGION_NOT_FOUND = 4;
+  public static final int KEY_NOT_IN_REGION = 5;
+  public static final int STALE_EPOCH = 6;
+  public static final int SERVER_IS_BUSY = 7;
+  public static final int STALE_COMMAND = 8;
+  public static final int STORE_NOT_MATCH = 9;
+  public static final int RAFT_ENTRY_TOO_LARGE = 10;
 
   public int getPort() {
     return port;
@@ -82,11 +83,15 @@ public class KVMockServer extends TikvGrpc.TikvImplBase {
         ByteString.copyFromUtf8(value));
   }
 
+  public void put(String key, ByteString data) {
+    put(ByteString.copyFromUtf8(key), data);
+  }
+
   public void putError(String key, int code) {
     errorMap.put(ByteString.copyFromUtf8(key), code);
   }
 
-  void clearAllMap() {
+  public void clearAllMap() {
     dataMap.clear();
     errorMap.clear();
   }
@@ -134,7 +139,7 @@ public class KVMockServer extends TikvGrpc.TikvImplBase {
       ByteString key = request.getKey();
 
       Kvrpcpb.RawPutResponse.Builder builder = Kvrpcpb.RawPutResponse.newBuilder();
-      Integer errorCode = errorMap.get(key);
+      Integer errorCode = errorMap.remove(key);
       Errorpb.Error.Builder errBuilder = Errorpb.Error.newBuilder();
       if (errorCode != null) {
         setErrorInfo(errorCode, errBuilder);
@@ -178,7 +183,7 @@ public class KVMockServer extends TikvGrpc.TikvImplBase {
       ByteString key = request.getKey();
 
       Kvrpcpb.RawDeleteResponse.Builder builder = Kvrpcpb.RawDeleteResponse.newBuilder();
-      Integer errorCode = errorMap.get(key);
+      Integer errorCode = errorMap.remove(key);
       Errorpb.Error.Builder errBuilder = Errorpb.Error.newBuilder();
       if (errorCode != null) {
         setErrorInfo(errorCode, errBuilder);
@@ -203,7 +208,7 @@ public class KVMockServer extends TikvGrpc.TikvImplBase {
       ByteString key = request.getKey();
 
       Kvrpcpb.GetResponse.Builder builder = Kvrpcpb.GetResponse.newBuilder();
-      Integer errorCode = errorMap.get(key);
+      Integer errorCode = errorMap.remove(key);
       Kvrpcpb.KeyError.Builder errBuilder = Kvrpcpb.KeyError.newBuilder();
       if (errorCode != null) {
         if (errorCode == ABORT) {
@@ -236,7 +241,7 @@ public class KVMockServer extends TikvGrpc.TikvImplBase {
 
       Kvrpcpb.ScanResponse.Builder builder = Kvrpcpb.ScanResponse.newBuilder();
       Error.Builder errBuilder = Error.newBuilder();
-      Integer errorCode = errorMap.get(key);
+      Integer errorCode = errorMap.remove(key);
       if (errorCode != null) {
         if (errorCode == ABORT) {
           errBuilder.setServerIsBusy(Errorpb.ServerIsBusy.getDefaultInstance());
@@ -279,7 +284,7 @@ public class KVMockServer extends TikvGrpc.TikvImplBase {
       Error.Builder errBuilder = Error.newBuilder();
       ImmutableList.Builder<Kvrpcpb.KvPair> resultList = ImmutableList.builder();
       for (ByteString key : keys) {
-        Integer errorCode = errorMap.get(key);
+        Integer errorCode = errorMap.remove(key);
         if (errorCode != null) {
           if (errorCode == ABORT) {
             errBuilder.setServerIsBusy(Errorpb.ServerIsBusy.getDefaultInstance());
@@ -315,16 +320,15 @@ public class KVMockServer extends TikvGrpc.TikvImplBase {
 
       Coprocessor.Response.Builder builderWrap = Coprocessor.Response.newBuilder();
       SelectResponse.Builder builder = SelectResponse.newBuilder();
-      com.pingcap.tidb.tipb.Error.Builder errBuilder = com.pingcap.tidb.tipb.Error.newBuilder();
+      com.pingcap.tikv.kvproto.Errorpb.Error.Builder errBuilder = com.pingcap.tikv.kvproto.Errorpb.Error.newBuilder();
+
 
       for (Coprocessor.KeyRange keyRange : keyRanges) {
-        Integer errorCode = errorMap.get(keyRange.getStart());
+        Integer errorCode = errorMap.remove(keyRange.getStart());
         if (errorCode != null) {
-          if (errorCode == ABORT) {
-            errBuilder.setCode(errorCode);
-            errBuilder.setMsg("whatever");
-          }
-          builder.setError(errBuilder.build());
+          errBuilder.setStaleEpoch(StaleEpoch.getDefaultInstance());
+
+          builderWrap.setRegionError(errBuilder.build());
           break;
         } else {
           ByteString startKey = keyRange.getStart();
@@ -361,7 +365,7 @@ public class KVMockServer extends TikvGrpc.TikvImplBase {
     return port;
   }
 
-  void stop() {
+  public void stop() {
     if (server != null) {
       server.shutdown();
     }

--- a/tikv-client/src/test/java/com/pingcap/tikv/operation/iterator/DAGIteratorTest.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/operation/iterator/DAGIteratorTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2017 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pingcap.tikv.operation.iterator;
+
+import static junit.framework.TestCase.assertEquals;
+
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.ByteString;
+import com.pingcap.tikv.GrpcUtils;
+import com.pingcap.tikv.KVMockServer;
+import com.pingcap.tikv.PDMockServer;
+import com.pingcap.tikv.TiConfiguration;
+import com.pingcap.tikv.TiSession;
+import com.pingcap.tikv.codec.Codec.BytesCodec;
+import com.pingcap.tikv.codec.Codec.IntegerCodec;
+import com.pingcap.tikv.codec.CodecDataOutput;
+import com.pingcap.tikv.expression.ColumnRef;
+import com.pingcap.tikv.kvproto.Coprocessor.KeyRange;
+import com.pingcap.tikv.kvproto.Kvrpcpb.CommandPri;
+import com.pingcap.tikv.kvproto.Kvrpcpb.IsolationLevel;
+import com.pingcap.tikv.kvproto.Metapb;
+import com.pingcap.tikv.meta.MetaUtils;
+import com.pingcap.tikv.meta.TiDAGRequest;
+import com.pingcap.tikv.meta.TiDAGRequest.PushDownType;
+import com.pingcap.tikv.meta.TiTableInfo;
+import com.pingcap.tikv.operation.SchemaInfer;
+import com.pingcap.tikv.region.RegionStoreClient;
+import com.pingcap.tikv.region.TiRegion;
+import com.pingcap.tikv.row.Row;
+import com.pingcap.tikv.types.IntegerType;
+import com.pingcap.tikv.types.StringType;
+import com.pingcap.tikv.util.RangeSplitter.RegionTask;
+import java.util.List;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class DAGIteratorTest {
+  private KVMockServer server;
+  private PDMockServer pdServer;
+  private static final String LOCAL_ADDR = "127.0.0.1";
+  private static final long CLUSTER_ID = 1024;
+  private int port;
+  private TiSession session;
+  private TiRegion region;
+
+  private static TiTableInfo createTable() {
+    return new MetaUtils.TableBuilder()
+        .name("testTable")
+        .addColumn("c1", IntegerType.INT, true)
+        .addColumn("c2", StringType.VARCHAR)
+        .build();
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    pdServer = new PDMockServer();
+    pdServer.start(CLUSTER_ID);
+    pdServer.addGetMemberResp(
+        GrpcUtils.makeGetMembersResponse(
+            pdServer.getClusterId(),
+            GrpcUtils.makeMember(1, "http://" + LOCAL_ADDR + ":" + pdServer.port),
+            GrpcUtils.makeMember(2, "http://" + LOCAL_ADDR + ":" + (pdServer.port + 1)),
+            GrpcUtils.makeMember(2, "http://" + LOCAL_ADDR + ":" + (pdServer.port + 2))));
+
+    Metapb.Region r =
+        Metapb.Region.newBuilder()
+            .setRegionEpoch(Metapb.RegionEpoch.newBuilder().setConfVer(1).setVersion(2))
+            .setId(233)
+            .setStartKey(ByteString.EMPTY)
+            .setEndKey(ByteString.EMPTY)
+            .addPeers(Metapb.Peer.newBuilder().setId(11).setStoreId(13))
+            .build();
+
+    region = new TiRegion(r, r.getPeers(0), IsolationLevel.RC, CommandPri.Low);
+    server = new KVMockServer();
+    port = server.start(region);
+    // No PD needed in this test
+    TiConfiguration conf = TiConfiguration.createDefault("127.0.0.1:" + pdServer.port);
+    session = TiSession.create(conf);
+  }
+
+  private RegionStoreClient createClient() {
+    Metapb.Store store =
+        Metapb.Store.newBuilder()
+            .setAddress(LOCAL_ADDR + ":" + port)
+            .setId(1)
+            .setState(Metapb.StoreState.Up)
+            .build();
+
+    return RegionStoreClient.create(region, store, session);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    server.stop();
+  }
+
+
+  @Test
+  public void staleEpochTest() throws Exception {
+    Metapb.Store store =
+        Metapb.Store.newBuilder()
+            .setAddress(LOCAL_ADDR + ":" + port)
+            .setId(1)
+            .setState(Metapb.StoreState.Up)
+            .build();
+
+    TiTableInfo table = createTable();
+    TiDAGRequest req = new TiDAGRequest(PushDownType.NORMAL);
+    req.setTableInfo(table);
+    req.addRequiredColumn(ColumnRef.create("c1"));
+    req.addRequiredColumn(ColumnRef.create("c2"));
+    req.setStartTs(1);
+    req.resolve();
+
+    List<KeyRange> keyRanges =
+        ImmutableList.of(createByteStringRange(ByteString.copyFromUtf8("key1"), ByteString.copyFromUtf8("key4")));
+
+    pdServer.addGetRegionResp(
+        GrpcUtils.makeGetRegionResponse(
+            pdServer.getClusterId(),
+            GrpcUtils.makeRegion(
+                region.getId(),
+                region.getStartKey(),
+                region.getEndKey(),
+                region.getRegionEpoch(),
+                region.getLeader())));
+    pdServer.addGetStoreResp(GrpcUtils.makeGetStoreResponse(pdServer.getClusterId(), store));
+    server.putError("key1", KVMockServer.STALE_EPOCH);
+    CodecDataOutput cdo = new CodecDataOutput();
+    IntegerCodec.writeLongFully(cdo, 666, false);
+    BytesCodec.writeBytesFully(cdo, "value1".getBytes());
+    server.put("key1", cdo.toByteString());
+    List<RegionTask> tasks = ImmutableList.of(RegionTask.newInstance(region, store, keyRanges));
+    CoprocessIterator<Row> iter = CoprocessIterator.getRowIterator(req, tasks, session);
+    iter.hasNext();
+    Row r = iter.next();
+    SchemaInfer infer = SchemaInfer.create(req);
+    assertEquals(r.get(0, infer.getType(0)), 666L);
+    assertEquals(r.get(1, infer.getType(1)), "value1");
+  }
+
+
+  private static KeyRange createByteStringRange(ByteString sKey, ByteString eKey) {
+    return KeyRange.newBuilder().setStart(sKey).setEnd(eKey).build();
+  }
+}

--- a/tikv-client/src/test/java/com/pingcap/tikv/operation/iterator/DAGIteratorTest.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/operation/iterator/DAGIteratorTest.java
@@ -130,15 +130,7 @@ public class DAGIteratorTest {
     List<KeyRange> keyRanges =
         ImmutableList.of(createByteStringRange(ByteString.copyFromUtf8("key1"), ByteString.copyFromUtf8("key4")));
 
-    pdServer.addGetRegionResp(
-        GrpcUtils.makeGetRegionResponse(
-            pdServer.getClusterId(),
-            GrpcUtils.makeRegion(
-                region.getId(),
-                region.getStartKey(),
-                region.getEndKey(),
-                region.getRegionEpoch(),
-                region.getLeader())));
+    pdServer.addGetRegionResp(GrpcUtils.makeGetRegionResponse(pdServer.getClusterId(), region.getMeta()));
     pdServer.addGetStoreResp(GrpcUtils.makeGetStoreResponse(pdServer.getClusterId(), store));
     server.putError("key1", KVMockServer.STALE_EPOCH);
     CodecDataOutput cdo = new CodecDataOutput();


### PR DESCRIPTION
According to TiDB's logic, we should trigger split and resend request.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tispark/325)
<!-- Reviewable:end -->
