### PR TITLE
Fix PDClient generates incorrect tso request

### DIFF
--- a/core/src/main/scala/com/pingcap/tispark/TiTableReference.scala
+++ b/core/src/main/scala/com/pingcap/tispark/TiTableReference.scala
@@ -15,4 +15,6 @@
 
 package com.pingcap.tispark
 
-case class TiTableReference(databaseName: String, tableName: String, sizeInBytes: Long = Long.MaxValue)
+case class TiTableReference(databaseName: String,
+                            tableName: String,
+                            sizeInBytes: Long = Long.MaxValue)

--- a/core/src/main/scala/org/apache/spark/sql/extensions/TiParser.scala
+++ b/core/src/main/scala/org/apache/spark/sql/extensions/TiParser.scala
@@ -23,7 +23,10 @@ case class TiParser(getOrCreateTiContext: SparkSession => TiContext)(sparkSessio
       Some(tableIdentifier.database.getOrElse(tiContext.tiCatalog.getCurrentDatabase))
     )
 
-  private def notTempView(tableIdentifier: TableIdentifier) = tableIdentifier.database.isEmpty && tiContext.sessionCatalog.getTempView(tableIdentifier.table).isEmpty
+  private def notTempView(tableIdentifier: TableIdentifier) =
+    tableIdentifier.database.isEmpty && tiContext.sessionCatalog
+      .getTempView(tableIdentifier.table)
+      .isEmpty
 
   /**
    * WAR to lead Spark to consider this relation being on local files.
@@ -61,13 +64,12 @@ case class TiParser(getOrCreateTiContext: SparkSession => TiContext)(sparkSessio
     case e @ ExplainCommand(logicalPlan, _, _, _) =>
       e.copy(logicalPlan = logicalPlan.transform(qualifyTableIdentifier))
     case c @ CacheTableCommand(tableIdentifier, plan, _)
-      if plan.isEmpty && notTempView(tableIdentifier) =>
+        if plan.isEmpty && notTempView(tableIdentifier) =>
       // Caching an unqualified catalog table.
       c.copy(qualifyTableIdentifierInternal(tableIdentifier))
     case c @ CacheTableCommand(_, plan, _) if plan.isDefined =>
       c.copy(plan = Some(plan.get.transform(qualifyTableIdentifier)))
-    case u @ UncacheTableCommand(tableIdentifier, _)
-      if notTempView(tableIdentifier) =>
+    case u @ UncacheTableCommand(tableIdentifier, _) if notTempView(tableIdentifier) =>
       // Uncaching an unqualified catalog table.
       u.copy(qualifyTableIdentifierInternal(tableIdentifier))
   }

--- a/tikv-client/src/main/java/com/pingcap/tikv/PDClient.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/PDClient.java
@@ -319,7 +319,7 @@ public class PDClient extends AbstractGRPCClient<PDBlockingStub, PDStub>
     checkNotNull(resp, "Failed to init client for PD cluster.");
     long clusterId = resp.getHeader().getClusterId();
     header = RequestHeader.newBuilder().setClusterId(clusterId).build();
-    tsoReq = TsoRequest.newBuilder().setHeader(header).build();
+    tsoReq = TsoRequest.newBuilder().setHeader(header).setCount(1).build();
     this.pdAddrs = pdAddrs;
     createLeaderWrapper(resp.getLeader().getClientUrls(0));
     service = Executors.newSingleThreadScheduledExecutor(new ThreadFactoryBuilder().setDaemon(true).build());


### PR DESCRIPTION
Previously we didn't correctly used setCount to specify logical offset, thus it was default to 0 and we might retrieve same timestamp in a short period of time.