### PR TITLE
Fix load table might result table not exists

### DIFF
--- a/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
@@ -20,25 +20,6 @@ import org.apache.spark.sql.functions.{col, sum}
 
 class IssueTestSuite extends BaseTiSparkSuite {
 
-  val tableNum = 5000
-
-  test("Test multiple tables across regions") {
-    for (x <- 1 to tableNum) {
-      tidbStmt.execute(s"DROP TABLE IF EXISTS `test$x`")
-      tidbStmt.execute(
-        s"""CREATE TABLE `test$x` (
-          |  `a` int(11) DEFAULT NULL
-          |) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin
-        """.stripMargin
-      )
-    }
-    refreshConnections()
-
-    for (x <- 1 to tableNum) {
-      ti.tidbMapTable("tispark_test", s"test$tableNum")
-    }
-  }
-
   test("Test count") {
     tidbStmt.execute("DROP TABLE IF EXISTS `t`")
     tidbStmt.execute(
@@ -297,9 +278,6 @@ class IssueTestSuite extends BaseTiSparkSuite {
       tidbStmt.execute("drop table if exists t1")
       tidbStmt.execute("drop table if exists t2")
       tidbStmt.execute("drop table if exists single_read")
-      for (x <- 1 to tableNum) {
-        tidbStmt.execute(s"DROP TABLE IF EXISTS `test$x`")
-      }
     } finally {
       super.afterAll()
     }

--- a/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
@@ -20,6 +20,25 @@ import org.apache.spark.sql.functions.{col, sum}
 
 class IssueTestSuite extends BaseTiSparkSuite {
 
+  val tableNum = 5000
+
+  test("Test multiple tables across regions") {
+    for (x <- 1 to tableNum) {
+      tidbStmt.execute(s"DROP TABLE IF EXISTS `test$x`")
+      tidbStmt.execute(
+        s"""CREATE TABLE `test$x` (
+          |  `a` int(11) DEFAULT NULL
+          |) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin
+        """.stripMargin
+      )
+    }
+    refreshConnections()
+
+    for (x <- 1 to tableNum) {
+      ti.tidbMapTable("tispark_test", s"test$tableNum")
+    }
+  }
+
   test("Test count") {
     tidbStmt.execute("DROP TABLE IF EXISTS `t`")
     tidbStmt.execute(
@@ -278,6 +297,9 @@ class IssueTestSuite extends BaseTiSparkSuite {
       tidbStmt.execute("drop table if exists t1")
       tidbStmt.execute("drop table if exists t2")
       tidbStmt.execute("drop table if exists single_read")
+      for (x <- 1 to tableNum) {
+        tidbStmt.execute(s"DROP TABLE IF EXISTS `test$x`")
+      }
     } finally {
       super.afterAll()
     }

--- a/tikv-client/src/main/java/com/pingcap/tikv/operation/iterator/ScanIterator.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/operation/iterator/ScanIterator.java
@@ -69,7 +69,11 @@ public class ScanIterator implements Iterator<Kvrpcpb.KvPair> {
     try (RegionStoreClient client = RegionStoreClient.create(region, store, session)) {
       BackOffer backOffer = ConcreteBackOffer.newScannerNextMaxBackOff();
       currentCache = client.scan(backOffer, startKey, version);
-      if (currentCache == null || currentCache.size() == 0) {
+      // currentCache is null means no keys found, whereas currentCache is empty means no values found
+      // the difference lies in whether to continue scanning, because chances are that the same key is
+      // split in another region because of pending entries, region split, e.t.c.
+      // See https://github.com/pingcap/tispark/issues/393 for details
+      if (currentCache == null) {
         return false;
       }
       index = 0;

--- a/tikv-client/src/test/java/com/pingcap/tikv/catalog/CatalogTest.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/catalog/CatalogTest.java
@@ -87,7 +87,7 @@ public class CatalogTest {
     Catalog cat = session.getCatalog();
     TiDBInfo db = cat.getDatabase("gLObal_temp");
     List<TiTableInfo> tables = cat.listTables(db);
-    List<String> names = tables.stream().map(table -> table.getName()).sorted().collect(Collectors.toList());
+    List<String> names = tables.stream().map(TiTableInfo::getName).sorted().collect(Collectors.toList());
     assertEquals(2, tables.size());
     assertEquals("test", names.get(0));
     assertEquals("test1", names.get(1));
@@ -103,7 +103,7 @@ public class CatalogTest {
     wrapper.call("reloadCache");
 
     tables = cat.listTables(db);
-    names = tables.stream().map(table -> table.getName()).sorted().collect(Collectors.toList());
+    names = tables.stream().map(TiTableInfo::getName).sorted().collect(Collectors.toList());
     assertEquals(3, tables.size());
     assertEquals("other", names.get(0));
     assertEquals("test", names.get(1));


### PR DESCRIPTION
Fix #393 

And enclose a copy of conclusion:

>Bug in ScanIterator caused seldom table not exists.
>
>When currentCache is null means no keys found, whereas currentCache is empty means no values found. The difference lies in whether to continue scanning, because chances are that the same key is split in another region because of pending entries, region split, e.t.c.
>
>e.g., Assume we fetch table information in DB:123, ScanIterator sends a request containing an encoded key, say [1,2,3,0,0,0,1], and finds the first region that contains this key. If the region's range(e.g., [[1,2,3,0,0,0,0], [1,2,3,0,0,1,1])) was not enough to cover all keys [1,2,3,0,0,0,1], it is possible that it returns a partial result because some other table meta are contained in another region(e.g., [[1,2,3,0,0,1,1], [1,2,3,0,0,2])).
>
>Because ScanIterator was only used in fetching table meta info, tests not covering thousands of tables are unable to reveal this bug beforehand.