### PR TITLE
[TISPARK-43] Fix request fail with Key not in region after retrying NotLeaderError

### DIFF
--- a/tikv-client/src/main/java/com/pingcap/tikv/region/RegionStoreClient.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/region/RegionStoreClient.java
@@ -372,8 +372,7 @@ public class RegionStoreClient extends AbstractGRPCClient<TikvBlockingStub, Tikv
   public void onNotLeader(TiRegion newRegion, Store newStore) {
     String addressStr = newStore.getAddress();
     ManagedChannel channel = getSession().getChannel(addressStr);
-    region = newRegion;
-    if (!region.switchPeer(newStore.getId())) {
+    if (!newRegion.switchPeer(newStore.getId())) {
       throw new TiClientInternalException("Failed to switch leader");
     }
     blockingStub = TikvGrpc.newBlockingStub(channel);

--- a/tikv-client/src/main/java/com/pingcap/tikv/region/RegionStoreClient.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/region/RegionStoreClient.java
@@ -388,7 +388,5 @@ public class RegionStoreClient extends AbstractGRPCClient<TikvBlockingStub, Tikv
     ManagedChannel channel = getSession().getChannel(addressStr);
     blockingStub = TikvGrpc.newBlockingStub(channel);
     asyncStub = TikvGrpc.newStub(channel);
-    region = regionStorePair.first;
-    region.switchPeer(store.getId());
   }
 }


### PR DESCRIPTION
Should not update region context when error is not leader