### PR TITLE
Fix LockResolverTest error when sending requests using callWithRetry

### DIFF
--- a/tikv-client/src/test/java/com/pingcap/tikv/txn/LockResolverTest.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/txn/LockResolverTest.java
@@ -205,7 +205,7 @@ public class LockResolverTest {
               resp -> resp.hasRegionError() ? resp.getRegionError() : null);
 
       CommitResponse resp =
-          client.lockResolverClient.callWithRetry(
+          client.callWithRetry(
               backOffer, TikvGrpc.METHOD_KV_COMMIT, factory, handler);
 
       if (resp.hasRegionError()) {


### PR DESCRIPTION
It causes possible unlimited retry because KVErrorHandler fails to update region/store information.