### PR TITLE
[TISPARK-38] Fix count(1) result is always 0 if subquery contains limit

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/TiStrategy.scala
+++ b/core/src/main/scala/org/apache/spark/sql/TiStrategy.scala
@@ -353,6 +353,7 @@ class TiStrategy(context: SQLContext) extends Strategy with Logging {
     filterToDAGRequest(tiColumns, pushdownFilters, source, dagRequest)
 
     if (tiColumns.isEmpty) {
+      // if tiColumns is empty, add a random column so that the plan will contain at least one column.
       val column = source.table.getColumn(0)
       dagRequest.addRequiredColumn(ColumnRef.create(column.getName))
     }

--- a/core/src/main/scala/org/apache/spark/sql/TiStrategy.scala
+++ b/core/src/main/scala/org/apache/spark/sql/TiStrategy.scala
@@ -352,6 +352,11 @@ class TiStrategy(context: SQLContext) extends Strategy with Logging {
 
     filterToDAGRequest(tiColumns, pushdownFilters, source, dagRequest)
 
+    if (tiColumns.isEmpty) {
+      val column = source.table.getColumn(0)
+      dagRequest.addRequiredColumn(ColumnRef.create(column.getName))
+    }
+
     // Right now we still use a projection even if the only evaluation is applying an alias
     // to a column.  Since this is a no-op, it could be avoided. However, using this
     // optimization with the current implementation would change the output schema.

--- a/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
@@ -35,11 +35,14 @@ abstract class QueryTest extends PlanTest {
 
   private val eps = 1.0e-2
 
-  protected def compSqlResult(sql: String, lhs: List[List[Any]], rhs: List[List[Any]]): Boolean = {
+  protected def compSqlResult(sql: String,
+                              lhs: List[List[Any]],
+                              rhs: List[List[Any]],
+                              checkLimit: Boolean = true): Boolean = {
     val isOrdered = sql.contains(" order by ")
     val isLimited = sql.contains(" limit ")
 
-    if (!isOrdered && isLimited) {
+    if (checkLimit && !isOrdered && isLimited) {
       logger.warn(
         s"Unknown correctness of test result: sql contains \'limit\' but not \'order by\'."
       )


### PR DESCRIPTION
If subquery contains limit and we select count(1) from outer query, required columns will be empty so we cannot fetch correct answer of count(1). Fix by adding a dummy column to DAGRequest.