### PR TITLE
Fix start-tithriftserver.sh losing extra options

### DIFF
--- a/core/scripts/start-tithriftserver.sh
+++ b/core/scripts/start-tithriftserver.sh
@@ -80,4 +80,4 @@ fi
 
 export SUBMIT_USAGE_FUNCTION=usage
 
-exec "${SPARK_HOME}"/sbin/spark-daemon.sh submit $CLASS 1 --name "Thrift JDBC/ODBC Server" "${SPARK_JARS_DIR}"/"${TISPARK_JAR}"
+exec "${SPARK_HOME}"/sbin/spark-daemon.sh submit $CLASS 1 --name "Thrift JDBC/ODBC Server" "$@" "${SPARK_JARS_DIR}"/"${TISPARK_JAR}"


### PR DESCRIPTION
Fix #435 pass those extra option parameters to spark-daemon.sh