### PR TITLE
Improve tidbMapTable logic

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/TiContext.scala
+++ b/core/src/main/scala/org/apache/spark/sql/TiContext.scala
@@ -138,7 +138,7 @@ class TiContext(val session: SparkSession) extends Serializable with Logging {
       meta
     )(sqlContext)
     val df = sqlContext.baseRelationToDataFrame(tiRelation)
-    df.createTempView(tableName)
+    df.createOrReplaceTempView(tableName)
     df
   }
 


### PR DESCRIPTION
Since some users might want to run the spark job repeatedly, it is not appropriate to use createTempView for `tidbMapTable` logic