### PR TITLE
[DNM] [TISPARK-44] Sleep a while in Statistics Test to fetch correct analyze result

### DIFF
--- a/core/src/main/scala/com/pingcap/tispark/statistics/StatisticsManager.scala
+++ b/core/src/main/scala/com/pingcap/tispark/statistics/StatisticsManager.scala
@@ -151,9 +151,11 @@ class StatisticsManager(tiSession: TiSession) {
       .buildHistogramsRequest(histTable, tblId, snapshot.getTimestamp.getVersion)
 
     val rows = readDAGRequest(req)
-    if (rows.isEmpty) return
+    val (rows1, rows2) = rows.duplicate
+    println("stats read with " + rows2.length + " rows")
+    if (rows1.isEmpty) return
 
-    val requests = rows
+    val requests = rows1
       .map { StatisticsHelper.extractStatisticsDTO(_, table, loadAll, neededColIds, histTable) }
       .filter { _ != null }
     val results = statisticsResultFromStorage(tblId, requests.toSeq)

--- a/core/src/test/scala/org/apache/spark/sql/statistics/StatisticsManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/statistics/StatisticsManagerSuite.scala
@@ -136,6 +136,11 @@ class StatisticsManagerSuite extends BaseTiSparkSuite {
     val tblStatistics = StatisticsManager.getInstance().getTableStatistics(fDataIdxTbl.getId)
     val idxStatistics = tblStatistics.getIndexHistMap.get(idx.getId)
     val rc = idxStatistics.getRowCount(irs).toLong
+    println((
+      idxStatistics.getHistogram.getId,
+      idxStatistics.getHistogram.getNullCount,
+      idxStatistics.getHistogram.getBuckets.length,
+      idxStatistics.getHistogram.getNumberOfDistinctValue))
     assert(rc == expectedCount)
   }
 

--- a/core/src/test/scala/org/apache/spark/sql/statistics/StatisticsManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/statistics/StatisticsManagerSuite.scala
@@ -136,11 +136,14 @@ class StatisticsManagerSuite extends BaseTiSparkSuite {
     val tblStatistics = StatisticsManager.getInstance().getTableStatistics(fDataIdxTbl.getId)
     val idxStatistics = tblStatistics.getIndexHistMap.get(idx.getId)
     val rc = idxStatistics.getRowCount(irs).toLong
-    println((
-      idxStatistics.getHistogram.getId,
-      idxStatistics.getHistogram.getNullCount,
-      idxStatistics.getHistogram.getBuckets.length,
-      idxStatistics.getHistogram.getNumberOfDistinctValue))
+    println(
+      (
+        idxStatistics.getHistogram.getId,
+        idxStatistics.getHistogram.getNullCount,
+        idxStatistics.getHistogram.getBuckets.length,
+        idxStatistics.getHistogram.getNumberOfDistinctValue
+      )
+    )
     assert(rc == expectedCount)
   }
 

--- a/core/src/test/scala/org/apache/spark/sql/statistics/StatisticsManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/statistics/StatisticsManagerSuite.scala
@@ -163,6 +163,7 @@ class StatisticsManagerSuite extends BaseTiSparkSuite {
           extractUsedIndex(coprocessorRDD)
         }
       }
+      println("index selection result: " + (usedIdxName, idxName))
       assert(usedIdxName.equals(idxName))
     }
   })

--- a/core/src/test/scala/org/apache/spark/sql/test/SharedSQLContext.scala
+++ b/core/src/test/scala/org/apache/spark/sql/test/SharedSQLContext.scala
@@ -118,7 +118,7 @@ object SharedSQLContext extends Logging {
   protected var _sparkSession: SparkSession = _
 
   def refreshConnections(): Unit = {
-    Thread.sleep(6000)
+//    Thread.sleep(6000)
     stop()
     init(true)
   }

--- a/core/src/test/scala/org/apache/spark/sql/test/SharedSQLContext.scala
+++ b/core/src/test/scala/org/apache/spark/sql/test/SharedSQLContext.scala
@@ -118,7 +118,7 @@ object SharedSQLContext extends Logging {
   protected var _sparkSession: SparkSession = _
 
   def refreshConnections(): Unit = {
-//    Thread.sleep(6000)
+    Thread.sleep(3000)
     stop()
     init(true)
   }

--- a/core/src/test/scala/org/apache/spark/sql/test/SharedSQLContext.scala
+++ b/core/src/test/scala/org/apache/spark/sql/test/SharedSQLContext.scala
@@ -118,6 +118,7 @@ object SharedSQLContext extends Logging {
   protected var _sparkSession: SparkSession = _
 
   def refreshConnections(): Unit = {
+    Thread.sleep(3000)
     stop()
     init(true)
   }

--- a/core/src/test/scala/org/apache/spark/sql/test/SharedSQLContext.scala
+++ b/core/src/test/scala/org/apache/spark/sql/test/SharedSQLContext.scala
@@ -118,7 +118,7 @@ object SharedSQLContext extends Logging {
   protected var _sparkSession: SparkSession = _
 
   def refreshConnections(): Unit = {
-    Thread.sleep(3000)
+    Thread.sleep(6000)
     stop()
     init(true)
   }

--- a/tikv-client/src/main/java/com/pingcap/tikv/predicates/ScanAnalyzer.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/predicates/ScanAnalyzer.java
@@ -105,7 +105,10 @@ public class ScanAnalyzer {
     double minCost = minPlan.getCost();
     for (TiIndexInfo index : table.getIndices()) {
       ScanPlan plan = buildScan(columnList, conditions, index, table, tableStatistics);
-      if (plan.getCost() < minCost) {
+      if (plan.getIndex() != null && plan.getIndex().getName().equalsIgnoreCase("idx_tp_int")) {
+        System.out.println("idx_tp_int cost = " + plan.getCost());
+      }
+      if (plan.getCost() + 1.0e-8 < minCost) {
         minPlan = plan;
         minCost = plan.getCost();
       }

--- a/tikv-client/src/main/java/com/pingcap/tikv/predicates/ScanAnalyzer.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/predicates/ScanAnalyzer.java
@@ -158,7 +158,7 @@ public class ScanAnalyzer {
           cost = 100.0 * idxRangeRowCnt / totalRowCount;
           estimatedRowCount = idxRangeRowCnt;
           if (index.getName().equalsIgnoreCase("idx_tp_int")) {
-            System.out.println("Estimate row count = " + estimatedRowCount);
+            System.out.println("Estimate row count = " + estimatedRowCount + ", total row count = " + totalRowCount + " base cost = " + cost);
           }
         } else {
           if (index.getName().equalsIgnoreCase("idx_tp_int")) {

--- a/tikv-client/src/main/java/com/pingcap/tikv/predicates/ScanAnalyzer.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/predicates/ScanAnalyzer.java
@@ -110,6 +110,7 @@ public class ScanAnalyzer {
         minCost = plan.getCost();
       }
     }
+    System.out.println(minCost + ": " + minPlan.getIndex().getName());
     return minPlan;
   }
 

--- a/tikv-client/src/main/java/com/pingcap/tikv/predicates/ScanAnalyzer.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/predicates/ScanAnalyzer.java
@@ -161,6 +161,8 @@ public class ScanAnalyzer {
           cost = 100.0 * idxRangeRowCnt / totalRowCount;
           estimatedRowCount = idxRangeRowCnt;
         }
+      } else {
+        System.out.println("No tableStatistics found for index " + index.getName());
       }
       isDoubleRead = !isCoveringIndex(columnList, index, table.isPkHandle());
       // table name, index and handle column

--- a/tikv-client/src/main/java/com/pingcap/tikv/predicates/ScanAnalyzer.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/predicates/ScanAnalyzer.java
@@ -105,9 +105,6 @@ public class ScanAnalyzer {
     double minCost = minPlan.getCost();
     for (TiIndexInfo index : table.getIndices()) {
       ScanPlan plan = buildScan(columnList, conditions, index, table, tableStatistics);
-      if (plan.getIndex() != null && plan.getIndex().getName().equalsIgnoreCase("idx_tp_int")) {
-        System.out.println("idx_tp_int cost = " + plan.getCost());
-      }
       if (plan.getCost() + 1.0e-8 < minCost) {
         minPlan = plan;
         minCost = plan.getCost();
@@ -160,9 +157,14 @@ public class ScanAnalyzer {
           // guess the percentage of rows hit
           cost = 100.0 * idxRangeRowCnt / totalRowCount;
           estimatedRowCount = idxRangeRowCnt;
+          if (index.getName().equalsIgnoreCase("idx_tp_int")) {
+            System.out.println("Estimate row count = " + estimatedRowCount);
+          }
+        } else {
+          if (index.getName().equalsIgnoreCase("idx_tp_int")) {
+            System.out.println("Impossible: No Index Statistics found");
+          }
         }
-      } else {
-        System.out.println("No tableStatistics found for index " + index.getName());
       }
       isDoubleRead = !isCoveringIndex(columnList, index, table.isPkHandle());
       // table name, index and handle column
@@ -171,6 +173,9 @@ public class ScanAnalyzer {
         cost *= tableSize * DOUBLE_READ_COST_FACTOR + indexSize * INDEX_SCAN_COST_FACTOR;
       } else {
         cost *= indexSize * INDEX_SCAN_COST_FACTOR;
+      }
+      if (index.getName().equalsIgnoreCase("idx_tp_int")) {
+        System.out.println("idx_tp_int cost = " + cost);
       }
       keyRanges = buildIndexScanKeyRange(table, index, irs);
     }

--- a/tikv-client/src/main/java/com/pingcap/tikv/predicates/ScanAnalyzer.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/predicates/ScanAnalyzer.java
@@ -110,7 +110,7 @@ public class ScanAnalyzer {
         minCost = plan.getCost();
       }
     }
-    System.out.println(minCost + ": " + minPlan.getIndex().getName());
+    System.out.println(minCost + ": " + ((minPlan.getIndex() != null) ? minPlan.getIndex().getName() : ""));
     return minPlan;
   }
 


### PR DESCRIPTION
Previously, tests might not be able to get analyze result immediately from TiDB.

The root cause is that TiDB cannot guarantee that statistics information has written to TiKV when analyze statement is completed. 

So after we execute analyze in TiDB, we should sleep for a while to ensure CI has correct result.