### PR TITLE
Resolve conflicting jackson version introduced by typesafe.play

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -37,21 +37,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <dependency>
-            <groupId>com.typesafe.play</groupId>
-            <artifactId>play-json_${scala.binary.version}</artifactId>
-            <version>${play.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.scala-lang</groupId>
-                    <artifactId>scala-library</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.scala-lang</groupId>
-                    <artifactId>scala-reflect</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
         <!-- For tests -->
         <dependency>
             <groupId>org.scalatest</groupId>


### PR DESCRIPTION
Play API was introduced for debugTools, but it also brings conflicting jackson version consequently.

As a matter of fact, Spark uses json4s for its JSON type support, which we can simply make use of. 

This PR replaces the original play API with json4s provided and does not introduce new dependencies.

@zanmato PTAL