### PR TITLE
Use case class for execution commands

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/execution/command/TiCommand.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/command/TiCommand.scala
@@ -5,12 +5,15 @@ import org.apache.spark.sql.catalyst.catalog.TiSessionCatalog
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 
-abstract class TiCommand extends RunnableCommand {
+/**
+ * TiCommand is used to inherit from [[org.apache.spark.sql.execution.command.RunnableCommand]]
+ *
+ * Because we are unable to extend from a case class implementing RunnableCommand, we will have
+ * to extend TiCommand from its abstract class directly.
+ */
+abstract class TiCommand(delegate: RunnableCommand) extends RunnableCommand {
   val tiContext: TiContext
   def tiCatalog: TiSessionCatalog = tiContext.tiCatalog
-}
-
-abstract class TiDelegateCommand(delegate: RunnableCommand) extends TiCommand {
   override def output: Seq[Attribute] = delegate.output
   override def children: Seq[LogicalPlan] = delegate.children
   override def run(sparkSession: SparkSession): Seq[Row] = delegate.run(sparkSession)

--- a/core/src/main/scala/org/apache/spark/sql/execution/command/TiCommand.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/command/TiCommand.scala
@@ -1,9 +1,17 @@
 package org.apache.spark.sql.execution.command
 
-import org.apache.spark.sql.TiContext
+import org.apache.spark.sql.{Row, SparkSession, TiContext}
 import org.apache.spark.sql.catalyst.catalog.TiSessionCatalog
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 
-trait TiCommand {
+abstract class TiCommand extends RunnableCommand {
   val tiContext: TiContext
   def tiCatalog: TiSessionCatalog = tiContext.tiCatalog
+}
+
+abstract class TiDelegateCommand(delegate: RunnableCommand) extends TiCommand {
+  override def output: Seq[Attribute] = delegate.output
+  override def children: Seq[LogicalPlan] = delegate.children
+  override def run(sparkSession: SparkSession): Seq[Row] = delegate.run(sparkSession)
 }

--- a/core/src/main/scala/org/apache/spark/sql/execution/command/TiSetDatabaseCommand.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/command/TiSetDatabaseCommand.scala
@@ -2,11 +2,10 @@ package org.apache.spark.sql.execution.command
 
 import org.apache.spark.sql.{Row, SparkSession, TiContext}
 
-case class TiSetDatabaseCommand(tiContext: TiContext, databaseName: String)
-    extends RunnableCommand
-    with TiCommand {
+case class TiSetDatabaseCommand(tiContext: TiContext, delegate: SetDatabaseCommand)
+    extends TiDelegateCommand(delegate) {
   override def run(sparkSession: SparkSession): Seq[Row] = {
-    tiCatalog.setCurrentDatabase(databaseName)
+    tiCatalog.setCurrentDatabase(delegate.databaseName)
     Seq.empty[Row]
   }
 }

--- a/core/src/main/scala/org/apache/spark/sql/execution/command/TiSetDatabaseCommand.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/command/TiSetDatabaseCommand.scala
@@ -3,7 +3,7 @@ package org.apache.spark.sql.execution.command
 import org.apache.spark.sql.{Row, SparkSession, TiContext}
 
 case class TiSetDatabaseCommand(tiContext: TiContext, delegate: SetDatabaseCommand)
-    extends TiDelegateCommand(delegate) {
+    extends TiCommand(delegate) {
   override def run(sparkSession: SparkSession): Seq[Row] = {
     tiCatalog.setCurrentDatabase(delegate.databaseName)
     Seq.empty[Row]

--- a/core/src/main/scala/org/apache/spark/sql/execution/command/TiShowDatabasesCommand.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/command/TiShowDatabasesCommand.scala
@@ -2,13 +2,12 @@ package org.apache.spark.sql.execution.command
 
 import org.apache.spark.sql.{Row, SparkSession, TiContext}
 
-class TiShowDatabasesCommand(val tiContext: TiContext, databasePattern: Option[String])
-    extends ShowDatabasesCommand(databasePattern)
-    with TiCommand {
+case class TiShowDatabasesCommand(tiContext: TiContext, delegate: ShowDatabasesCommand)
+    extends TiDelegateCommand(delegate) {
   override def run(sparkSession: SparkSession): Seq[Row] = {
     val databases =
       // Not leveraging catalog-specific db pattern, at least Hive and Spark behave different than each other.
-      databasePattern
+      delegate.databasePattern
         .map(tiCatalog.listDatabases)
         .getOrElse(tiCatalog.listDatabases())
     databases.map { d =>

--- a/core/src/main/scala/org/apache/spark/sql/execution/command/TiShowDatabasesCommand.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/command/TiShowDatabasesCommand.scala
@@ -3,7 +3,7 @@ package org.apache.spark.sql.execution.command
 import org.apache.spark.sql.{Row, SparkSession, TiContext}
 
 case class TiShowDatabasesCommand(tiContext: TiContext, delegate: ShowDatabasesCommand)
-    extends TiDelegateCommand(delegate) {
+    extends TiCommand(delegate) {
   override def run(sparkSession: SparkSession): Seq[Row] = {
     val databases =
       // Not leveraging catalog-specific db pattern, at least Hive and Spark behave different than each other.

--- a/core/src/main/scala/org/apache/spark/sql/execution/command/TiShowTablesCommand.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/command/TiShowTablesCommand.scala
@@ -1,25 +1,21 @@
 package org.apache.spark.sql.execution.command
 
-import org.apache.spark.sql.catalyst.catalog.CatalogTypes.TablePartitionSpec
 import org.apache.spark.sql.{Row, SparkSession, TiContext}
 
-class TiShowTablesCommand(val tiContext: TiContext,
-                          databaseName: Option[String],
-                          tableIdentifierPattern: Option[String],
-                          isExtended: Boolean,
-                          partitionSpec: Option[TablePartitionSpec])
-    extends ShowTablesCommand(databaseName, tableIdentifierPattern, isExtended, partitionSpec)
-    with TiCommand {
+case class TiShowTablesCommand(tiContext: TiContext, delegate: ShowTablesCommand)
+    extends TiDelegateCommand(delegate) {
   override def run(sparkSession: SparkSession): Seq[Row] = {
-    val db = databaseName.getOrElse(tiCatalog.getCurrentDatabase)
+    val db = delegate.databaseName.getOrElse(tiCatalog.getCurrentDatabase)
     // Show the information of tables.
     val tables =
-      tableIdentifierPattern.map(tiCatalog.listTables(db, _)).getOrElse(tiCatalog.listTables(db))
+      delegate.tableIdentifierPattern
+        .map(tiCatalog.listTables(db, _))
+        .getOrElse(tiCatalog.listTables(db))
     tables.map { tableIdent =>
       val database = tableIdent.database.getOrElse("")
       val tableName = tableIdent.table
       val isTemp = tiCatalog.isTemporaryTable(tableIdent)
-      if (isExtended) {
+      if (delegate.isExtended) {
         val information = tiCatalog.getTempViewOrPermanentTableMetadata(tableIdent).simpleString
         Row(database, tableName, isTemp, s"$information\n")
       } else {

--- a/core/src/main/scala/org/apache/spark/sql/execution/command/TiShowTablesCommand.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/command/TiShowTablesCommand.scala
@@ -3,7 +3,7 @@ package org.apache.spark.sql.execution.command
 import org.apache.spark.sql.{Row, SparkSession, TiContext}
 
 case class TiShowTablesCommand(tiContext: TiContext, delegate: ShowTablesCommand)
-    extends TiDelegateCommand(delegate) {
+    extends TiCommand(delegate) {
   override def run(sparkSession: SparkSession): Seq[Row] = {
     val db = delegate.databaseName.getOrElse(tiCatalog.getCurrentDatabase)
     // Show the information of tables.

--- a/core/src/main/scala/org/apache/spark/sql/extensions/TiDDLRule.scala
+++ b/core/src/main/scala/org/apache/spark/sql/extensions/TiDDLRule.scala
@@ -11,17 +11,11 @@ case class TiDDLRule(getOrCreateTiContext: SparkSession => TiContext)(sparkSessi
 
   override def apply(plan: LogicalPlan): LogicalPlan = plan transformUp {
     // TODO: support other commands that may concern TiSpark catalog.
-    case ShowDatabasesCommand(databasePattern) =>
-      new TiShowDatabasesCommand(tiContext, databasePattern)
-    case SetDatabaseCommand(databaseName) =>
-      TiSetDatabaseCommand(tiContext, databaseName)
-    case ShowTablesCommand(databaseName, tableIdentifierPattern, isExtended, partitionSpec) =>
-      new TiShowTablesCommand(
-        tiContext,
-        databaseName,
-        tableIdentifierPattern,
-        isExtended,
-        partitionSpec
-      )
+    case sd: ShowDatabasesCommand =>
+      TiShowDatabasesCommand(tiContext, sd)
+    case sd: SetDatabaseCommand =>
+      TiSetDatabaseCommand(tiContext, sd)
+    case st: ShowTablesCommand =>
+      TiShowTablesCommand(tiContext, st)
   }
 }

--- a/core/src/main/scala/org/apache/spark/sql/extensions/TiResolutionRule.scala
+++ b/core/src/main/scala/org/apache/spark/sql/extensions/TiResolutionRule.scala
@@ -3,7 +3,7 @@ package org.apache.spark.sql.extensions
 import com.pingcap.tispark.statistics.StatisticsManager
 import org.apache.spark.sql.{AnalysisException, _}
 import org.apache.spark.sql.catalyst.TableIdentifier
-import org.apache.spark.sql.catalyst.analysis.{NoSuchTableException, UnresolvedRelation}
+import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.rules.Rule
 import com.pingcap.tispark.{MetaManager, TiDBRelation, TiTableReference}
@@ -14,11 +14,11 @@ case class TiResolutionRule(getOrCreateTiContext: SparkSession => TiContext)(
   sparkSession: SparkSession
 ) extends Rule[LogicalPlan] {
   protected lazy val tiContext: TiContext = getOrCreateTiContext(sparkSession)
-  private def autoLoad = tiContext.autoLoad
-  protected def meta: MetaManager = tiContext.meta
-  private def tiCatalog = tiContext.tiCatalog
-  private def tiSession = tiContext.tiSession
-  private def sqlContext = tiContext.sqlContext
+  private lazy val autoLoad = tiContext.autoLoad
+  protected lazy val meta: MetaManager = tiContext.meta
+  private lazy val tiCatalog = tiContext.tiCatalog
+  private lazy val tiSession = tiContext.tiSession
+  private lazy val sqlContext = tiContext.sqlContext
 
   private def getDatabaseFromIdentifier(tableIdentifier: TableIdentifier): String =
     tableIdentifier.database.getOrElse(tiCatalog.getCurrentDatabase)


### PR DESCRIPTION
By using case class for execution commands, it will not affect other projects depending on it.