### PR TITLE
Refactor resolve relations

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/extensions/TiParser.scala
+++ b/core/src/main/scala/org/apache/spark/sql/extensions/TiParser.scala
@@ -1,7 +1,6 @@
 package org.apache.spark.sql.extensions
 
 import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation
-import org.apache.spark.sql.catalyst.catalog.TiSessionCatalog
 import org.apache.spark.sql.catalyst.expressions.{Exists, Expression, ListQuery, NamedExpression, ScalarSubquery}
 import org.apache.spark.sql.catalyst.parser._
 import org.apache.spark.sql.catalyst.plans.logical._
@@ -15,7 +14,6 @@ case class TiParser(getOrCreateTiContext: SparkSession => TiContext)(sparkSessio
                                                                      delegate: ParserInterface)
     extends ParserInterface {
   private lazy val tiContext = getOrCreateTiContext(sparkSession)
-  private lazy val tiCatalog = tiContext.tiCatalog
   private lazy val internal = new SparkSqlParser(sparkSession.sqlContext.conf)
 
   private def qualifyTableIdentifierInternal(tableIdentifier: TableIdentifier): TableIdentifier =
@@ -26,70 +24,64 @@ case class TiParser(getOrCreateTiContext: SparkSession => TiContext)(sparkSessio
 
   /**
    * Determines whether a table specified by tableIdentifier is
-   * NOT a tempView registered. This is used for TiSpark to transform
+   * needs to be qualified. This is used for TiSpark to transform
    * plans and decides whether a relation should be resolved or parsed.
    *
    * @param tableIdentifier tableIdentifier
-   * @return whether it is not a tempView
+   * @return whether it needs qualifying
    */
-  private def notTempView(tableIdentifier: TableIdentifier) =
-    !tiCatalog.isTemporaryTable(tableIdentifier)
+  private def needQualify(tableIdentifier: TableIdentifier) =
+    tableIdentifier.database.isEmpty && tiContext.sessionCatalog
+      .getTempView(tableIdentifier.table)
+      .isEmpty
 
   /**
    * WAR to lead Spark to consider this relation being on local files.
    * Otherwise Spark will lookup this relation in his session catalog.
    * See [[org.apache.spark.sql.catalyst.analysis.Analyzer.ResolveRelations.resolveRelation]] for detail.
-   *
-   * Here we use transformUp when transforming logicalPlans because We should first
-   * deal with the leaf nodes, and a bottom-to-top recursion is needed.
    */
   private val qualifyTableIdentifier: PartialFunction[LogicalPlan, LogicalPlan] = {
-    case r @ UnresolvedRelation(tableIdentifier)
-        if tiCatalog
-          .catalogOf(tableIdentifier.database)
-          .exists(_.isInstanceOf[TiSessionCatalog]) && notTempView(tableIdentifier) =>
-      // Use SubqueryAlias so that projects and joins can correctly resolve
-      // UnresolvedAttributes in JoinConditions, Projects, Filters, etc.
-      SubqueryAlias(tableIdentifier.table, r.copy(qualifyTableIdentifierInternal(tableIdentifier)))
+    case r @ UnresolvedRelation(tableIdentifier) if needQualify(tableIdentifier) =>
+      r.copy(qualifyTableIdentifierInternal(tableIdentifier))
     case f @ Filter(condition, _) =>
       f.copy(
-        condition = condition.transformUp {
-          case e @ Exists(plan, _, _) => e.copy(plan = plan.transformUp(qualifyTableIdentifier))
+        condition = condition.transform {
+          case e @ Exists(plan, _, _) => e.copy(plan = plan.transform(qualifyTableIdentifier))
           case ls @ ListQuery(plan, _, _, _) =>
-            ls.copy(plan = plan.transformUp(qualifyTableIdentifier))
+            ls.copy(plan = plan.transform(qualifyTableIdentifier))
           case s @ ScalarSubquery(plan, _, _) =>
-            s.copy(plan = plan.transformUp(qualifyTableIdentifier))
+            s.copy(plan = plan.transform(qualifyTableIdentifier))
         }
       )
     case p @ Project(projectList, _) =>
       p.copy(
-        projectList = projectList.map(_.transformUp {
+        projectList = projectList.map(_.transform {
           case s @ ScalarSubquery(plan, _, _) =>
-            s.copy(plan = plan.transformUp(qualifyTableIdentifier))
+            s.copy(plan = plan.transform(qualifyTableIdentifier))
         }.asInstanceOf[NamedExpression])
       )
     case w @ With(_, cteRelations) =>
       w.copy(
         cteRelations = cteRelations
-          .map(p => (p._1, p._2.transformUp(qualifyTableIdentifier).asInstanceOf[SubqueryAlias]))
+          .map(p => (p._1, p._2.transform(qualifyTableIdentifier).asInstanceOf[SubqueryAlias]))
       )
     case cv @ CreateViewCommand(_, _, _, _, _, child, _, _, _) =>
-      cv.copy(child = child.transformUp(qualifyTableIdentifier))
+      cv.copy(child = child.transform(qualifyTableIdentifier))
     case e @ ExplainCommand(logicalPlan, _, _, _) =>
-      e.copy(logicalPlan = logicalPlan.transformUp(qualifyTableIdentifier))
+      e.copy(logicalPlan = logicalPlan.transform(qualifyTableIdentifier))
     case c @ CacheTableCommand(tableIdentifier, plan, _)
-        if plan.isEmpty && notTempView(tableIdentifier) =>
+        if plan.isEmpty && needQualify(tableIdentifier) =>
       // Caching an unqualified catalog table.
       c.copy(qualifyTableIdentifierInternal(tableIdentifier))
     case c @ CacheTableCommand(_, plan, _) if plan.isDefined =>
-      c.copy(plan = Some(plan.get.transformUp(qualifyTableIdentifier)))
-    case u @ UncacheTableCommand(tableIdentifier, _) if notTempView(tableIdentifier) =>
+      c.copy(plan = Some(plan.get.transform(qualifyTableIdentifier)))
+    case u @ UncacheTableCommand(tableIdentifier, _) if needQualify(tableIdentifier) =>
       // Uncaching an unqualified catalog table.
       u.copy(qualifyTableIdentifierInternal(tableIdentifier))
   }
 
   override def parsePlan(sqlText: String): LogicalPlan =
-    internal.parsePlan(sqlText).transformUp(qualifyTableIdentifier)
+    internal.parsePlan(sqlText).transform(qualifyTableIdentifier)
 
   override def parseExpression(sqlText: String): Expression =
     internal.parseExpression(sqlText)


### PR DESCRIPTION
In #512, we resolved column names from `UnresolvedRelations` by wrapping it with `SubqueryAlias`.

We now refactor this logic so that the qualification phrase and resolving phrase are separated more elegantly.