### PR TITLE
Allow TiSpark retrieve row id

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Below configurations can be put together with spark-defaults.conf or passed in t
 | spark.tispark.plan.downgrade.index_threshold | 10000 | If index scan ranges on one region exceeds this limit in original request, downgrade this region's request to table scan rather than original planned index scan |
 | spark.tispark.type.unsupported_mysql_types |  "time,enum,set,year,json" | A comma separated list of mysql types TiSpark does not support currently, refer to `Unsupported MySQL Type List` below |
 | spark.tispark.request.timezone.offset |  Local Timezone offset | An integer, represents timezone offset to UTC time(like 28800, GMT+8), this value will be added to requests issued to TiKV |
+| spark.tispark.show_rowid |  Show implicit row Id | If to show implicit row Id if exists |
 
 ## Unsupported MySQL Type List
 

--- a/core/src/main/scala/com/pingcap/tispark/TiConfigConst.scala
+++ b/core/src/main/scala/com/pingcap/tispark/TiConfigConst.scala
@@ -38,4 +38,5 @@ object TiConfigConst {
   val UNSUPPORTED_TYPES: String = "spark.tispark.type.unsupported_mysql_types"
   val ENABLE_AUTO_LOAD_STATISTICS: String = "spark.tispark.statistics.auto_load"
   val CACHE_EXPIRE_AFTER_ACCESS: String = "spark.tispark.statistics.expire_after_access"
+  val SHOW_ROWID: String = "spark.tispark.show_rowid"
 }

--- a/core/src/main/scala/com/pingcap/tispark/TiUtils.scala
+++ b/core/src/main/scala/com/pingcap/tispark/TiUtils.scala
@@ -216,6 +216,10 @@ object TiUtils {
       val priority = CommandPri.valueOf(conf.get(TiConfigConst.REQUEST_COMMAND_PRIORITY))
       tiConf.setCommandPriority(priority)
     }
+
+    if (conf.contains(TiConfigConst.SHOW_ROWID)) {
+      tiConf.setShowRowId(conf.get(TiConfigConst.SHOW_ROWID).toBoolean)
+    }
     tiConf
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/TiContext.scala
+++ b/core/src/main/scala/org/apache/spark/sql/TiContext.scala
@@ -129,15 +129,20 @@ class TiContext(val session: SparkSession) extends Serializable with Logging {
     }
   }
 
-  // tidbMapTable does not do any check any meta information
-  // it just register table for later use
-  def tidbMapTable(dbName: String, tableName: String): DataFrame = {
+  def getDataFrame(dbName: String, tableName: String): DataFrame = {
     val tiRelation = new TiDBRelation(
       tiSession,
       new TiTableReference(dbName, tableName),
       meta
     )(sqlContext)
     val df = sqlContext.baseRelationToDataFrame(tiRelation)
+    df
+  }
+
+  // tidbMapTable does not do any check any meta information
+  // it just register table for later use
+  def tidbMapTable(dbName: String, tableName: String): DataFrame = {
+    val df = getDataFrame(dbName, tableName)
     df.createOrReplaceTempView(tableName)
     df
   }

--- a/core/src/main/scala/org/apache/spark/sql/TiContext.scala
+++ b/core/src/main/scala/org/apache/spark/sql/TiContext.scala
@@ -135,8 +135,7 @@ class TiContext(val session: SparkSession) extends Serializable with Logging {
       new TiTableReference(dbName, tableName),
       meta
     )(sqlContext)
-    val df = sqlContext.baseRelationToDataFrame(tiRelation)
-    df
+    sqlContext.baseRelationToDataFrame(tiRelation)
   }
 
   // tidbMapTable does not do any check any meta information

--- a/tikv-client/pom.xml
+++ b/tikv-client/pom.xml
@@ -21,7 +21,7 @@
         <junit.version>4.12</junit.version>
         <log4j.version>1.2.17</log4j.version>
         <slf4j.version>1.7.16</slf4j.version>
-        <grpc.version>1.12.0</grpc.version>
+        <grpc.version>1.7.0</grpc.version>
         <powermock.version>1.6.6</powermock.version>
         <jackson.version>2.6.6</jackson.version>
         <trove4j.version>3.0.1</trove4j.version>

--- a/tikv-client/src/main/java/com/pingcap/tikv/TiConfiguration.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/TiConfiguration.java
@@ -43,6 +43,7 @@ public class TiConfiguration implements Serializable {
   private static final int DEF_TABLE_SCAN_CONCURRENCY = 512;
   private static final CommandPri DEF_COMMAND_PRIORITY = CommandPri.Low;
   private static final IsolationLevel DEF_ISOLATION_LEVEL = IsolationLevel.RC;
+  private static final boolean DEF_SHOW_ROWID = false;
 
   private int timeout = DEF_TIMEOUT;
   private TimeUnit timeoutUnit = DEF_TIMEOUT_UNIT;
@@ -58,6 +59,7 @@ public class TiConfiguration implements Serializable {
   private CommandPri commandPriority = DEF_COMMAND_PRIORITY;
   private IsolationLevel isolationLevel = DEF_ISOLATION_LEVEL;
   private int maxRequestKeyRangeSize = MAX_REQUEST_KEY_RANGE_SIZE;
+  private boolean showRowId = DEF_SHOW_ROWID;
 
   public static TiConfiguration createDefault(String pdAddrsStr) {
     Objects.requireNonNull(pdAddrsStr, "pdAddrsStr is null");
@@ -196,5 +198,13 @@ public class TiConfiguration implements Serializable {
       throw new IllegalArgumentException("Key range size cannot be less than 1");
     }
     this.maxRequestKeyRangeSize = maxRequestKeyRangeSize;
+  }
+
+  public void setShowRowId(boolean flag) {
+    this.showRowId = flag;
+  }
+
+  public boolean ifShowRowId() {
+    return showRowId;
   }
 }

--- a/tikv-client/src/main/java/com/pingcap/tikv/TiSession.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/TiSession.java
@@ -84,7 +84,9 @@ public class TiSession implements AutoCloseable {
         if (catalog == null) {
           catalog = new Catalog(() -> createSnapshot(),
               conf.getMetaReloadPeriod(),
-              conf.getMetaReloadPeriodUnit());
+              conf.getMetaReloadPeriodUnit(),
+              conf.ifShowRowId()
+          );
         }
         res = catalog;
       }

--- a/tikv-client/src/main/java/com/pingcap/tikv/meta/Collation.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/meta/Collation.java
@@ -27,7 +27,7 @@ public class Collation {
     return code;
   }
 
-  static String translate(int code) {
+  public static String translate(int code) {
     String collation = collationCodeMap.get(code);
     if (collation == null) {
       return "";

--- a/tikv-client/src/main/java/com/pingcap/tikv/meta/TiColumnInfo.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/meta/TiColumnInfo.java
@@ -44,8 +44,9 @@ public class TiColumnInfo implements Serializable {
   private final String defaultValue;
   private final String originDefaultValue;
 
-  public static final TiColumnInfo ROW_ID =
-      new TiColumnInfo(-1, "_tidb_rowid", 0, IntegerType.BIGINT, true);
+  public static TiColumnInfo getRowIdColumn(int offset) {
+    return new TiColumnInfo(-1, "_tidb_rowid", offset, IntegerType.ROW_ID_TYPE, true);
+  }
 
   @VisibleForTesting
   private static final int PK_MASK = 0x2;

--- a/tikv-client/src/main/java/com/pingcap/tikv/meta/TiColumnInfo.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/meta/TiColumnInfo.java
@@ -15,6 +15,8 @@
 
 package com.pingcap.tikv.meta;
 
+import static java.util.Objects.requireNonNull;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -25,12 +27,10 @@ import com.pingcap.tikv.codec.CodecDataOutput;
 import com.pingcap.tikv.types.DataType;
 import com.pingcap.tikv.types.DataType.EncodeType;
 import com.pingcap.tikv.types.DataTypeFactory;
-
+import com.pingcap.tikv.types.IntegerType;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Objects;
-
-import static java.util.Objects.requireNonNull;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class TiColumnInfo implements Serializable {
@@ -43,6 +43,9 @@ public class TiColumnInfo implements Serializable {
   private final boolean isPrimaryKey;
   private final String defaultValue;
   private final String originDefaultValue;
+
+  public static final TiColumnInfo ROW_ID =
+      new TiColumnInfo(-1, "_tidb_rowid", 0, IntegerType.BIGINT, true);
 
   @VisibleForTesting
   private static final int PK_MASK = 0x2;

--- a/tikv-client/src/main/java/com/pingcap/tikv/meta/TiColumnInfo.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/meta/TiColumnInfo.java
@@ -74,6 +74,40 @@ public class TiColumnInfo implements Serializable {
     this.isPrimaryKey = (type.getFlag() & PK_MASK) > 0;
   }
 
+  public TiColumnInfo(
+      long id,
+      String name,
+      int offset,
+      DataType type,
+      SchemaState schemaState,
+      String originalDefaultValue,
+      String defaultValue,
+      String comment) {
+    this.id = id;
+    this.name = requireNonNull(name, "column name is null").toLowerCase();
+    this.offset = offset;
+    this.type = requireNonNull(type, "data type is null");
+    this.schemaState = schemaState;
+    this.comment = comment;
+    this.defaultValue = defaultValue;
+    this.originDefaultValue = originalDefaultValue;
+    this.isPrimaryKey = (type.getFlag() & PK_MASK) > 0;
+  }
+
+  public TiColumnInfo copyWithoutPrimaryKey() {
+    type.setflag(type.getFlag() & (~TiColumnInfo.PK_MASK));
+    return new TiColumnInfo(
+        this.id,
+        this.name,
+        this.offset,
+        this.type,
+        this.schemaState,
+        this.originDefaultValue,
+        this.defaultValue,
+        this.comment
+    );
+  }
+
   @VisibleForTesting
   public TiColumnInfo(long id, String name, int offset, DataType type, boolean isPrimaryKey) {
     this.id = id;

--- a/tikv-client/src/main/java/com/pingcap/tikv/meta/TiTableInfo.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/meta/TiTableInfo.java
@@ -149,7 +149,8 @@ public class TiTableInfo implements Serializable {
   public TiTableInfo copyTableWithRowId() {
     if (!isPkHandle()) {
       ImmutableList.Builder<TiColumnInfo> newColumns = ImmutableList.builder();
-      newColumns.addAll(getColumns());
+      getColumns().stream()
+                  .forEach(col -> newColumns.add(col.copyWithoutPrimaryKey()));
       newColumns.add(TiColumnInfo.getRowIdColumn(getColumns().size()));
       return new TiTableInfo(
           getId(), CIStr.newCIStr(getName()), getCharset(), getCollate(),

--- a/tikv-client/src/main/java/com/pingcap/tikv/meta/TiTableInfo.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/meta/TiTableInfo.java
@@ -147,13 +147,13 @@ public class TiTableInfo implements Serializable {
   }
 
   public TiTableInfo copyTableWithRowId() {
-    if (isPkHandle()) {
+    if (!isPkHandle()) {
       ImmutableList.Builder<TiColumnInfo> newColumns = ImmutableList.builder();
       newColumns.addAll(getColumns());
-      newColumns.add(TiColumnInfo.ROW_ID);
+      newColumns.add(TiColumnInfo.getRowIdColumn(getColumns().size()));
       return new TiTableInfo(
           getId(), CIStr.newCIStr(getName()), getCharset(), getCollate(),
-          isPkHandle(), newColumns.build(), getIndices(),
+          true, newColumns.build(), getIndices(),
           getComment(), getAutoIncId(), getMaxColumnId(),
           getMaxIndexId(), getOldSchemaId());
     } else {

--- a/tikv-client/src/main/java/com/pingcap/tikv/meta/TiTableInfo.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/meta/TiTableInfo.java
@@ -20,7 +20,6 @@ import static java.util.Objects.requireNonNull;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 import com.pingcap.tidb.tipb.TableInfo;
 import com.pingcap.tikv.exception.TiClientInternalException;
@@ -145,6 +144,21 @@ public class TiTableInfo implements Serializable {
       }
     }
     return null;
+  }
+
+  public TiTableInfo copyTableWithRowId() {
+    if (isPkHandle()) {
+      ImmutableList.Builder<TiColumnInfo> newColumns = ImmutableList.builder();
+      newColumns.addAll(getColumns());
+      newColumns.add(TiColumnInfo.ROW_ID);
+      return new TiTableInfo(
+          getId(), CIStr.newCIStr(getName()), getCharset(), getCollate(),
+          isPkHandle(), newColumns.build(), getIndices(),
+          getComment(), getAutoIncId(), getMaxColumnId(),
+          getMaxIndexId(), getOldSchemaId());
+    } else {
+      return this;
+    }
   }
 
   @Override

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/DataType.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/DataType.java
@@ -63,7 +63,7 @@ public abstract class DataType implements Serializable {
   protected final MySQLType tp;
   // Not Encode/Decode flag, this is used to strict mysql type
   // such as not null, timestamp
-  protected int flag;
+  protected final int flag;
   protected final int decimal;
   private final String charset;
   protected final int collation;

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/DataType.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/DataType.java
@@ -15,6 +15,9 @@
 
 package com.pingcap.tikv.types;
 
+import static com.pingcap.tikv.codec.Codec.isNullFlag;
+import static java.util.Objects.requireNonNull;
+
 import com.google.common.collect.ImmutableList;
 import com.pingcap.tidb.tipb.ExprType;
 import com.pingcap.tikv.codec.Codec;
@@ -23,13 +26,9 @@ import com.pingcap.tikv.codec.CodecDataOutput;
 import com.pingcap.tikv.exception.TypeException;
 import com.pingcap.tikv.meta.Collation;
 import com.pingcap.tikv.meta.TiColumnInfo;
-
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.List;
-
-import static com.pingcap.tikv.codec.Codec.isNullFlag;
-import static java.util.Objects.requireNonNull;
 
 /** Base Type for encoding and decoding TiDB row information. */
 public abstract class DataType implements Serializable {
@@ -88,6 +87,16 @@ public abstract class DataType implements Serializable {
     this.decimal = UNSPECIFIED_LEN;
     this.charset = "";
     this.collation = Collation.DEF_COLLATION_CODE;
+  }
+
+  protected DataType(MySQLType type, int flag, int len, int decimal, String charset, int collation) {
+    this.tp = type;
+    this.flag = flag;
+    this.elems = ImmutableList.of();
+    this.length = len;
+    this.decimal = decimal;
+    this.charset = charset;
+    this.collation = collation;
   }
 
   protected abstract Object decodeNotNull(int flag, CodecDataInput cdi);

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/DataType.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/DataType.java
@@ -26,6 +26,7 @@ import com.pingcap.tikv.codec.CodecDataOutput;
 import com.pingcap.tikv.exception.TypeException;
 import com.pingcap.tikv.meta.Collation;
 import com.pingcap.tikv.meta.TiColumnInfo;
+import com.pingcap.tikv.meta.TiColumnInfo.InternalTypeHolder;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.List;
@@ -34,21 +35,21 @@ import java.util.List;
 public abstract class DataType implements Serializable {
 
   // Flag Information for strict mysql type
-  protected static final int NotNullFlag = 1; /* Field can't be NULL */
-  protected static final int PriKeyFlag = 2; /* Field is part of a primary key */
-  protected static final int UniqueKeyFlag = 4; /* Field is part of a unique key */
-  protected static final int MultipleKeyFlag = 8; /* Field is part of a key */
-  protected static final int BlobFlag = 16; /* Field is a blob */
-  protected static final int UnsignedFlag = 32; /* Field is unsigned */
-  protected static final int ZerofillFlag = 64; /* Field is zerofill */
-  protected static final int BinaryFlag = 128; /* Field is binary   */
-  protected static final int EnumFlag = 256; /* Field is an enum */
-  protected static final int AutoIncrementFlag = 512; /* Field is an auto increment field */
-  protected static final int TimestampFlag = 1024; /* Field is a timestamp */
-  protected static final int SetFlag = 2048; /* Field is a set */
-  protected static final int NoDefaultValueFlag = 4096; /* Field doesn't have a default value */
-  protected static final int OnUpdateNowFlag = 8192; /* Field is set to NOW on UPDATE */
-  protected static final int NumFlag = 32768; /* Field is a num (for clients) */
+  public static final int NotNullFlag = 1; /* Field can't be NULL */
+  public static final int PriKeyFlag = 2; /* Field is part of a primary key */
+  public static final int UniqueKeyFlag = 4; /* Field is part of a unique key */
+  public static final int MultipleKeyFlag = 8; /* Field is part of a key */
+  public static final int BlobFlag = 16; /* Field is a blob */
+  public static final int UnsignedFlag = 32; /* Field is unsigned */
+  public static final int ZerofillFlag = 64; /* Field is zerofill */
+  public static final int BinaryFlag = 128; /* Field is binary   */
+  public static final int EnumFlag = 256; /* Field is an enum */
+  public static final int AutoIncrementFlag = 512; /* Field is an auto increment field */
+  public static final int TimestampFlag = 1024; /* Field is a timestamp */
+  public static final int SetFlag = 2048; /* Field is a set */
+  public static final int NoDefaultValueFlag = 4096; /* Field doesn't have a default value */
+  public static final int OnUpdateNowFlag = 8192; /* Field is set to NOW on UPDATE */
+  public static final int NumFlag = 32768; /* Field is a num (for clients) */
 
   public enum EncodeType {
     KEY,
@@ -97,11 +98,6 @@ public abstract class DataType implements Serializable {
     this.decimal = decimal;
     this.charset = charset;
     this.collation = collation;
-  }
-
-  // TODO: need a better design
-  public void setflag(int flag) {
-    this.flag = flag;
   }
 
   protected abstract Object decodeNotNull(int flag, CodecDataInput cdi);
@@ -336,5 +332,12 @@ public abstract class DataType implements Serializable {
             * (collation == 0 ? 1 : collation)
             * (length == 0 ? 1 : length)
             * (elems.hashCode()));
+  }
+
+  public InternalTypeHolder toTypeHolder() {
+    return new InternalTypeHolder(
+        getTypeCode(), flag, length, decimal,
+        charset, "", "", Collation.translate(collation), elems
+    );
   }
 }

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/DataType.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/DataType.java
@@ -62,7 +62,7 @@ public abstract class DataType implements Serializable {
   protected final MySQLType tp;
   // Not Encode/Decode flag, this is used to strict mysql type
   // such as not null, timestamp
-  protected final int flag;
+  protected int flag;
   protected final int decimal;
   private final String charset;
   protected final int collation;
@@ -97,6 +97,11 @@ public abstract class DataType implements Serializable {
     this.decimal = decimal;
     this.charset = charset;
     this.collation = collation;
+  }
+
+  // TODO: need a better design
+  public void setflag(int flag) {
+    this.flag = flag;
   }
 
   protected abstract Object decodeNotNull(int flag, CodecDataInput cdi);

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/IntegerType.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/IntegerType.java
@@ -24,8 +24,8 @@ import com.pingcap.tikv.codec.Codec.IntegerCodec;
 import com.pingcap.tikv.codec.CodecDataInput;
 import com.pingcap.tikv.codec.CodecDataOutput;
 import com.pingcap.tikv.exception.TypeException;
+import com.pingcap.tikv.meta.Collation;
 import com.pingcap.tikv.meta.TiColumnInfo;
-
 import java.math.BigDecimal;
 
 public class IntegerType extends DataType {
@@ -36,10 +36,23 @@ public class IntegerType extends DataType {
   public static final IntegerType BIGINT = new IntegerType(MySQLType.TypeLonglong);
   public static final IntegerType BOOLEAN = TINYINT;
 
+  public static final IntegerType ROW_ID_TYPE = new IntegerType(
+      MySQLType.TypeLonglong,
+      PriKeyFlag,
+      20,
+      0
+  );
+
+
+
   public static final MySQLType[] subTypes = new MySQLType[] {
       MySQLType.TypeTiny, MySQLType.TypeShort, MySQLType.TypeInt24,
       MySQLType.TypeLong, MySQLType.TypeLonglong
   };
+
+  protected IntegerType(MySQLType type, int flag, int len, int decimal) {
+    super(type, flag, len, decimal, "", Collation.DEF_COLLATION_CODE);
+  }
 
   protected IntegerType(MySQLType tp) {
     super(tp);


### PR DESCRIPTION
For implicit primary key, allow TiSpark to retrieve row_id. It's controlled by switch and if turned on, user will be able to see this column and retrieve it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tispark/367)
<!-- Reviewable:end -->
