### PR TITLE
Eliminate useless loading process

### DIFF
--- a/core/src/test/scala/org/apache/spark/sql/BaseInitialOnceSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/BaseInitialOnceSuite.scala
@@ -1,0 +1,11 @@
+package org.apache.spark.sql
+
+class BaseInitialOnceSuite extends BaseTiSparkSuite {
+  private var init = false
+
+  override def beforeAll(): Unit =
+    if (!init) {
+      super.beforeAll()
+      init = true
+    }
+}

--- a/core/src/test/scala/org/apache/spark/sql/expression/Aggregate0Suite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/Aggregate0Suite.scala
@@ -17,9 +17,9 @@
 
 package org.apache.spark.sql.expression
 
-import org.apache.spark.sql.BaseTiSparkSuite
+import org.apache.spark.sql.BaseInitialOnceSuite
 
-class Aggregate0Suite extends BaseTiSparkSuite {
+class Aggregate0Suite extends BaseInitialOnceSuite {
   private val allCases = Seq[String](
     "select tp_mediumtext from full_data_type_table  group by (tp_mediumtext)  order by tp_mediumtext ",
     "select tp_double from full_data_type_table  group by (tp_double)  order by tp_double ",

--- a/core/src/test/scala/org/apache/spark/sql/expression/ArithmeticAgg0Suite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/ArithmeticAgg0Suite.scala
@@ -17,9 +17,9 @@
 
 package org.apache.spark.sql.expression
 
-import org.apache.spark.sql.BaseTiSparkSuite
+import org.apache.spark.sql.BaseInitialOnceSuite
 
-class ArithmeticAgg0Suite extends BaseTiSparkSuite {
+class ArithmeticAgg0Suite extends BaseInitialOnceSuite {
   private val allCases = Seq[String](
     "select min(tp_smallint) from full_data_type_table",
     "select sum(tp_char) from full_data_type_table",

--- a/core/src/test/scala/org/apache/spark/sql/expression/ArithmeticTest0Suite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/ArithmeticTest0Suite.scala
@@ -17,9 +17,9 @@
 
 package org.apache.spark.sql.expression
 
-import org.apache.spark.sql.BaseTiSparkSuite
+import org.apache.spark.sql.BaseInitialOnceSuite
 
-class ArithmeticTest0Suite extends BaseTiSparkSuite {
+class ArithmeticTest0Suite extends BaseInitialOnceSuite {
   private val allCases = Seq[String](
     "select tp_tinyint + 9223372036854775807 from full_data_type_table  order by id_dt  limit 10",
     "select tp_tinyint + -9223372036854775808 from full_data_type_table  order by id_dt  limit 10",

--- a/core/src/test/scala/org/apache/spark/sql/expression/ArithmeticTest1Suite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/ArithmeticTest1Suite.scala
@@ -17,9 +17,9 @@
 
 package org.apache.spark.sql.expression
 
-import org.apache.spark.sql.BaseTiSparkSuite
+import org.apache.spark.sql.BaseInitialOnceSuite
 
-class ArithmeticTest1Suite extends BaseTiSparkSuite {
+class ArithmeticTest1Suite extends BaseInitialOnceSuite {
   private val allCases = Seq[String](
     "select tp_mediumint / 127 from full_data_type_table  order by id_dt  limit 10",
     "select tp_mediumint / -128 from full_data_type_table  order by id_dt  limit 10",

--- a/core/src/test/scala/org/apache/spark/sql/expression/ArithmeticTest2Suite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/ArithmeticTest2Suite.scala
@@ -17,9 +17,9 @@
 
 package org.apache.spark.sql.expression
 
-import org.apache.spark.sql.BaseTiSparkSuite
+import org.apache.spark.sql.BaseInitialOnceSuite
 
-class ArithmeticTest2Suite extends BaseTiSparkSuite {
+class ArithmeticTest2Suite extends BaseInitialOnceSuite {
   private val divideCases = Seq[String](
     "select id_dt from full_data_type_table where tp_int / tp_tinyint > 0 order by id_dt",
     "select id_dt from full_data_type_table where tp_bigint / tp_int >= 0 order by id_dt",

--- a/core/src/test/scala/org/apache/spark/sql/expression/Between0Suite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/Between0Suite.scala
@@ -17,9 +17,9 @@
 
 package org.apache.spark.sql.expression
 
-import org.apache.spark.sql.BaseTiSparkSuite
+import org.apache.spark.sql.BaseInitialOnceSuite
 
-class Between0Suite extends BaseTiSparkSuite {
+class Between0Suite extends BaseInitialOnceSuite {
   private val allCases = Seq[String](
     "select tp_int from full_data_type_table  where tp_int between -1202333 and 601508558",
     "select tp_bigint from full_data_type_table  where tp_bigint between -2902580959275580308 and 9223372036854775807",

--- a/core/src/test/scala/org/apache/spark/sql/expression/CartesianTypeTestCases0Suite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/CartesianTypeTestCases0Suite.scala
@@ -17,9 +17,9 @@
 
 package org.apache.spark.sql.expression
 
-import org.apache.spark.sql.BaseTiSparkSuite
+import org.apache.spark.sql.BaseInitialOnceSuite
 
-class CartesianTypeTestCases0Suite extends BaseTiSparkSuite {
+class CartesianTypeTestCases0Suite extends BaseInitialOnceSuite {
   private val allCases = Seq[String](
     "select id_dt,tp_smallint from full_data_type_table  where id_dt = tp_smallint order by id_dt  limit 20",
     "select id_dt,tp_bigint from full_data_type_table  where id_dt = tp_bigint order by id_dt  limit 20",

--- a/core/src/test/scala/org/apache/spark/sql/expression/CartesianTypeTestCases1Suite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/CartesianTypeTestCases1Suite.scala
@@ -17,9 +17,9 @@
 
 package org.apache.spark.sql.expression
 
-import org.apache.spark.sql.BaseTiSparkSuite
+import org.apache.spark.sql.BaseInitialOnceSuite
 
-class CartesianTypeTestCases1Suite extends BaseTiSparkSuite {
+class CartesianTypeTestCases1Suite extends BaseInitialOnceSuite {
   private val allCases = Seq[String](
     "select tp_tinyint,tp_smallint from full_data_type_table  where tp_tinyint <= tp_smallint order by id_dt  limit 20",
     "select tp_nvarchar,tp_nvarchar from full_data_type_table  where tp_nvarchar <= tp_nvarchar order by id_dt  limit 20",

--- a/core/src/test/scala/org/apache/spark/sql/expression/CartesianTypeTestCases2Suite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/CartesianTypeTestCases2Suite.scala
@@ -17,9 +17,9 @@
 
 package org.apache.spark.sql.expression
 
-import org.apache.spark.sql.BaseTiSparkSuite
+import org.apache.spark.sql.BaseInitialOnceSuite
 
-class CartesianTypeTestCases2Suite extends BaseTiSparkSuite {
+class CartesianTypeTestCases2Suite extends BaseInitialOnceSuite {
   private val allCases = Seq[String](
     "select tp_int,tp_decimal from full_data_type_table  where tp_int <> tp_decimal order by id_dt  limit 20",
     "select tp_mediumint,id_dt from full_data_type_table  where tp_mediumint <> id_dt order by id_dt  limit 20",

--- a/core/src/test/scala/org/apache/spark/sql/expression/ComplexAggregateSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/ComplexAggregateSuite.scala
@@ -17,9 +17,9 @@
 
 package org.apache.spark.sql.expression
 
-import org.apache.spark.sql.BaseTiSparkSuite
+import org.apache.spark.sql.BaseInitialOnceSuite
 
-class ComplexAggregateSuite extends BaseTiSparkSuite {
+class ComplexAggregateSuite extends BaseInitialOnceSuite {
   private val allCases = Seq[String](
     "select min(tp_smallint) from full_data_type_table",
     "select sum(tp_char) from full_data_type_table",

--- a/core/src/test/scala/org/apache/spark/sql/expression/ComplexGroupBySuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/ComplexGroupBySuite.scala
@@ -17,9 +17,9 @@
 
 package org.apache.spark.sql.expression
 
-import org.apache.spark.sql.BaseTiSparkSuite
+import org.apache.spark.sql.BaseInitialOnceSuite
 
-class ComplexGroupBySuite extends BaseTiSparkSuite {
+class ComplexGroupBySuite extends BaseInitialOnceSuite {
   private val allCases = Seq[String](
     "select tp_int + 1 from full_data_type_table  group by (tp_int + 1)",
     "select tp_float * 2 from full_data_type_table  group by (tp_float * 2)",

--- a/core/src/test/scala/org/apache/spark/sql/expression/Count0Suite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/Count0Suite.scala
@@ -17,9 +17,9 @@
 
 package org.apache.spark.sql.expression
 
-import org.apache.spark.sql.BaseTiSparkSuite
+import org.apache.spark.sql.BaseInitialOnceSuite
 
-class Count0Suite extends BaseTiSparkSuite {
+class Count0Suite extends BaseInitialOnceSuite {
   private val countCases = Seq[String](
     "select count(tp_int) from full_data_type_table ",
     "select count(tp_date) from full_data_type_table ",

--- a/core/src/test/scala/org/apache/spark/sql/expression/Distinct0Suite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/Distinct0Suite.scala
@@ -17,9 +17,9 @@
 
 package org.apache.spark.sql.expression
 
-import org.apache.spark.sql.BaseTiSparkSuite
+import org.apache.spark.sql.BaseInitialOnceSuite
 
-class Distinct0Suite extends BaseTiSparkSuite {
+class Distinct0Suite extends BaseInitialOnceSuite {
   private val allCases = Seq[String](
     "select  distinct(tp_binary)  from full_data_type_table  order by tp_binary ",
     "select  distinct(tp_nvarchar)  from full_data_type_table  order by tp_nvarchar ",

--- a/core/src/test/scala/org/apache/spark/sql/expression/FirstLast0Suite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/FirstLast0Suite.scala
@@ -17,9 +17,9 @@
 
 package org.apache.spark.sql.expression
 
-import org.apache.spark.sql.BaseTiSparkSuite
+import org.apache.spark.sql.BaseInitialOnceSuite
 
-class FirstLast0Suite extends BaseTiSparkSuite {
+class FirstLast0Suite extends BaseInitialOnceSuite {
   private val allCases = Seq[String](
     "select first(tp_char) from full_data_type_table  group by (tp_nvarchar)   order by tp_nvarchar ",
     "select last(tp_double) from full_data_type_table  group by (tp_nvarchar)   order by tp_nvarchar ",

--- a/core/src/test/scala/org/apache/spark/sql/expression/Having0Suite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/Having0Suite.scala
@@ -17,9 +17,9 @@
 
 package org.apache.spark.sql.expression
 
-import org.apache.spark.sql.BaseTiSparkSuite
+import org.apache.spark.sql.BaseInitialOnceSuite
 
-class Having0Suite extends BaseTiSparkSuite {
+class Having0Suite extends BaseInitialOnceSuite {
   private val allCases = Seq[String](
     "select tp_int%1000 a, count(*) from full_data_type_table group by (tp_int%1000) having sum(tp_int%1000) > 100 order by a",
     "select tp_bigint%1000 a, count(*) from full_data_type_table group by (tp_bigint%1000) having sum(tp_bigint%1000) < 100 order by a"

--- a/core/src/test/scala/org/apache/spark/sql/expression/InTest0Suite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/InTest0Suite.scala
@@ -17,9 +17,9 @@
 
 package org.apache.spark.sql.expression
 
-import org.apache.spark.sql.BaseTiSparkSuite
+import org.apache.spark.sql.BaseInitialOnceSuite
 
-class InTest0Suite extends BaseTiSparkSuite {
+class InTest0Suite extends BaseInitialOnceSuite {
   private val allCases = Seq[String](
     "select tp_int from full_data_type_table  where tp_int in (2333, 601508558, 4294967296, 4294967295)",
     "select tp_bigint from full_data_type_table  where tp_bigint in (122222, -2902580959275580308, 9223372036854775807, 9223372036854775808)",

--- a/core/src/test/scala/org/apache/spark/sql/expression/LikeTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/LikeTestSuite.scala
@@ -15,9 +15,9 @@
 
 package org.apache.spark.sql.expression
 
-import org.apache.spark.sql.BaseTiSparkSuite
+import org.apache.spark.sql.BaseInitialOnceSuite
 
-class LikeTestSuite extends BaseTiSparkSuite {
+class LikeTestSuite extends BaseInitialOnceSuite {
   private val tableScanCases = Seq[String](
     "select tp_varchar from full_data_type_table where tp_varchar LIKE 'a%'",
     "select tp_varchar from full_data_type_table where tp_varchar LIKE '%a%'",

--- a/core/src/test/scala/org/apache/spark/sql/expression/LogicalAndOr0Suite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/LogicalAndOr0Suite.scala
@@ -17,9 +17,9 @@
 
 package org.apache.spark.sql.expression
 
-import org.apache.spark.sql.BaseTiSparkSuite
+import org.apache.spark.sql.BaseInitialOnceSuite
 
-class LogicalAndOr0Suite extends BaseTiSparkSuite {
+class LogicalAndOr0Suite extends BaseInitialOnceSuite {
   private val allCases = Seq[String](
     "select tp_char,tp_smallint from full_data_type_table  where tp_char = tp_smallint and tp_char > 0",
     "select tp_char,id_dt from full_data_type_table  where tp_char = id_dt and tp_char > 0",

--- a/core/src/test/scala/org/apache/spark/sql/expression/OtherTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/OtherTestSuite.scala
@@ -17,9 +17,9 @@
 
 package org.apache.spark.sql.expression
 
-import org.apache.spark.sql.BaseTiSparkSuite
+import org.apache.spark.sql.BaseInitialOnceSuite
 
-class OtherTestSuite extends BaseTiSparkSuite {
+class OtherTestSuite extends BaseInitialOnceSuite {
   private val cases = Seq[String](
     "select id_dt from full_data_type_table where tp_date is null",
     "select id_dt from full_data_type_table where tp_date is not null",

--- a/core/src/test/scala/org/apache/spark/sql/expression/PlaceHolderTest0Suite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/PlaceHolderTest0Suite.scala
@@ -17,9 +17,9 @@
 
 package org.apache.spark.sql.expression
 
-import org.apache.spark.sql.BaseTiSparkSuite
+import org.apache.spark.sql.BaseInitialOnceSuite
 
-class PlaceHolderTest0Suite extends BaseTiSparkSuite {
+class PlaceHolderTest0Suite extends BaseInitialOnceSuite {
   private val allCases = Seq[String](
     "select  id_dt  from full_data_type_table  where tp_char = null",
     "select  id_dt  from full_data_type_table  where tp_char = 'PingCAP'",

--- a/core/src/test/scala/org/apache/spark/sql/expression/PlaceHolderTest1Suite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/PlaceHolderTest1Suite.scala
@@ -17,9 +17,9 @@
 
 package org.apache.spark.sql.expression
 
-import org.apache.spark.sql.BaseTiSparkSuite
+import org.apache.spark.sql.BaseInitialOnceSuite
 
-class PlaceHolderTest1Suite extends BaseTiSparkSuite {
+class PlaceHolderTest1Suite extends BaseInitialOnceSuite {
   private val allCases = Seq[String](
     "select  count(1)  from full_data_type_table  where tp_float > null",
     "select  count(1)  from full_data_type_table  where tp_float > '2017-11-02'",

--- a/core/src/test/scala/org/apache/spark/sql/expression/PlaceHolderTest2Suite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/PlaceHolderTest2Suite.scala
@@ -17,9 +17,9 @@
 
 package org.apache.spark.sql.expression
 
-import org.apache.spark.sql.BaseTiSparkSuite
+import org.apache.spark.sql.BaseInitialOnceSuite
 
-class PlaceHolderTest2Suite extends BaseTiSparkSuite {
+class PlaceHolderTest2Suite extends BaseInitialOnceSuite {
   private val allCases = Seq[String](
     "select  count(1)  from full_data_type_table  where id_dt >= '2017-11-02'",
     "select  count(1)  from full_data_type_table  where id_dt >= '2017-10-30'",

--- a/core/src/test/scala/org/apache/spark/sql/expression/PlaceHolderTest3Suite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/PlaceHolderTest3Suite.scala
@@ -17,9 +17,9 @@
 
 package org.apache.spark.sql.expression
 
-import org.apache.spark.sql.BaseTiSparkSuite
+import org.apache.spark.sql.BaseInitialOnceSuite
 
-class PlaceHolderTest3Suite extends BaseTiSparkSuite {
+class PlaceHolderTest3Suite extends BaseInitialOnceSuite {
   private val allCases = Seq[String](
     "select  count(1)  from full_data_type_table  where tp_double <> '2017-10-30'",
     "select  count(1)  from full_data_type_table  where tp_double <> '2017-09-07 11:11:11'",

--- a/core/src/test/scala/org/apache/spark/sql/expression/SimpleSelect0Suite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/SimpleSelect0Suite.scala
@@ -17,9 +17,9 @@
 
 package org.apache.spark.sql.expression
 
-import org.apache.spark.sql.BaseTiSparkSuite
+import org.apache.spark.sql.BaseInitialOnceSuite
 
-class SimpleSelect0Suite extends BaseTiSparkSuite {
+class SimpleSelect0Suite extends BaseInitialOnceSuite {
   private val allCases = Seq[String](
     "select tp_text from full_data_type_table  order by tp_text  limit 20",
     "select tp_binary from full_data_type_table  order by tp_binary  limit 20",

--- a/core/src/test/scala/org/apache/spark/sql/expression/Union0Suite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/Union0Suite.scala
@@ -17,9 +17,9 @@
 
 package org.apache.spark.sql.expression
 
-import org.apache.spark.sql.BaseTiSparkSuite
+import org.apache.spark.sql.BaseInitialOnceSuite
 
-class Union0Suite extends BaseTiSparkSuite {
+class Union0Suite extends BaseInitialOnceSuite {
   private val allCases = Seq[String](
     "(select tp_decimal from full_data_type_table where tp_decimal < 0) union (select tp_decimal from full_data_type_table where tp_decimal > 0) order by tp_decimal",
     "(select tp_smallint from full_data_type_table where tp_smallint < 0) union (select tp_smallint from full_data_type_table where tp_smallint > 0) order by tp_smallint",

--- a/core/src/test/scala/org/apache/spark/sql/expression/index/Aggregate0Suite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/index/Aggregate0Suite.scala
@@ -17,9 +17,9 @@
 
 package org.apache.spark.sql.expression.index
 
-import org.apache.spark.sql.BaseTiSparkSuite
+import org.apache.spark.sql.BaseInitialOnceSuite
 
-class Aggregate0Suite extends BaseTiSparkSuite {
+class Aggregate0Suite extends BaseInitialOnceSuite {
   private val allCases = Seq[String](
     "select tp_mediumint from full_data_type_table_idx  group by (tp_mediumint)  order by tp_mediumint ",
     "select tp_float from full_data_type_table_idx  group by (tp_float)  order by tp_float ",

--- a/core/src/test/scala/org/apache/spark/sql/expression/index/Between0Suite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/index/Between0Suite.scala
@@ -17,9 +17,9 @@
 
 package org.apache.spark.sql.expression.index
 
-import org.apache.spark.sql.BaseTiSparkSuite
+import org.apache.spark.sql.BaseInitialOnceSuite
 
-class Between0Suite extends BaseTiSparkSuite {
+class Between0Suite extends BaseInitialOnceSuite {
   private val allCases = Seq[String](
     "select tp_int from full_data_type_table_idx  where tp_int between -1202333 and 601508558 order by id_dt ",
     "select tp_bigint from full_data_type_table_idx  where tp_bigint between -2902580959275580308 and 9223372036854775807 order by id_dt ",

--- a/core/src/test/scala/org/apache/spark/sql/expression/index/ComprehensiveSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/index/ComprehensiveSuite.scala
@@ -15,9 +15,9 @@
 
 package org.apache.spark.sql.expression.index
 
-import org.apache.spark.sql.BaseTiSparkSuite
+import org.apache.spark.sql.BaseInitialOnceSuite
 
-class ComprehensiveSuite extends BaseTiSparkSuite {
+class ComprehensiveSuite extends BaseInitialOnceSuite {
   private val allCases = Seq[String](
     // MultiKeys
     """select tp_int, tp_float from full_data_type_table_idx

--- a/core/src/test/scala/org/apache/spark/sql/expression/index/CoveringIndex0Suite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/index/CoveringIndex0Suite.scala
@@ -17,9 +17,9 @@
 
 package org.apache.spark.sql.expression.index
 
-import org.apache.spark.sql.BaseTiSparkSuite
+import org.apache.spark.sql.BaseInitialOnceSuite
 
-class CoveringIndex0Suite extends BaseTiSparkSuite {
+class CoveringIndex0Suite extends BaseInitialOnceSuite {
   private val allCases = Seq[String](
     // cover index tests with count(*)
     "select count(*) from full_data_type_table_idx where tp_varchar < 'a1c9e581-470a-4594-a72d-55ce40dd6ec3'",

--- a/core/src/test/scala/org/apache/spark/sql/expression/index/InTest0Suite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/index/InTest0Suite.scala
@@ -17,9 +17,9 @@
 
 package org.apache.spark.sql.expression.index
 
-import org.apache.spark.sql.BaseTiSparkSuite
+import org.apache.spark.sql.BaseInitialOnceSuite
 
-class InTest0Suite extends BaseTiSparkSuite {
+class InTest0Suite extends BaseInitialOnceSuite {
   private val allCases = Seq[String](
     "select tp_int from full_data_type_table_idx  where tp_int in (2333, 601508558, 4294967296, 4294967295) order by id_dt ",
     "select tp_bigint from full_data_type_table_idx  where tp_bigint in (122222, -2902580959275580308, 9223372036854775807, 9223372036854775808) order by id_dt ",

--- a/core/src/test/scala/org/apache/spark/sql/expression/index/Join0Suite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/index/Join0Suite.scala
@@ -17,9 +17,9 @@
 
 package org.apache.spark.sql.expression.index
 
-import org.apache.spark.sql.BaseTiSparkSuite
+import org.apache.spark.sql.BaseInitialOnceSuite
 
-class Join0Suite extends BaseTiSparkSuite {
+class Join0Suite extends BaseInitialOnceSuite {
   private val allCases = Seq[String](
     "select a.id_dt from full_data_type_table_idx a join full_data_type_table_idx b on a.tp_decimal = b.tp_decimal",
     "select a.id_dt from full_data_type_table_idx a join full_data_type_table_idx b on a.id_dt = b.id_dt",

--- a/core/src/test/scala/org/apache/spark/sql/expression/index/PlaceHolder0Suite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/index/PlaceHolder0Suite.scala
@@ -17,9 +17,9 @@
 
 package org.apache.spark.sql.expression.index
 
-import org.apache.spark.sql.BaseTiSparkSuite
+import org.apache.spark.sql.BaseInitialOnceSuite
 
-class PlaceHolder0Suite extends BaseTiSparkSuite {
+class PlaceHolder0Suite extends BaseInitialOnceSuite {
   private val allCases = Seq[String](
     "select tp_tinyint from full_data_type_table_idx  where tp_tinyint = null",
     "select tp_tinyint from full_data_type_table_idx  where tp_tinyint = 'PingCAP'",

--- a/core/src/test/scala/org/apache/spark/sql/expression/index/PlaceHolder1Suite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/index/PlaceHolder1Suite.scala
@@ -17,9 +17,9 @@
 
 package org.apache.spark.sql.expression.index
 
-import org.apache.spark.sql.BaseTiSparkSuite
+import org.apache.spark.sql.BaseInitialOnceSuite
 
-class PlaceHolder1Suite extends BaseTiSparkSuite {
+class PlaceHolder1Suite extends BaseInitialOnceSuite {
   private val allCases = Seq[String](
     "select tp_decimal from full_data_type_table_idx  where tp_decimal > -128",
     "select tp_decimal from full_data_type_table_idx  where tp_decimal > 0",

--- a/core/src/test/scala/org/apache/spark/sql/expression/index/PlaceHolder2Suite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/index/PlaceHolder2Suite.scala
@@ -17,9 +17,9 @@
 
 package org.apache.spark.sql.expression.index
 
-import org.apache.spark.sql.BaseTiSparkSuite
+import org.apache.spark.sql.BaseInitialOnceSuite
 
-class PlaceHolder2Suite extends BaseTiSparkSuite {
+class PlaceHolder2Suite extends BaseInitialOnceSuite {
   private val allCases = Seq[String](
     "select tp_decimal from full_data_type_table_idx  where tp_decimal != null",
     "select tp_decimal from full_data_type_table_idx  where tp_decimal != 'PingCAP'",

--- a/core/src/test/scala/org/apache/spark/sql/expression/index/Special0Suite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/index/Special0Suite.scala
@@ -17,9 +17,9 @@
 
 package org.apache.spark.sql.expression.index
 
-import org.apache.spark.sql.BaseTiSparkSuite
+import org.apache.spark.sql.BaseInitialOnceSuite
 
-class Special0Suite extends BaseTiSparkSuite {
+class Special0Suite extends BaseInitialOnceSuite {
   private val allCases = Seq[String](
     "select * from full_data_type_table_idx where tp_date = date(date '2017-10-30')",
     "select * from full_data_type_table_idx where tp_date = date(date '2017-11-02')",

--- a/core/src/test/scala/org/apache/spark/sql/test/SharedSQLContext.scala
+++ b/core/src/test/scala/org/apache/spark/sql/test/SharedSQLContext.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.test.Utils._
 import org.apache.spark.sql._
 import org.apache.spark.{SparkConf, SparkFunSuite}
 import org.joda.time.DateTimeZone
-import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
+import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.Eventually
 import org.slf4j.Logger
 

--- a/core/src/test/scala/org/apache/spark/sql/test/TestSparkSession.scala
+++ b/core/src/test/scala/org/apache/spark/sql/test/TestSparkSession.scala
@@ -16,26 +16,20 @@
 package org.apache.spark.sql.test
 
 import org.apache.spark.sql.SparkSession
-import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.spark.SparkConf
 
 /**
  * A special [[SparkSession]] prepared for testing.
  */
-private[spark] class TestSparkSession(sc: SparkContext) extends SparkSession(sc) { self =>
-  def this(sparkConf: SparkConf) {
-    this(
-      new SparkContext(
-        "local[2]",
-        "tispark-integration-test",
-        sparkConf.set("spark.sql.testkey", "true")
-      )
-    )
-  }
+private[spark] class TestSparkSession(sparkConf: SparkConf) { self =>
+  private val spark = SparkSession
+    .builder()
+    .master("local[2]")
+    .appName("tispark-integration-test")
+    .config(sparkConf.set("spark.sql.testkey", "true"))
+    .getOrCreate()
+  SparkSession.setDefaultSession(spark)
+  SparkSession.setActiveSession(spark)
 
-  def this() {
-    this(new SparkConf)
-  }
-
-  SparkSession.setDefaultSession(this)
-  SparkSession.setActiveSession(this)
+  def session: SparkSession = spark
 }

--- a/core/src/test/scala/org/apache/spark/sql/test/TestSparkSession.scala
+++ b/core/src/test/scala/org/apache/spark/sql/test/TestSparkSession.scala
@@ -24,7 +24,7 @@ import org.apache.spark.SparkConf
 private[spark] class TestSparkSession(sparkConf: SparkConf) { self =>
   private val spark = SparkSession
     .builder()
-    .master("local[2]")
+    .master("local[*]")
     .appName("tispark-integration-test")
     .config(sparkConf.set("spark.sql.testkey", "true"))
     .getOrCreate()


### PR DESCRIPTION
Some TestSuites don't need to load data for each nested test. Speed up testing progress.