### PR TITLE
Fix unresolved column name when using table.column

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,6 @@ core/src/test/resources/tidb_config.properties
 python/build/
 python/dist/
 python/pytispark.egg-info/
+
+# ignore spark warehouse
+spark-warehouse

--- a/core/src/main/scala/org/apache/spark/sql/extensions/TiParser.scala
+++ b/core/src/main/scala/org/apache/spark/sql/extensions/TiParser.scala
@@ -50,7 +50,7 @@ case class TiParser(getOrCreateTiContext: SparkSession => TiContext)(sparkSessio
           .exists(_.isInstanceOf[TiSessionCatalog]) && notTempView(tableIdentifier) =>
       // Use SubqueryAlias so that projects and joins can correctly resolve
       // UnresolvedAttributes in JoinConditions, Projects, Filters, etc.
-      SubqueryAlias.apply(
+      SubqueryAlias(
         tableIdentifier.table,
         child = r.copy(qualifyTableIdentifierInternal(tableIdentifier))
       )

--- a/core/src/main/scala/org/apache/spark/sql/extensions/TiParser.scala
+++ b/core/src/main/scala/org/apache/spark/sql/extensions/TiParser.scala
@@ -41,7 +41,7 @@ case class TiParser(getOrCreateTiContext: SparkSession => TiContext)(sparkSessio
    * See [[org.apache.spark.sql.catalyst.analysis.Analyzer.ResolveRelations.resolveRelation]] for detail.
    *
    * Here we use transformUp when transforming logicalPlans because We should first
-   * deal with the leaf nodes, and a bottom-to-top regression is needed.
+   * deal with the leaf nodes, and a bottom-to-top recursion is needed.
    */
   private val qualifyTableIdentifier: PartialFunction[LogicalPlan, LogicalPlan] = {
     case r @ UnresolvedRelation(tableIdentifier)

--- a/core/src/main/scala/org/apache/spark/sql/extensions/TiParser.scala
+++ b/core/src/main/scala/org/apache/spark/sql/extensions/TiParser.scala
@@ -27,7 +27,7 @@ case class TiParser(getOrCreateTiContext: SparkSession => TiContext)(sparkSessio
   /**
    * Determines whether a table specified by tableIdentifier is
    * NOT a tempView registered. This is used for TiSpark to transform
-   * plans and decides whether a relation should be resolved of parsed.
+   * plans and decides whether a relation should be resolved or parsed.
    *
    * @param tableIdentifier tableIdentifier
    * @return whether it is not a tempView

--- a/core/src/main/scala/org/apache/spark/sql/extensions/TiParser.scala
+++ b/core/src/main/scala/org/apache/spark/sql/extensions/TiParser.scala
@@ -50,10 +50,7 @@ case class TiParser(getOrCreateTiContext: SparkSession => TiContext)(sparkSessio
           .exists(_.isInstanceOf[TiSessionCatalog]) && notTempView(tableIdentifier) =>
       // Use SubqueryAlias so that projects and joins can correctly resolve
       // UnresolvedAttributes in JoinConditions, Projects, Filters, etc.
-      SubqueryAlias(
-        tableIdentifier.table,
-        child = r.copy(qualifyTableIdentifierInternal(tableIdentifier))
-      )
+      SubqueryAlias(tableIdentifier.table, r.copy(qualifyTableIdentifierInternal(tableIdentifier)))
     case f @ Filter(condition, _) =>
       f.copy(
         condition = condition.transformUp {

--- a/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
@@ -19,6 +19,29 @@ import com.pingcap.tispark.TiConfigConst
 import org.apache.spark.sql.functions.{col, sum}
 
 class IssueTestSuite extends BaseTiSparkSuite {
+  test("cannot resolve column name when specifying table.column") {
+    spark
+      .sql(
+        "select full_data_type_table.id_dt from full_data_type_table"
+      )
+      .explain(true)
+    spark
+      .sql(
+        "select full_data_type_table.id_dt from full_data_type_table"
+      )
+      .show
+    spark
+      .sql(
+        "select full_data_type_table.id_dt from full_data_type_table join full_data_type_table_idx on full_data_type_table.id_dt = full_data_type_table_idx.id_dt"
+      )
+      .explain(true)
+    spark
+      .sql(
+        "select full_data_type_table.id_dt from full_data_type_table join full_data_type_table_idx on full_data_type_table.id_dt = full_data_type_table_idx.id_dt"
+      )
+      .show
+  }
+
   test("partition read") {
     tidbStmt.execute("DROP TABLE IF EXISTS `partition_t`")
     tidbStmt.execute("""

--- a/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
@@ -20,26 +20,16 @@ import org.apache.spark.sql.functions.{col, sum}
 
 class IssueTestSuite extends BaseTiSparkSuite {
   test("cannot resolve column name when specifying table.column") {
-    spark
-      .sql(
-        "select full_data_type_table.id_dt from full_data_type_table"
-      )
-      .explain(true)
-    spark
-      .sql(
-        "select full_data_type_table.id_dt from full_data_type_table"
-      )
-      .show
+    spark.sql("select full_data_type_table.id_dt from full_data_type_table").explain(true)
+    judge("select full_data_type_table.id_dt from full_data_type_table")
     spark
       .sql(
         "select full_data_type_table.id_dt from full_data_type_table join full_data_type_table_idx on full_data_type_table.id_dt = full_data_type_table_idx.id_dt"
       )
       .explain(true)
-    spark
-      .sql(
-        "select full_data_type_table.id_dt from full_data_type_table join full_data_type_table_idx on full_data_type_table.id_dt = full_data_type_table_idx.id_dt"
-      )
-      .show
+    judge(
+      "select full_data_type_table.id_dt from full_data_type_table join full_data_type_table_idx on full_data_type_table.id_dt = full_data_type_table_idx.id_dt"
+    )
   }
 
   test("partition read") {

--- a/tikv-client/src/main/java/com/pingcap/tikv/region/RegionStoreClient.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/region/RegionStoreClient.java
@@ -105,8 +105,7 @@ public class RegionStoreClient extends AbstractGRPCClient<TikvBlockingStub, Tikv
   // lockResolverClient, after implements the
   // write implementation of tispark, we can change
   // it to private
-  @VisibleForTesting
-  public final LockResolverClient lockResolverClient;
+  @VisibleForTesting public final LockResolverClient lockResolverClient;
   private TikvBlockingStub blockingStub;
   private TikvStub asyncStub;
 


### PR DESCRIPTION
Fix #511, the root cause is missing subquery alias when resolving `UnresolvedRelations`