### PR TITLE
Fix TopN validation

### DIFF
--- a/tikv-client/src/main/java/com/pingcap/tikv/meta/TiDAGRequest.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/meta/TiDAGRequest.java
@@ -454,12 +454,6 @@ public class TiDAGRequest implements Serializable {
           EXEC_TYPE_PRIORITY_MAP.get(formerType)) {
         throw new DAGRequestException("Invalid executor priority.");
       }
-      if (currentType.equals(ExecType.TypeTopN)) {
-        long limit = dagRequest.getExecutors(i).getTopN().getLimit();
-        if (limit == 0) {
-          throw new DAGRequestException("TopN executor should contain non-zero limit number but received:" + limit);
-        }
-      }
       formerType = currentType;
     }
   }

--- a/tikv-client/src/test/java/com/pingcap/tikv/meta/TiDAGRequestTest.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/meta/TiDAGRequestTest.java
@@ -52,6 +52,19 @@ public class TiDAGRequestTest {
   }
 
   @Test
+  public void testTopNCouldPushDownLimit0() {
+    TiTableInfo table = createTable();
+    TiDAGRequest dagRequest = new TiDAGRequest(TiDAGRequest.PushDownType.NORMAL);
+    ColumnRef col1 = ColumnRef.create("c1", table);
+    dagRequest.addOrderByItem(ByItem.create(col1, false));
+    dagRequest.addRequiredColumn(col1);
+    dagRequest.setLimit(0);
+    dagRequest.setTableInfo(table);
+    dagRequest.setStartTs(1);
+    dagRequest.buildScan(false);
+  }
+
+  @Test
   public void testSerializable() throws Exception {
     TiTableInfo table = createTable();
     TiDAGRequest selReq = new TiDAGRequest(TiDAGRequest.PushDownType.NORMAL);


### PR DESCRIPTION
Seems current TiKV allows TopN with limit 0, remove this constrain check.