### PR TITLE
Fix test fails due to dbPrefix

### DIFF
--- a/core/src/test/scala/org/apache/spark/sql/BaseTiSparkSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/BaseTiSparkSuite.scala
@@ -86,7 +86,7 @@ class BaseTiSparkSuite extends QueryTest with SharedSQLContext {
       tableNames = Seq.empty[String]
       for (dbName <- databases) {
         tidbConn.setCatalog(dbName)
-        ti.tidbMapDatabase(dbName)
+        ti.tidbMapDatabase(dbPrefix + dbName)
         val tableDF = spark.read
           .format("jdbc")
           .option(JDBCOptions.JDBC_URL, jdbcUrl)
@@ -109,7 +109,7 @@ class BaseTiSparkSuite extends QueryTest with SharedSQLContext {
   protected def loadTestData(testTables: TestTables): Unit = {
     val dbName = testTables.dbName
     tidbConn.setCatalog(dbName)
-    ti.tidbMapDatabase(dbName)
+    ti.tidbMapDatabase(dbPrefix + dbName)
     for (tableName <- testTables.tables) {
       createOrReplaceTempView(dbName, tableName)
     }

--- a/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
@@ -20,9 +20,9 @@ import org.apache.spark.sql.functions.{col, sum}
 
 class IssueTestSuite extends BaseTiSparkSuite {
 
-  test("test") {
-    ti.tidbMapTable("tidb_tispark_test", "full_data_type_table", dbNameAsPrefix = true)
-    val df = spark.sql("select count(*) from tidb_tispark_test_full_data_type_table")
+  test("test db prefix") {
+    ti.tidbMapTable(s"${dbPrefix}tispark_test", "full_data_type_table", dbNameAsPrefix = true)
+    val df = spark.sql(s"select count(*) from ${dbPrefix}tispark_test_full_data_type_table")
     df.explain()
     df.show
   }
@@ -172,7 +172,7 @@ class IssueTestSuite extends BaseTiSparkSuite {
 
   // https://github.com/pingcap/tispark/issues/255
   test("Group by with first") {
-    ti.tidbMapDatabase("tpch_test")
+    ti.tidbMapDatabase(dbPrefix + "tpch_test")
     val q1 =
       """
         |select

--- a/core/src/test/scala/org/apache/spark/sql/benchmark/TPCHQuerySuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/benchmark/TPCHQuerySuite.scala
@@ -53,7 +53,7 @@ class TPCHQuerySuite extends BaseTiSparkSuite {
   private lazy val tiSparkRes = {
     val result = mutable.Map[String, List[List[Any]]]()
     // We do not use statistic information here due to conflict of netty versions when physical plan has broadcast nodes.
-    ti.tidbMapDatabase(tpchDBName, autoLoadStatistics = false)
+    ti.tidbMapDatabase(dbPrefix + tpchDBName, autoLoadStatistics = false)
     tpchQueries.foreach { name =>
       val queryString = resourceToString(
         s"tpch-sql/$name.sql",

--- a/core/src/test/scala/org/apache/spark/sql/test/SharedSQLContext.scala
+++ b/core/src/test/scala/org/apache/spark/sql/test/SharedSQLContext.scala
@@ -53,6 +53,8 @@ trait SharedSQLContext extends SparkFunSuite with Eventually with BeforeAndAfter
 
   protected def tpchDBName: String = SharedSQLContext.tpchDBName
 
+  protected def dbPrefix: String = SharedSQLContext.dbPrefix
+
   protected def timeZoneOffset: String = SharedSQLContext.timeZoneOffset
 
   protected def refreshConnections(): Unit = SharedSQLContext.refreshConnections()
@@ -97,6 +99,7 @@ object SharedSQLContext extends Logging {
   private var _sparkJDBC: SparkSession = _
   protected var jdbcUrl: String = _
   protected var tpchDBName: String = _
+  protected var dbPrefix: String = _
 
   protected lazy val sql = spark.sql _
 
@@ -211,11 +214,15 @@ object SharedSQLContext extends Logging {
         prop.load(confStream)
       }
 
-      tpchDBName = getOrElse(prop, TPCH_DB_NAME, "tpch_test")
       import com.pingcap.tispark.TiConfigConst._
       sparkConf.set(PD_ADDRESSES, getOrElse(prop, PD_ADDRESSES, "127.0.0.1:2379"))
       sparkConf.set(ALLOW_INDEX_READ, getOrElse(prop, ALLOW_INDEX_READ, "true"))
-      sparkConf.set(DB_PREFIX, getOrElse(prop, DB_PREFIX, "tidb_"))
+
+      dbPrefix = getOrElse(prop, DB_PREFIX, "tidb_")
+      sparkConf.set(DB_PREFIX, dbPrefix)
+
+      tpchDBName = getOrElse(prop, TPCH_DB_NAME, "tpch_test")
+
       _tidbConf = prop
       _sparkSession = new TestSparkSession(sparkConf)
     }


### PR DESCRIPTION
If dbPrefix was set in test config, other tests might also be involved. Fix its influence.