### PR TITLE
[TISPARK-36] Improve test logic

### DIFF
--- a/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
@@ -34,7 +34,13 @@ class IssueTestSuite extends BaseTiSparkSuite {
     )
     refreshConnections()
 
-    judge("select a, max(b) from t group by a limit 2")
+    assert(
+      try {
+        judge("select a, max(b) from t group by a limit 2")
+        false
+      } catch {
+        case _: Throwable => true
+      })
   }
 
   test("Test index task downgrade") {

--- a/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
@@ -20,6 +20,23 @@ import org.apache.spark.sql.functions.{col, sum}
 
 class IssueTestSuite extends BaseTiSparkSuite {
 
+  test("Test sql with limit without order by") {
+    tidbStmt.execute("DROP TABLE IF EXISTS `t`")
+    tidbStmt.execute(
+      """CREATE TABLE `t` (
+        |  `a` int(11) DEFAULT NULL,
+        |  `b` decimal(15,2) DEFAULT NULL
+        |) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin
+      """.stripMargin
+    )
+    tidbStmt.execute(
+      "insert into t values(1,771.64),(2,378.49),(3,920.92),(4,113.97)"
+    )
+    refreshConnections()
+
+    judge("select a, max(b) from t group by a limit 2")
+  }
+
   test("Test index task downgrade") {
     val sqlConf = ti.session.sqlContext.conf
     val prevRegionIndexScanDowngradeThreshold =

--- a/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
@@ -35,6 +35,20 @@ abstract class QueryTest extends PlanTest {
 
   private val eps = 1.0e-2
 
+  protected def compSqlResult(sql: String, lhs: List[List[Any]], rhs: List[List[Any]]): Boolean = {
+    val isOrdered = sql.contains(" order by ")
+    val isLimited = sql.contains(" limit ")
+
+    if (!isOrdered && isLimited) {
+      logger.warn(
+        s"Unknown correctness of test result: sql contains \'limit\' but not \'order by\'."
+      )
+      true
+    } else {
+      compResult(lhs, rhs, isOrdered)
+    }
+  }
+
   /**
    * Compare whether lhs equals to rhs
    *

--- a/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
@@ -132,8 +132,10 @@ abstract class QueryTest extends PlanTest {
             lhs.sortWith((_1, _2) => _1.mkString("").compare(_2.mkString("")) < 0),
             rhs.sortWith((_1, _2) => _1.mkString("").compare(_2.mkString("")) < 0)
           )
-        } else {
+        } else if (lhs.length == rhs.length) {
           comp(lhs, rhs)
+        } else {
+          false
         }
       } catch {
         // TODO:Remove this temporary exception handling

--- a/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
@@ -43,7 +43,7 @@ abstract class QueryTest extends PlanTest {
       logger.warn(
         s"Unknown correctness of test result: sql contains \'limit\' but not \'order by\'."
       )
-      true
+      false
     } else {
       compResult(lhs, rhs, isOrdered)
     }


### PR DESCRIPTION
TestSuite cannot handle tests with limit but without orderBy, e.g., select * from t limit 20.

If sql contains limit but not orderBy, the test result should be undefined.