### PR TITLE
Fix leak session

### DIFF
--- a/core/src/main/scala/com/pingcap/tispark/TiSessionCache.scala
+++ b/core/src/main/scala/com/pingcap/tispark/TiSessionCache.scala
@@ -15,22 +15,19 @@
 
 package com.pingcap.tispark
 
-import java.util.HashMap
-
 import com.pingcap.tikv.{TiConfiguration, TiSession}
-import com.pingcap.tispark.listener.CacheInvalidateListener
 
 object TiSessionCache {
-  private val sessionCache: HashMap[String, TiSession] = new HashMap[String, TiSession]()
+  private var sessionCached: TiSession = null
 
-  def getSession(appId: String, conf: TiConfiguration): TiSession = this.synchronized {
-    val session = sessionCache.get(appId)
-    if (session == null) {
-      val newSession = TiSession.create(conf)
-      sessionCache.put(appId, newSession)
-      newSession
+  // Since we create session as singleton now, configuration change will not
+  // reflect change
+  def getSession(conf: TiConfiguration): TiSession = this.synchronized {
+    if (sessionCached == null) {
+      sessionCached = TiSession.create(conf)
+      sessionCached
     } else {
-      session
+      sessionCached
     }
   }
 }

--- a/core/src/main/scala/com/pingcap/tispark/statistics/StatisticsHelper.scala
+++ b/core/src/main/scala/com/pingcap/tispark/statistics/StatisticsHelper.scala
@@ -93,8 +93,8 @@ object StatisticsHelper {
       indexFlag = 0
       dataType = colInfos.head.getType
     } else if (!isIndex || indexInfos.isEmpty) {
-      logger.error(
-        s"We cannot find histogram id $histID in table info ${table.getName} now. It may be deleted."
+      logger.warn(
+        s"Cannot find histogram id $histID in table info ${table.getName} now. It may be deleted."
       )
       needed = false
     }

--- a/core/src/main/scala/org/apache/spark/sql/execution/CoprocessorRDD.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/CoprocessorRDD.scala
@@ -161,7 +161,6 @@ case class RegionTaskExec(child: SparkPlan,
   )
 
   private val sqlConf = sqlContext.conf
-  private val appId = SparkContext.getOrCreate().appName
   private val downgradeThreshold =
     sqlConf.getConfString(TiConfigConst.REGION_INDEX_SCAN_DOWNGRADE_THRESHOLD, "10000").toInt
   private lazy val project = UnsafeProjection.create(schema)

--- a/core/src/main/scala/org/apache/spark/sql/execution/CoprocessorRDD.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/CoprocessorRDD.scala
@@ -206,7 +206,7 @@ case class RegionTaskExec(child: SparkPlan,
         // For each partition, we do some initialization work
         val logger = Logger.getLogger(getClass.getName)
         logger.info(s"In partition No.$index")
-        val session = TiSessionCache.getSession(appId, tiConf)
+        val session = TiSessionCache.getSession(tiConf)
         session.injectCallBackFunc(callBackFunc)
         val batchSize = tiConf.getIndexScanBatchSize
 

--- a/core/src/main/scala/org/apache/spark/sql/tispark/TiHandleRDD.scala
+++ b/core/src/main/scala/org/apache/spark/sql/tispark/TiHandleRDD.scala
@@ -51,7 +51,7 @@ class TiHandleRDD(val dagRequest: TiDAGRequest,
     new Iterator[Row] {
       dagRequest.resolve()
       private val tiPartition = split.asInstanceOf[TiPartition]
-      private val session = TiSessionCache.getSession(tiPartition.appId, tiConf)
+      private val session = TiSessionCache.getSession(tiConf)
       private val snapshot = session.createSnapshot(ts)
       private[this] val tasks = tiPartition.tasks
 

--- a/core/src/main/scala/org/apache/spark/sql/tispark/TiRDD.scala
+++ b/core/src/main/scala/org/apache/spark/sql/tispark/TiRDD.scala
@@ -60,7 +60,7 @@ class TiRDD(val dagRequest: TiDAGRequest,
 
     // bypass, sum return a long type
     private val tiPartition = split.asInstanceOf[TiPartition]
-    private val session = TiSessionCache.getSession(tiPartition.appId, tiConf)
+    private val session = TiSessionCache.getSession(tiConf)
     session.injectCallBackFunc(callBackFunc)
     private val snapshot = session.createSnapshot(ts)
     private[this] val tasks = tiPartition.tasks


### PR DESCRIPTION
Previously session is cached and recreate per query. But it does not have a proper way to cache out. Now delete this cache completely but some conf change might not be able propagate to query execution now. It's ok for user perspective just with a little inconvenience.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tispark/331)
<!-- Reviewable:end -->
