### PR TITLE
[TISPARK-45] Fix ScanIterator logic where index may be out of bound

### DIFF
--- a/tikv-client/src/main/java/com/pingcap/tikv/operation/iterator/ScanIterator.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/operation/iterator/ScanIterator.java
@@ -115,8 +115,7 @@ public class ScanIterator implements Iterator<Kvrpcpb.KvPair> {
       if (!loadCache()) {
         endOfRegion = true;
       }
-    }
-    if (!contains(currentCache.get(index).getKey())) {
+    } else if (!contains(currentCache.get(index).getKey())) {
       endOfRegion = true;
       return false;
     }

--- a/tikv-client/src/main/java/com/pingcap/tikv/operation/iterator/ScanIterator.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/operation/iterator/ScanIterator.java
@@ -114,8 +114,10 @@ public class ScanIterator implements Iterator<Kvrpcpb.KvPair> {
     if (cacheDrain()) {
       if (!loadCache()) {
         endOfRegion = true;
+        return false;
       }
-    } else if (!contains(currentCache.get(index).getKey())) {
+    }
+    if (!contains(currentCache.get(index).getKey())) {
       endOfRegion = true;
       return false;
     }


### PR DESCRIPTION
In previous implementation, if `index` is not initialized, `IndexOutOfBoundsException` would be thrown.