### PR TITLE
Add tests for unsigned data types

### DIFF
--- a/core/src/test/scala/org/apache/spark/sql/BaseTiSparkSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/BaseTiSparkSuite.scala
@@ -125,6 +125,8 @@ class BaseTiSparkSuite extends QueryTest with SharedSQLContext {
         qJDBC = qSpark.replace("full_data_type_table_idx", "full_data_type_table_idx_j")
       } else if (qSpark.contains("full_data_type_table")) {
         qJDBC = qSpark.replace("full_data_type_table", "full_data_type_table_j")
+      } else {
+        qJDBC = qSpark
       }
     }
     qJDBC

--- a/core/src/test/scala/org/apache/spark/sql/BaseTiSparkSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/BaseTiSparkSuite.scala
@@ -175,23 +175,32 @@ class BaseTiSparkSuite extends QueryTest with SharedSQLContext {
     try {
       explainSpark(qSpark)
       if (qJDBC == null) {
-        runTestWithReplaceTableName(qSpark, skipped, rSpark, rJDBC, rTiDB, skipJDBC, skipTiDB)
+        runTest(qSpark, skipped, rSpark, rJDBC, rTiDB, skipJDBC, skipTiDB)
       } else {
-        runTest(qSpark, qJDBC, skipped, rSpark, rJDBC, rTiDB, skipJDBC, skipTiDB)
+        runTestWithoutReplaceTableName(
+          qSpark,
+          qJDBC,
+          skipped,
+          rSpark,
+          rJDBC,
+          rTiDB,
+          skipJDBC,
+          skipTiDB
+        )
       }
     } catch {
       case e: Throwable => fail(e)
     }
   }
 
-  def runTestWithReplaceTableName(qSpark: String,
-                                  skipped: Boolean = false,
-                                  rSpark: List[List[Any]] = null,
-                                  rJDBC: List[List[Any]] = null,
-                                  rTiDB: List[List[Any]] = null,
-                                  skipJDBC: Boolean = false,
-                                  skipTiDB: Boolean = false): Unit = {
-    runTest(
+  def runTest(qSpark: String,
+              skipped: Boolean = false,
+              rSpark: List[List[Any]] = null,
+              rJDBC: List[List[Any]] = null,
+              rTiDB: List[List[Any]] = null,
+              skipJDBC: Boolean = false,
+              skipTiDB: Boolean = false): Unit = {
+    runTestWithoutReplaceTableName(
       qSpark,
       replaceJDBCTableName(qSpark, skipJDBC),
       skipped,
@@ -220,14 +229,14 @@ class BaseTiSparkSuite extends QueryTest with SharedSQLContext {
    * @param skipJDBC  whether not to run test for Spark-JDBC
    * @param skipTiDB  whether not to run test for TiDB
    */
-  def runTest(qSpark: String,
-              qJDBC: String,
-              skipped: Boolean = false,
-              rSpark: List[List[Any]] = null,
-              rJDBC: List[List[Any]] = null,
-              rTiDB: List[List[Any]] = null,
-              skipJDBC: Boolean = false,
-              skipTiDB: Boolean = false): Unit = {
+  def runTestWithoutReplaceTableName(qSpark: String,
+                                     qJDBC: String,
+                                     skipped: Boolean = false,
+                                     rSpark: List[List[Any]] = null,
+                                     rJDBC: List[List[Any]] = null,
+                                     rTiDB: List[List[Any]] = null,
+                                     skipJDBC: Boolean = false,
+                                     skipTiDB: Boolean = false): Unit = {
     if (skipped) {
       logger.warn(s"Test is skipped. [With Spark SQL: $qSpark]")
       return
@@ -275,7 +284,10 @@ class BaseTiSparkSuite extends QueryTest with SharedSQLContext {
       }
       if (skipTiDB || !compResult(r1, r3, isOrdered)) {
         fail(
-          s"Failed with \nTiSpark:\t\t${mapStringNestedList(r1)}\nSpark With JDBC:${mapStringNestedList(r2)}\nTiDB:\t\t\t${mapStringNestedList(r3)}"
+          s"""Failed with
+             |TiSpark:\t\t${mapStringNestedList(r1)}
+             |Spark With JDBC:${mapStringNestedList(r2)}
+             |TiDB:\t\t\t${mapStringNestedList(r3)}""".stripMargin
         )
       }
     }

--- a/core/src/test/scala/org/apache/spark/sql/BaseTiSparkSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/BaseTiSparkSuite.scala
@@ -118,19 +118,40 @@ class BaseTiSparkSuite extends QueryTest with SharedSQLContext {
     spark.sparkContext.setLogLevel(level)
   }
 
+  def replaceJDBCTableName(qSpark: String, skipJDBC: Boolean): String = {
+    var qJDBC: String = null
+    if (!skipJDBC) {
+      if (qSpark.contains("full_data_type_table_idx")) {
+        qJDBC = qSpark.replace("full_data_type_table_idx", "full_data_type_table_idx_j")
+      } else if (qSpark.contains("full_data_type_table")) {
+        qJDBC = qSpark.replace("full_data_type_table", "full_data_type_table_j")
+      }
+    }
+    qJDBC
+  }
+
   def judge(str: String, skipped: Boolean = false): Unit =
     assert(execDBTSAndJudge(str, skipped))
 
   def execDBTSAndJudge(str: String, skipped: Boolean = false): Boolean =
     try {
-      compResult(querySpark(str), queryTiDB(str), str.contains(" order by "))
+      if (skipped) {
+        logger.warn(s"Test is skipped. [With Spark SQL: $str]")
+        true
+      } else {
+        compResult(querySpark(str), queryTiDB(str), str.contains(" order by "))
+      }
     } catch {
       case e: Throwable => fail(e)
     }
 
   def explainSpark(str: String, skipped: Boolean = false): Unit =
     try {
-      spark.sql(str).explain()
+      if (skipped) {
+        logger.warn(s"Test is skipped. [With Spark SQL: $str]")
+      } else {
+        spark.sql(str).explain()
+      }
     } catch {
       case e: Throwable => fail(e)
     }
@@ -143,42 +164,116 @@ class BaseTiSparkSuite extends QueryTest with SharedSQLContext {
       case e: Throwable => fail(e)
     }
 
-  def explainAndRunTest(qSpark: String, qJDBC: String, skipped: Boolean = false): Unit = {
+  def explainAndRunTest(qSpark: String,
+                        qJDBC: String = null,
+                        skipped: Boolean = false,
+                        rSpark: List[List[Any]] = null,
+                        rJDBC: List[List[Any]] = null,
+                        rTiDB: List[List[Any]] = null,
+                        skipJDBC: Boolean = false,
+                        skipTiDB: Boolean = false): Unit = {
     try {
       explainSpark(qSpark)
-      runTest(qSpark, qJDBC)
+      if (qJDBC == null) {
+        runTestWithReplaceTableName(qSpark, skipped, rSpark, rJDBC, rTiDB, skipJDBC, skipTiDB)
+      } else {
+        runTest(qSpark, qJDBC, skipped, rSpark, rJDBC, rTiDB, skipJDBC, skipTiDB)
+      }
     } catch {
       case e: Throwable => fail(e)
     }
   }
 
-  def runTest(qSpark: String, qJDBC: String): Unit = {
-    var r1: List[List[Any]] = null
-    var r2: List[List[Any]] = null
-    var r3: List[List[Any]] = null
+  def runTestWithReplaceTableName(qSpark: String,
+                                  skipped: Boolean = false,
+                                  rSpark: List[List[Any]] = null,
+                                  rJDBC: List[List[Any]] = null,
+                                  rTiDB: List[List[Any]] = null,
+                                  skipJDBC: Boolean = false,
+                                  skipTiDB: Boolean = false): Unit = {
+    runTest(
+      qSpark,
+      replaceJDBCTableName(qSpark, skipJDBC),
+      skipped,
+      rSpark,
+      rJDBC,
+      rTiDB,
+      skipJDBC,
+      skipTiDB
+    )
+  }
 
-    try {
-      r1 = querySpark(qSpark)
-    } catch {
-      case e: Throwable => fail(e)
+  /** Run test with sql `qSpark` for TiSpark and TiDB, `qJDBC` for Spark-JDBC. Throw fail exception when
+   *    - TiSpark query throws exception
+   *    - Both TiDB and Spark-JDBC queries fails to execute
+   *    - Both TiDB and Spark-JDBC results differ from TiSpark result
+   *
+   *  rSpark, rJDBC and rTiDB are used when we want to guarantee a fixed result which might change due to
+   *    - Current incorrectness/instability in used version(s)
+   *    - Format differences for partial data types
+   *
+   * @param qSpark    query for TiSpark and TiDB
+   * @param qJDBC     query for Spark-JDBC
+   * @param rSpark    pre-calculated TiSpark result
+   * @param rJDBC     pre-calculated Spark-JDBC result
+   * @param rTiDB     pre-calculated TiDB result
+   * @param skipJDBC  whether not to run test for Spark-JDBC
+   * @param skipTiDB  whether not to run test for TiDB
+   */
+  def runTest(qSpark: String,
+              qJDBC: String,
+              skipped: Boolean = false,
+              rSpark: List[List[Any]] = null,
+              rJDBC: List[List[Any]] = null,
+              rTiDB: List[List[Any]] = null,
+              skipJDBC: Boolean = false,
+              skipTiDB: Boolean = false): Unit = {
+    if (skipped) {
+      logger.warn(s"Test is skipped. [With Spark SQL: $qSpark]")
+      return
     }
 
-    try {
-      r2 = querySpark(qJDBC)
-    } catch {
-      case e: Throwable =>
-        logger.warn(s"Spark with JDBC failed when executing:$qJDBC", e) // JDBC failed
+    var r1: List[List[Any]] = rSpark
+    var r2: List[List[Any]] = rJDBC
+    var r3: List[List[Any]] = rTiDB
+
+    if (r1 == null) {
+      try {
+        r1 = querySpark(qSpark)
+      } catch {
+        case e: Throwable => fail(e)
+      }
+    }
+
+    if (skipJDBC && skipTiDB) {
+      // If JDBC and TiDB tests are both skipped, the correctness of test is not guaranteed.
+      // However the result might still be useful when we only want to test if the query fails in TiSpark.
+      logger.warn(
+        s"Unknown correctness of test result: Skipped in both JDBC and TiDB. [With Spark SQL: $qSpark]"
+      )
+      return
+    }
+
+    if (!skipJDBC && r2 == null) {
+      try {
+        r2 = querySpark(qJDBC)
+      } catch {
+        case e: Throwable =>
+          logger.warn(s"Spark with JDBC failed when executing:$qJDBC", e) // JDBC failed
+      }
     }
 
     val isOrdered = qSpark.contains(" order by ")
 
-    if (!compResult(r1, r2, isOrdered)) {
-      try {
-        r3 = queryTiDB(qSpark)
-      } catch {
-        case e: Throwable => logger.warn(s"TiDB failed when executing:$qSpark", e) // TiDB failed
+    if (skipJDBC || !compResult(r1, r2, isOrdered)) {
+      if (!skipTiDB && r3 == null) {
+        try {
+          r3 = queryTiDB(qSpark)
+        } catch {
+          case e: Throwable => logger.warn(s"TiDB failed when executing:$qSpark", e) // TiDB failed
+        }
       }
-      if (!compResult(r1, r3, isOrdered)) {
+      if (skipTiDB || !compResult(r1, r3, isOrdered)) {
         fail(
           s"Failed with \nTiSpark:\t\t${mapStringNestedList(r1)}\nSpark With JDBC:${mapStringNestedList(r2)}\nTiDB:\t\t\t${mapStringNestedList(r3)}"
         )

--- a/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
@@ -121,8 +121,8 @@ class IssueTestSuite extends BaseTiSparkSuite {
         |group by
         |   l_partkey""".stripMargin
     // Should not throw any exception
-    runTest(q1)
-    runTest(q2)
+    runTest(q1, skipTiDB = true)
+    runTest(q2, skipTiDB = true)
   }
 
   // https://github.com/pingcap/tispark/issues/162

--- a/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
@@ -121,8 +121,8 @@ class IssueTestSuite extends BaseTiSparkSuite {
         |group by
         |   l_partkey""".stripMargin
     // Should not throw any exception
-    runTest(q1, q1.replace("full_data_type_table", "full_data_type_table_j"))
-    runTest(q2, q2.replace("full_data_type_table", "full_data_type_table_j"))
+    runTest(q1)
+    runTest(q2)
   }
 
   // https://github.com/pingcap/tispark/issues/162

--- a/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
@@ -111,19 +111,23 @@ abstract class QueryTest extends PlanTest {
       }
     }
 
-    try {
-      if (!isOrdered) {
-        comp(
-          lhs.sortWith((_1, _2) => _1.mkString("").compare(_2.mkString("")) < 0),
-          rhs.sortWith((_1, _2) => _1.mkString("").compare(_2.mkString("")) < 0)
-        )
-      } else {
-        comp(lhs, rhs)
+    if (lhs != null && rhs != null) {
+      try {
+        if (!isOrdered) {
+          comp(
+            lhs.sortWith((_1, _2) => _1.mkString("").compare(_2.mkString("")) < 0),
+            rhs.sortWith((_1, _2) => _1.mkString("").compare(_2.mkString("")) < 0)
+          )
+        } else {
+          comp(lhs, rhs)
+        }
+      } catch {
+        // TODO:Remove this temporary exception handling
+        //      case _:RuntimeException => false
+        case _: Throwable => false
       }
-    } catch {
-      // TODO:Remove this temporary exception handling
-      //      case _:RuntimeException => false
-      case _: Throwable => false
+    } else {
+      false
     }
   }
 

--- a/core/src/test/scala/org/apache/spark/sql/expression/Aggregate0Suite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/Aggregate0Suite.scala
@@ -52,7 +52,7 @@ class Aggregate0Suite extends BaseTiSparkSuite {
   allCases foreach { query =>
     {
       test(query) {
-        runTest(query, query.replace("full_data_type_table", "full_data_type_table_j"))
+        runTest(query)
       }
     }
   }

--- a/core/src/test/scala/org/apache/spark/sql/expression/ArithmeticAgg0Suite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/ArithmeticAgg0Suite.scala
@@ -110,7 +110,7 @@ class ArithmeticAgg0Suite extends BaseTiSparkSuite {
   allCases foreach { query =>
     {
       test(query) {
-        runTest(query, query.replace("full_data_type_table", "full_data_type_table_j"))
+        runTest(query)
       }
     }
   }

--- a/core/src/test/scala/org/apache/spark/sql/expression/ArithmeticTest0Suite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/ArithmeticTest0Suite.scala
@@ -534,7 +534,7 @@ class ArithmeticTest0Suite extends BaseTiSparkSuite {
   allCases foreach { query =>
     {
       test(query) {
-        runTest(query, query.replace("full_data_type_table", "full_data_type_table_j"))
+        runTest(query)
       }
     }
   }

--- a/core/src/test/scala/org/apache/spark/sql/expression/ArithmeticTest1Suite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/ArithmeticTest1Suite.scala
@@ -211,7 +211,7 @@ class ArithmeticTest1Suite extends BaseTiSparkSuite {
   allCases foreach { query =>
     {
       test(query) {
-        runTest(query, query.replace("full_data_type_table", "full_data_type_table_j"))
+        runTest(query)
       }
     }
   }

--- a/core/src/test/scala/org/apache/spark/sql/expression/ArithmeticTest2Suite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/ArithmeticTest2Suite.scala
@@ -45,7 +45,7 @@ class ArithmeticTest2Suite extends BaseTiSparkSuite {
   allCases foreach { query =>
     {
       test(query) {
-        runTest(query, query.replace("full_data_type_table", "full_data_type_table_j"))
+        runTest(query)
       }
     }
   }

--- a/core/src/test/scala/org/apache/spark/sql/expression/Between0Suite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/Between0Suite.scala
@@ -35,7 +35,7 @@ class Between0Suite extends BaseTiSparkSuite {
   allCases foreach { query =>
     {
       test(query) {
-        runTest(query, query.replace("full_data_type_table", "full_data_type_table_j"))
+        runTest(query)
       }
     }
   }

--- a/core/src/test/scala/org/apache/spark/sql/expression/CartesianTypeTestCases0Suite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/CartesianTypeTestCases0Suite.scala
@@ -439,7 +439,7 @@ class CartesianTypeTestCases0Suite extends BaseTiSparkSuite {
   allCases foreach { query =>
     {
       test(query) {
-        runTest(query, query.replace("full_data_type_table", "full_data_type_table_j"))
+        runTest(query)
       }
     }
   }

--- a/core/src/test/scala/org/apache/spark/sql/expression/CartesianTypeTestCases1Suite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/CartesianTypeTestCases1Suite.scala
@@ -431,7 +431,7 @@ class CartesianTypeTestCases1Suite extends BaseTiSparkSuite {
   allCases foreach { query =>
     {
       test(query) {
-        runTest(query, query.replace("full_data_type_table", "full_data_type_table_j"))
+        runTest(query)
       }
     }
   }

--- a/core/src/test/scala/org/apache/spark/sql/expression/CartesianTypeTestCases2Suite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/CartesianTypeTestCases2Suite.scala
@@ -48,7 +48,7 @@ class CartesianTypeTestCases2Suite extends BaseTiSparkSuite {
   allCases foreach { query =>
     {
       test(query) {
-        runTest(query, query.replace("full_data_type_table", "full_data_type_table_j"))
+        runTest(query)
       }
     }
   }

--- a/core/src/test/scala/org/apache/spark/sql/expression/ComplexAggregateSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/ComplexAggregateSuite.scala
@@ -32,7 +32,7 @@ class ComplexAggregateSuite extends BaseTiSparkSuite {
   allCases.map { _.replace(")", " / tp_int)") } ++ allCases.map { _.replace(")", " / tp_double)") } ++ allCases
     .map { _.replace(")", " + tp_float * 2)") } foreach { query =>
     test(query) {
-      runTest(query, query.replace("full_data_type_table", "full_data_type_table_j"))
+      runTest(query)
     }
   }
 }

--- a/core/src/test/scala/org/apache/spark/sql/expression/ComplexGroupBySuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/ComplexGroupBySuite.scala
@@ -36,7 +36,7 @@ class ComplexGroupBySuite extends BaseTiSparkSuite {
 
   allCases foreach { query =>
     test(query) {
-      runTest(query, query.replace("full_data_type_table", "full_data_type_table_j"))
+      runTest(query)
     }
   }
 }

--- a/core/src/test/scala/org/apache/spark/sql/expression/Count0Suite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/Count0Suite.scala
@@ -51,7 +51,7 @@ class Count0Suite extends BaseTiSparkSuite {
   allCases foreach { query =>
     {
       test(query) {
-        runTest(query, query.replace("full_data_type_table", "full_data_type_table_j"))
+        runTest(query)
       }
     }
   }

--- a/core/src/test/scala/org/apache/spark/sql/expression/Distinct0Suite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/Distinct0Suite.scala
@@ -44,7 +44,7 @@ class Distinct0Suite extends BaseTiSparkSuite {
   allCases foreach { query =>
     {
       test(query) {
-        runTest(query, query.replace("full_data_type_table", "full_data_type_table_j"))
+        runTest(query)
       }
     }
   }

--- a/core/src/test/scala/org/apache/spark/sql/expression/FirstLast0Suite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/FirstLast0Suite.scala
@@ -18,7 +18,6 @@
 package org.apache.spark.sql.expression
 
 import org.apache.spark.sql.BaseTiSparkSuite
-import org.apache.spark.sql.test.SharedSQLContext
 
 class FirstLast0Suite extends BaseTiSparkSuite {
   private val allCases = Seq[String](
@@ -69,7 +68,7 @@ class FirstLast0Suite extends BaseTiSparkSuite {
   allCases foreach { query =>
     {
       test(query) {
-        runTest(query, query.replace("full_data_type_table", "full_data_type_table_j"))
+        runTest(query)
       }
     }
   }

--- a/core/src/test/scala/org/apache/spark/sql/expression/Having0Suite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/Having0Suite.scala
@@ -28,7 +28,7 @@ class Having0Suite extends BaseTiSparkSuite {
   allCases foreach { query =>
     {
       test(query) {
-        runTest(query, query.replace("full_data_type_table", "full_data_type_table_j"))
+        runTest(query)
       }
     }
   }

--- a/core/src/test/scala/org/apache/spark/sql/expression/InTest0Suite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/InTest0Suite.scala
@@ -36,7 +36,7 @@ class InTest0Suite extends BaseTiSparkSuite {
   allCases foreach { query =>
     {
       test(query) {
-        runTest(query, query.replace("full_data_type_table", "full_data_type_table_j"))
+        runTest(query)
       }
     }
   }

--- a/core/src/test/scala/org/apache/spark/sql/expression/LikeTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/LikeTestSuite.scala
@@ -40,16 +40,13 @@ class LikeTestSuite extends BaseTiSparkSuite {
 
   tableScanCases foreach { query =>
     test(query) {
-      explainAndRunTest(query, query.replace("full_data_type_table", "full_data_type_table_j"))
+      explainAndRunTest(query)
     }
   }
 
   indexScanCases foreach { query =>
     test(query) {
-      explainAndRunTest(
-        query,
-        query.replace("full_data_type_table_idx", "full_data_type_table_idx_j")
-      )
+      explainAndRunTest(query)
     }
   }
 }

--- a/core/src/test/scala/org/apache/spark/sql/expression/LogicalAndOr0Suite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/LogicalAndOr0Suite.scala
@@ -382,7 +382,7 @@ class LogicalAndOr0Suite extends BaseTiSparkSuite {
   allCases foreach { query =>
     {
       test(query) {
-        runTest(query, query.replace("full_data_type_table", "full_data_type_table_j"))
+        runTest(query)
       }
     }
   }

--- a/core/src/test/scala/org/apache/spark/sql/expression/OtherTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/OtherTestSuite.scala
@@ -37,7 +37,7 @@ class OtherTestSuite extends BaseTiSparkSuite {
   cases foreach { query =>
     {
       test(query) {
-        runTest(query, query.replace("full_data_type_table", "full_data_type_table_j"))
+        runTest(query)
       }
     }
   }

--- a/core/src/test/scala/org/apache/spark/sql/expression/PlaceHolderTest0Suite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/PlaceHolderTest0Suite.scala
@@ -656,7 +656,7 @@ class PlaceHolderTest0Suite extends BaseTiSparkSuite {
   allCases foreach { query =>
     {
       test(query) {
-        runTest(query, query.replace("full_data_type_table", "full_data_type_table_j"))
+        runTest(query)
       }
     }
   }

--- a/core/src/test/scala/org/apache/spark/sql/expression/PlaceHolderTest1Suite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/PlaceHolderTest1Suite.scala
@@ -636,7 +636,7 @@ class PlaceHolderTest1Suite extends BaseTiSparkSuite {
   allCases foreach { query =>
     {
       test(query) {
-        runTest(query, query.replace("full_data_type_table", "full_data_type_table_j"))
+        runTest(query)
       }
     }
   }

--- a/core/src/test/scala/org/apache/spark/sql/expression/PlaceHolderTest2Suite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/PlaceHolderTest2Suite.scala
@@ -656,7 +656,7 @@ class PlaceHolderTest2Suite extends BaseTiSparkSuite {
   allCases foreach { query =>
     {
       test(query) {
-        runTest(query, query.replace("full_data_type_table", "full_data_type_table_j"))
+        runTest(query)
       }
     }
   }

--- a/core/src/test/scala/org/apache/spark/sql/expression/PlaceHolderTest3Suite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/PlaceHolderTest3Suite.scala
@@ -214,7 +214,7 @@ class PlaceHolderTest3Suite extends BaseTiSparkSuite {
   allCases foreach { query =>
     {
       test(query) {
-        runTest(query, query.replace("full_data_type_table", "full_data_type_table_j"))
+        runTest(query)
       }
     }
   }

--- a/core/src/test/scala/org/apache/spark/sql/expression/SimpleSelect0Suite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/SimpleSelect0Suite.scala
@@ -48,7 +48,7 @@ class SimpleSelect0Suite extends BaseTiSparkSuite {
   allCases foreach { query =>
     {
       test(query) {
-        runTest(query, query.replace("full_data_type_table", "full_data_type_table_j"))
+        runTest(query)
       }
     }
   }

--- a/core/src/test/scala/org/apache/spark/sql/expression/Union0Suite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/Union0Suite.scala
@@ -36,7 +36,7 @@ class Union0Suite extends BaseTiSparkSuite {
   allCases foreach { query =>
     {
       test(query) {
-        runTest(query, query.replace("full_data_type_table", "full_data_type_table_j"))
+        runTest(query)
       }
     }
   }

--- a/core/src/test/scala/org/apache/spark/sql/expression/index/Aggregate0Suite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/index/Aggregate0Suite.scala
@@ -42,7 +42,7 @@ class Aggregate0Suite extends BaseTiSparkSuite {
   allCases foreach { query =>
     {
       test(query) {
-        runTest(query, query.replace("full_data_type_table_idx", "full_data_type_table_idx_j"))
+        runTest(query)
       }
     }
   }

--- a/core/src/test/scala/org/apache/spark/sql/expression/index/Between0Suite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/index/Between0Suite.scala
@@ -38,7 +38,7 @@ class Between0Suite extends BaseTiSparkSuite {
         if (query.equals(
               "select tp_real from full_data_type_table_idx  where tp_real between 4.44 and 0.5194052764001038 order by id_dt"
             )) cancel("This case is pending to be solved in other PRs")
-        runTest(query, query.replace("full_data_type_table_idx", "full_data_type_table_idx_j"))
+        runTest(query)
       }
     }
   }

--- a/core/src/test/scala/org/apache/spark/sql/expression/index/ComprehensiveSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/index/ComprehensiveSuite.scala
@@ -53,7 +53,7 @@ class ComprehensiveSuite extends BaseTiSparkSuite {
 
   allCases foreach { query =>
     test(query) {
-      runTest(query, query.replace("full_data_type_table_idx", "full_data_type_table_idx_j"))
+      runTest(query)
     }
   }
 }

--- a/core/src/test/scala/org/apache/spark/sql/expression/index/CoveringIndex0Suite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/index/CoveringIndex0Suite.scala
@@ -495,7 +495,7 @@ class CoveringIndex0Suite extends BaseTiSparkSuite {
   allCases foreach { query =>
     {
       test(query) {
-        runTest(query, query.replace("full_data_type_table_idx", "full_data_type_table_idx_j"))
+        runTest(query)
       }
     }
   }

--- a/core/src/test/scala/org/apache/spark/sql/expression/index/InTest0Suite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/index/InTest0Suite.scala
@@ -36,7 +36,7 @@ class InTest0Suite extends BaseTiSparkSuite {
   allCases foreach { query =>
     {
       test(query) {
-        runTest(query, query.replace("full_data_type_table_idx", "full_data_type_table_idx_j"))
+        runTest(query)
       }
     }
   }

--- a/core/src/test/scala/org/apache/spark/sql/expression/index/Join0Suite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/index/Join0Suite.scala
@@ -39,7 +39,7 @@ class Join0Suite extends BaseTiSparkSuite {
   allCases foreach { query =>
     {
       test(query) {
-        runTest(query, query.replace("full_data_type_table_idx", "full_data_type_table_idx_j"))
+        runTest(query)
       }
     }
   }

--- a/core/src/test/scala/org/apache/spark/sql/expression/index/PlaceHolder0Suite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/index/PlaceHolder0Suite.scala
@@ -527,7 +527,7 @@ class PlaceHolder0Suite extends BaseTiSparkSuite {
   allCases foreach { query =>
     {
       test(query) {
-        runTest(query, query.replace("full_data_type_table_idx", "full_data_type_table_idx_j"))
+        runTest(query)
       }
     }
   }

--- a/core/src/test/scala/org/apache/spark/sql/expression/index/PlaceHolder1Suite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/index/PlaceHolder1Suite.scala
@@ -517,7 +517,7 @@ class PlaceHolder1Suite extends BaseTiSparkSuite {
   allCases foreach { query =>
     {
       test(query) {
-        runTest(query, query.replace("full_data_type_table_idx", "full_data_type_table_idx_j"))
+        runTest(query)
       }
     }
   }

--- a/core/src/test/scala/org/apache/spark/sql/expression/index/PlaceHolder2Suite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/index/PlaceHolder2Suite.scala
@@ -211,7 +211,7 @@ class PlaceHolder2Suite extends BaseTiSparkSuite {
   allCases foreach { query =>
     {
       test(query) {
-        runTest(query, query.replace("full_data_type_table_idx", "full_data_type_table_idx_j"))
+        runTest(query)
       }
     }
   }

--- a/core/src/test/scala/org/apache/spark/sql/expression/index/Special0Suite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/index/Special0Suite.scala
@@ -82,7 +82,7 @@ class Special0Suite extends BaseTiSparkSuite {
   allCases foreach { query =>
     {
       test(query) {
-        runTest(query, query.replace("full_data_type_table_idx", "full_data_type_table_idx_j"))
+        runTest(query)
       }
     }
   }

--- a/core/src/test/scala/org/apache/spark/sql/expression/index/UnsignedTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/index/UnsignedTestSuite.scala
@@ -19,7 +19,7 @@ import org.apache.spark.sql.BaseTiSparkSuite
 
 class UnsignedTestSuite extends BaseTiSparkSuite {
 
-  test("Unsigned Index Tests") {
+  test("Unsigned Index Tests for TISPARK-28 and TISPARK-29") {
     tidbStmt.execute("DROP TABLE IF EXISTS `unsigned_test`")
     tidbStmt.execute(
       """CREATE TABLE `unsigned_test` (
@@ -35,8 +35,30 @@ class UnsignedTestSuite extends BaseTiSparkSuite {
     )
     tidbStmt.execute("ANALYZE TABLE `unsigned_test`")
     refreshConnections()
-    explainAndRunTest("select * from unsigned_test where c2 < -1", skipTiDB = true, skipped = true)
-    explainAndRunTest("select c2 from unsigned_test where c2 < -1", skipTiDB = true, skipped = true)
+    // TODO: After we fixed unsigned behavior, delete `skipped` setting for this test
+    explainAndRunTest(
+      "select * from unsigned_test",
+      rJDBC = List(
+        List(1, 1, 1),
+        List(2, 3, 4),
+        List(3, 5, 7),
+        List(9223372036854775807L, 9223372036854775807L, 0)
+      ),
+      skipTiDB = true,
+      skipped = true
+    )
+    explainAndRunTest(
+      "select * from unsigned_test where c2 < -1",
+      rJDBC = List(List.empty),
+      skipTiDB = true,
+      skipped = true
+    )
+    explainAndRunTest(
+      "select c2 from unsigned_test where c2 < -1",
+      rJDBC = List(List.empty),
+      skipTiDB = true,
+      skipped = true
+    )
   }
 
   override def afterAll(): Unit = {

--- a/core/src/test/scala/org/apache/spark/sql/expression/index/UnsignedTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/index/UnsignedTestSuite.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.expression.index
+
+import org.apache.spark.sql.BaseTiSparkSuite
+
+class UnsignedTestSuite extends BaseTiSparkSuite {
+
+  test("Unsigned Index Tests") {
+    tidbStmt.execute("DROP TABLE IF EXISTS `unsigned_test`")
+    tidbStmt.execute(
+      """CREATE TABLE `unsigned_test` (
+        |  `c1` bigint(20) UNSIGNED NOT NULL,
+        |  `c2` bigint(20) UNSIGNED DEFAULT NULL,
+        |  `c3` bigint(20) DEFAULT NULL,
+        |  PRIMARY KEY (`c1`),
+        |  KEY `idx_c2` (`c2`)
+        |) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin""".stripMargin
+    )
+    tidbStmt.execute(
+      "insert into `unsigned_test` values(1,1,1),(2,3,4),(3,5,7),(9223372036854775807,9223372036854775807,0)"
+    )
+    tidbStmt.execute("ANALYZE TABLE `unsigned_test`")
+    refreshConnections()
+    explainAndRunTest("select * from unsigned_test where c2 < -1", skipTiDB = true, skipped = true)
+    explainAndRunTest("select c2 from unsigned_test where c2 < -1", skipTiDB = true, skipped = true)
+  }
+
+  override def afterAll(): Unit = {
+    try {
+      tidbStmt.execute("drop table if exists `unsigned_test`")
+    } finally {
+      super.afterAll()
+    }
+  }
+}


### PR DESCRIPTION
Given the fact that TiDB is also incorrect on this issue, This PR also modifies the test framework to compare our result with pre-calculated answers rather than TiDB/Spark-JDBC output.