### PR TITLE
Adding set and enum support

### DIFF
--- a/core/src/main/scala/com/pingcap/tispark/TiUtils.scala
+++ b/core/src/main/scala/com/pingcap/tispark/TiUtils.scala
@@ -139,8 +139,8 @@ object TiUtils {
       case _: DateTimeType  => sql.types.TimestampType
       case _: TimestampType => sql.types.TimestampType
       case _: DateType      => sql.types.DateType
-      case _: EnumType      => sql.types.LongType
-      case _: SetType       => sql.types.LongType
+      case _: EnumType      => sql.types.StringType
+      case _: SetType       => sql.types.StringType
       case _: YearType      => sql.types.LongType
       case _: JsonType      => sql.types.StringType
     }

--- a/core/src/main/scala/org/apache/spark/sql/TiStrategy.scala
+++ b/core/src/main/scala/org/apache/spark/sql/TiStrategy.scala
@@ -64,7 +64,7 @@ case class TiStrategy(getOrCreateTiContext: SparkSession => TiContext)(sparkSess
 
   def typeBlackList: TypeBlacklist = {
     val blacklistString =
-      sqlConf.getConfString(TiConfigConst.UNSUPPORTED_TYPES, "time,enum,set,year")
+      sqlConf.getConfString(TiConfigConst.UNSUPPORTED_TYPES, "time,year")
     new TypeBlacklist(blacklistString)
   }
 

--- a/core/src/test/resources/tidb_config.properties.template
+++ b/core/src/test/resources/tidb_config.properties.template
@@ -1,0 +1,18 @@
+# TiDB address
+# tidb.addr=127.0.0.1
+# TiDB port
+# tidb.port=4000
+# TiDB login user
+# tidb.user=root
+# TiDB login password
+# tidb.password=
+# TPCH database name, if you already have a tpch database in TiDB, specify the db name so that TPCH tests will run on this database
+# tpch.db=tpch_test
+# Placement Driver address:port
+# spark.tispark.pd.addresses=127.0.0.1:2379
+# Whether to allow index read in tests, you must set this to true to run index tests.
+# spark.tispark.plan.allow_index_read=true
+# Whether to load test data before running tests. If you haven't load tispark_test or tpch_test data, set this to true. The next time you run tests, you can set this to false.
+# test.data.load=false
+# DB prefix for tidb databases in case it conflicts with hive database
+# spark.tispark.db_prefix=tidb_ 

--- a/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
@@ -19,17 +19,21 @@ import com.pingcap.tispark.TiConfigConst
 import org.apache.spark.sql.functions.{col, sum}
 
 class IssueTestSuite extends BaseTiSparkSuite {
-  test("adding set and enum"){
-    tidbStmt.execute("drop table set_t if exists ")
-    tidbStmt.execute("drop table enum_t if exists")
-    tidbStmt.execute("CREATE TABLE `set_t` (" +
-      "`priority` set('Low','Medium','High') NOT NULL," +
-      " PRIMARY KEY (`id`));")
-    judge("select * from set_t")
-    tidbStmt.execute("CREATE TABLE `enum_t` (" +
-      "`priority` set('Low','Medium','High') NOT NULL," +
-      " PRIMARY KEY (`id`));")
-    judge("select * from enum_t")
+  test("adding set and enum") {
+    tidbStmt.execute("drop table if exists set_t")
+    tidbStmt.execute("drop table if exists enum_t")
+    tidbStmt.execute(
+      "CREATE TABLE `set_t` (" +
+        "`priority` set('Low','Medium','High') NOT NULL);"
+    )
+    tidbStmt.execute("INSERT INTO set_t(priority) VALUES('High');")
+    judge("select * from set_t;")
+    tidbStmt.execute(
+      "CREATE TABLE `enum_t` (" +
+        "`priority` set('Low','Medium','High') NOT NULL);"
+    )
+    tidbStmt.execute("INSERT INTO enum_t(priority) VALUES('High');")
+    judge("select * from enum_t;")
   }
   test("cannot resolve column name when specifying table.column") {
     spark.sql("select full_data_type_table.id_dt from full_data_type_table").explain(true)

--- a/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
@@ -29,8 +29,6 @@ class IssueTestSuite extends BaseTiSparkSuite {
     tidbStmt.execute("INSERT INTO set_t(priority) VALUES('High')")
     tidbStmt.execute("INSERT INTO set_t(priority) VALUES('Medium')")
     tidbStmt.execute("INSERT INTO set_t(priority) VALUES('Low')")
-    judge("select * from set_t")
-    judge("select * from set_t where priority = 'High'")
     tidbStmt.execute(
       "CREATE TABLE `enum_t` (" +
         "`priority` set('Low','Medium','High') NOT NULL)"
@@ -38,6 +36,9 @@ class IssueTestSuite extends BaseTiSparkSuite {
     tidbStmt.execute("INSERT INTO enum_t(priority) VALUES('High')")
     tidbStmt.execute("INSERT INTO enum_t(priority) VALUES('Medium')")
     tidbStmt.execute("INSERT INTO enum_t(priority) VALUES('Low')")
+    refreshConnections()
+    judge("select * from set_t")
+    judge("select * from set_t where priority = 'High'")
     judge("select * from enum_t")
     judge("select * from enum_t where priority = 'High'")
   }

--- a/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
@@ -27,13 +27,19 @@ class IssueTestSuite extends BaseTiSparkSuite {
         "`priority` set('Low','Medium','High') NOT NULL);"
     )
     tidbStmt.execute("INSERT INTO set_t(priority) VALUES('High');")
+    tidbStmt.execute("INSERT INTO set_t(priority) VALUES('Medium');")
+    tidbStmt.execute("INSERT INTO set_t(priority) VALUES('Low');")
     judge("select * from set_t;")
+    judge("select * from set_t where priority = 'High';")
     tidbStmt.execute(
       "CREATE TABLE `enum_t` (" +
         "`priority` set('Low','Medium','High') NOT NULL);"
     )
     tidbStmt.execute("INSERT INTO enum_t(priority) VALUES('High');")
+    tidbStmt.execute("INSERT INTO enum_t(priority) VALUES('Medium');")
+    tidbStmt.execute("INSERT INTO enum_t(priority) VALUES('Low');")
     judge("select * from enum_t;")
+    judge("select * from enum_t where priority = 'High';")
   }
   test("cannot resolve column name when specifying table.column") {
     spark.sql("select full_data_type_table.id_dt from full_data_type_table").explain(true)

--- a/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
@@ -24,23 +24,24 @@ class IssueTestSuite extends BaseTiSparkSuite {
     tidbStmt.execute("drop table if exists enum_t")
     tidbStmt.execute(
       "CREATE TABLE `set_t` (" +
-        "`priority` set('Low','Medium','High') NOT NULL);"
+        "`priority` set('Low','Medium','High') NOT NULL)"
     )
-    tidbStmt.execute("INSERT INTO set_t(priority) VALUES('High');")
-    tidbStmt.execute("INSERT INTO set_t(priority) VALUES('Medium');")
-    tidbStmt.execute("INSERT INTO set_t(priority) VALUES('Low');")
-    judge("select * from set_t;")
-    judge("select * from set_t where priority = 'High';")
+    tidbStmt.execute("INSERT INTO set_t(priority) VALUES('High')")
+    tidbStmt.execute("INSERT INTO set_t(priority) VALUES('Medium')")
+    tidbStmt.execute("INSERT INTO set_t(priority) VALUES('Low')")
+    judge("select * from set_t")
+    judge("select * from set_t where priority = 'High'")
     tidbStmt.execute(
       "CREATE TABLE `enum_t` (" +
-        "`priority` set('Low','Medium','High') NOT NULL);"
+        "`priority` set('Low','Medium','High') NOT NULL)"
     )
-    tidbStmt.execute("INSERT INTO enum_t(priority) VALUES('High');")
-    tidbStmt.execute("INSERT INTO enum_t(priority) VALUES('Medium');")
-    tidbStmt.execute("INSERT INTO enum_t(priority) VALUES('Low');")
-    judge("select * from enum_t;")
-    judge("select * from enum_t where priority = 'High';")
+    tidbStmt.execute("INSERT INTO enum_t(priority) VALUES('High')")
+    tidbStmt.execute("INSERT INTO enum_t(priority) VALUES('Medium')")
+    tidbStmt.execute("INSERT INTO enum_t(priority) VALUES('Low')")
+    judge("select * from enum_t")
+    judge("select * from enum_t where priority = 'High'")
   }
+
   test("cannot resolve column name when specifying table.column") {
     spark.sql("select full_data_type_table.id_dt from full_data_type_table").explain(true)
     judge("select full_data_type_table.id_dt from full_data_type_table")

--- a/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
@@ -19,7 +19,18 @@ import com.pingcap.tispark.TiConfigConst
 import org.apache.spark.sql.functions.{col, sum}
 
 class IssueTestSuite extends BaseTiSparkSuite {
-
+  test("adding set and enum"){
+    tidbStmt.execute("drop table set_t if exists ")
+    tidbStmt.execute("drop table enum_t if exists")
+    tidbStmt.execute("CREATE TABLE `set_t` (" +
+      "`priority` set('Low','Medium','High') NOT NULL," +
+      " PRIMARY KEY (`id`));")
+    judge("select * from set_t")
+    tidbStmt.execute("CREATE TABLE `enum_t` (" +
+      "`priority` set('Low','Medium','High') NOT NULL," +
+      " PRIMARY KEY (`id`));")
+    judge("select * from enum_t")
+  }
   test("cannot resolve column name when specifying table.column") {
     spark.sql("select full_data_type_table.id_dt from full_data_type_table").explain(true)
     judge("select full_data_type_table.id_dt from full_data_type_table")

--- a/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
@@ -376,6 +376,8 @@ class IssueTestSuite extends BaseTiSparkSuite {
       tidbStmt.execute("drop table if exists t2")
       tidbStmt.execute("drop table if exists single_read")
       tidbStmt.execute("DROP TABLE IF EXISTS `partition_t`")
+      tidbStmt.execute("drop table if exists set_t")
+      tidbStmt.execute("drop table if exists enum_t")
     } finally {
       super.afterAll()
     }

--- a/core/src/test/scala/org/apache/spark/sql/catalyst/catalog/CatalogTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/catalyst/catalog/CatalogTestSuite.scala
@@ -72,8 +72,8 @@ class CatalogTestSuite extends BaseTiSparkSuite {
         List("tp_tinytext", "string", "true", null),
         List("tp_bit", "bigint", "true", null),
         List("tp_time", "timestamp", "true", null),
-        List("tp_enum", "bigint", "true", null),
-        List("tp_set", "bigint", "true", null)
+        List("tp_enum", "string", "true", null),
+        List("tp_set", "string", "true", null)
       )
     setCurrentDatabase("tispark_test")
     spark.sql("desc full_data_type_table").explain(true)

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/EnumType.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/EnumType.java
@@ -16,15 +16,13 @@
 package com.pingcap.tikv.types;
 
 import com.pingcap.tidb.tipb.ExprType;
+import com.pingcap.tikv.codec.Codec;
+import com.pingcap.tikv.codec.Codec.IntegerCodec;
 import com.pingcap.tikv.codec.CodecDataInput;
 import com.pingcap.tikv.codec.CodecDataOutput;
-import com.pingcap.tikv.exception.UnsupportedTypeException;
+import com.pingcap.tikv.exception.TypeException;
 import com.pingcap.tikv.meta.TiColumnInfo;
 
-/**
- * TODO: Support Enum Type EnumType class is set now only to indicate this type exists, so that we
- * could throw UnsupportedTypeException when encountered. Its logic is not yet implemented.
- */
 public class EnumType extends DataType {
   public static final EnumType ENUM = new EnumType(MySQLType.TypeEnum);
 
@@ -41,25 +39,26 @@ public class EnumType extends DataType {
   /** {@inheritDoc} */
   @Override
   protected Object decodeNotNull(int flag, CodecDataInput cdi) {
-    throw new UnsupportedTypeException("Enum type not supported");
+    if (flag != Codec.UINT_FLAG) throw new TypeException("Invalid IntegerType flag: " + flag);
+    return IntegerCodec.readULong(cdi);
   }
 
   /** {@inheritDoc} Enum is encoded as unsigned int64 with its 0-based value. */
   @Override
   protected void encodeKey(CodecDataOutput cdo, Object value) {
-    throw new UnsupportedTypeException("Enum type not supported");
+    IntegerCodec.writeULongFully(cdo, Converter.convertToLong(value), true);
   }
 
   /** {@inheritDoc} Enum is encoded as unsigned int64 with its 0-based value. */
   @Override
   protected void encodeValue(CodecDataOutput cdo, Object value) {
-    throw new UnsupportedTypeException("Enum type not supported");
+    IntegerCodec.writeULongFully(cdo, Converter.convertToLong(value), false);
   }
 
   /** {@inheritDoc} */
   @Override
   protected void encodeProto(CodecDataOutput cdo, Object value) {
-    throw new UnsupportedTypeException("Enum type not supported");
+    IntegerCodec.writeULong(cdo, Converter.convertToLong(value));
   }
 
   @Override

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/EnumType.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/EnumType.java
@@ -41,7 +41,10 @@ public class EnumType extends DataType {
   @Override
   protected Object decodeNotNull(int flag, CodecDataInput cdi) {
     if (flag != Codec.UVARINT_FLAG) throw new TypeException("Invalid IntegerType flag: " + flag);
-    return this.getElems().get((int) IntegerCodec.readUVarLong(cdi) - 1);
+    int idx = (int) IntegerCodec.readUVarLong(cdi) - 1;
+    if (idx > this.getElems().size()) throw new TypeException("Index is out of range, better "
+        + "take a look at tidb side.");
+    return this.getElems().get(idx);
   }
 
   /** {@inheritDoc} Enum is encoded as unsigned int64 with its 0-based value. */

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/EnumType.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/EnumType.java
@@ -39,8 +39,8 @@ public class EnumType extends DataType {
   /** {@inheritDoc} */
   @Override
   protected Object decodeNotNull(int flag, CodecDataInput cdi) {
-    if (flag != Codec.UINT_FLAG) throw new TypeException("Invalid IntegerType flag: " + flag);
-    return IntegerCodec.readULong(cdi);
+    if (flag != Codec.UVARINT_FLAG) throw new TypeException("Invalid IntegerType flag: " + flag);
+    return this.getElems().get((int) IntegerCodec.readUVarLong(cdi) - 1);
   }
 
   /** {@inheritDoc} Enum is encoded as unsigned int64 with its 0-based value. */

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/EnumType.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/EnumType.java
@@ -21,6 +21,7 @@ import com.pingcap.tikv.codec.Codec.IntegerCodec;
 import com.pingcap.tikv.codec.CodecDataInput;
 import com.pingcap.tikv.codec.CodecDataOutput;
 import com.pingcap.tikv.exception.TypeException;
+import com.pingcap.tikv.exception.UnsupportedTypeException;
 import com.pingcap.tikv.meta.TiColumnInfo;
 
 public class EnumType extends DataType {
@@ -46,19 +47,19 @@ public class EnumType extends DataType {
   /** {@inheritDoc} Enum is encoded as unsigned int64 with its 0-based value. */
   @Override
   protected void encodeKey(CodecDataOutput cdo, Object value) {
-    IntegerCodec.writeULongFully(cdo, Converter.convertToLong(value), true);
+    throw new UnsupportedTypeException("Enum type cannot be pushed down.");
   }
 
   /** {@inheritDoc} Enum is encoded as unsigned int64 with its 0-based value. */
   @Override
   protected void encodeValue(CodecDataOutput cdo, Object value) {
-    IntegerCodec.writeULongFully(cdo, Converter.convertToLong(value), false);
+    throw new UnsupportedTypeException("Enum type cannot be pushed down.");
   }
 
   /** {@inheritDoc} */
   @Override
   protected void encodeProto(CodecDataOutput cdo, Object value) {
-    IntegerCodec.writeULong(cdo, Converter.convertToLong(value));
+    throw new UnsupportedTypeException("Enum type cannot be pushed down.");
   }
 
   @Override

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/EnumType.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/EnumType.java
@@ -42,7 +42,7 @@ public class EnumType extends DataType {
   protected Object decodeNotNull(int flag, CodecDataInput cdi) {
     if (flag != Codec.UVARINT_FLAG) throw new TypeException("Invalid IntegerType flag: " + flag);
     int idx = (int) IntegerCodec.readUVarLong(cdi) - 1;
-    if (idx > this.getElems().size()) throw new TypeException("Index is out of range, better "
+    if (idx <0 || idx > this.getElems().size()) throw new TypeException("Index is out of range, better "
         + "take a look at tidb side.");
     return this.getElems().get(idx);
   }

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/SetType.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/SetType.java
@@ -21,6 +21,7 @@ import com.pingcap.tikv.codec.Codec.IntegerCodec;
 import com.pingcap.tikv.codec.CodecDataInput;
 import com.pingcap.tikv.codec.CodecDataOutput;
 import com.pingcap.tikv.exception.TypeException;
+import com.pingcap.tikv.exception.UnsupportedTypeException;
 import com.pingcap.tikv.meta.TiColumnInfo;
 import java.util.ArrayList;
 import java.util.List;
@@ -67,6 +68,7 @@ public class SetType extends DataType {
     for (int i = 0; i < this.getElems().size(); i++) {
       if ((number & setIndexValue[i]) > 0) {
         items.add(this.getElems().get(i));
+        number &= setIndexInvertValue[i];
       }
     }
 
@@ -80,19 +82,19 @@ public class SetType extends DataType {
   /** {@inheritDoc} */
   @Override
   protected void encodeKey(CodecDataOutput cdo, Object value) {
-    IntegerCodec.writeULongFully(cdo, Converter.convertToLong(value), true);
+    throw new UnsupportedTypeException("Set type cannot be pushed down.");
   }
 
   /** {@inheritDoc} */
   @Override
   protected void encodeValue(CodecDataOutput cdo, Object value) {
-    IntegerCodec.writeULongFully(cdo, Converter.convertToLong(value), false);
+    throw new UnsupportedTypeException("Set type cannot be pushed down.");
   }
 
   /** {@inheritDoc} */
   @Override
   protected void encodeProto(CodecDataOutput cdo, Object value) {
-    IntegerCodec.writeULong(cdo, Converter.convertToLong(value));
+    throw new UnsupportedTypeException("Set type cannot be pushed down.");
   }
 
   @Override

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/SetType.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/SetType.java
@@ -62,8 +62,6 @@ public class SetType extends DataType {
   @Override
   protected Object decodeNotNull(int flag, CodecDataInput cdi) {
     if (flag != Codec.UVARINT_FLAG) throw new TypeException("Invalid IntegerType flag: " + flag);
-    // When it comes to the last element of elems, index decoded from cid is alwasy
-    // larger than 2 rather than 1.
     int number = (int) IntegerCodec.readUVarLong(cdi);
     List<String> items = new ArrayList<>();
     for (int i = 0; i < this.getElems().size(); i++) {

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/SetType.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/SetType.java
@@ -39,8 +39,8 @@ public class SetType extends DataType {
   /** {@inheritDoc} */
   @Override
   protected Object decodeNotNull(int flag, CodecDataInput cdi) {
-    if (flag != Codec.UINT_FLAG) throw new TypeException("Invalid IntegerType flag: " + flag);
-    return IntegerCodec.readULong(cdi);
+    if (flag != Codec.UVARINT_FLAG) throw new TypeException("Invalid IntegerType flag: " + flag);
+    return this.getElems().get((int) IntegerCodec.readUVarLong(cdi) - 2);
   }
 
   /** {@inheritDoc} */

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/SetType.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/SetType.java
@@ -16,17 +16,13 @@
 package com.pingcap.tikv.types;
 
 import com.pingcap.tidb.tipb.ExprType;
+import com.pingcap.tikv.codec.Codec;
+import com.pingcap.tikv.codec.Codec.IntegerCodec;
 import com.pingcap.tikv.codec.CodecDataInput;
 import com.pingcap.tikv.codec.CodecDataOutput;
-import com.pingcap.tikv.exception.UnsupportedTypeException;
+import com.pingcap.tikv.exception.TypeException;
 import com.pingcap.tikv.meta.TiColumnInfo;
 
-/**
- * TODO: Support Set Type SetType class is set now only to indicate this type exists, so that we
- * could throw UnsupportedTypeException when encountered. Its logic is not yet implemented.
- *
- * <p>Set is encoded as unsigned int64 with its 0-based value.
- */
 public class SetType extends DataType {
   public static final SetType SET = new SetType(MySQLType.TypeSet);
 
@@ -43,25 +39,26 @@ public class SetType extends DataType {
   /** {@inheritDoc} */
   @Override
   protected Object decodeNotNull(int flag, CodecDataInput cdi) {
-    throw new UnsupportedTypeException("Set type not supported");
+    if (flag != Codec.UINT_FLAG) throw new TypeException("Invalid IntegerType flag: " + flag);
+    return IntegerCodec.readULong(cdi);
   }
 
   /** {@inheritDoc} */
   @Override
   protected void encodeKey(CodecDataOutput cdo, Object value) {
-    throw new UnsupportedTypeException("Set type not supported");
+    IntegerCodec.writeULongFully(cdo, Converter.convertToLong(value), true);
   }
 
   /** {@inheritDoc} */
   @Override
   protected void encodeValue(CodecDataOutput cdo, Object value) {
-    throw new UnsupportedTypeException("Set type not supported");
+    IntegerCodec.writeULongFully(cdo, Converter.convertToLong(value), false);
   }
 
   /** {@inheritDoc} */
   @Override
   protected void encodeProto(CodecDataOutput cdo, Object value) {
-    throw new UnsupportedTypeException("Set type not supported");
+    IntegerCodec.writeULong(cdo, Converter.convertToLong(value));
   }
 
   @Override

--- a/tikv-client/src/test/java/com/pingcap/tikv/codec/CodecTest.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/codec/CodecTest.java
@@ -526,7 +526,4 @@ public class CodecTest {
     time2 = DateTimeCodec.readFromUVarInt(cdi, otherTz);
     assertEquals(time.getMillis(), time2.getMillis());
   }
-
-  @Test
-  public void testEnumAndSet() {}
 }

--- a/tikv-client/src/test/java/com/pingcap/tikv/codec/CodecTest.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/codec/CodecTest.java
@@ -526,4 +526,7 @@ public class CodecTest {
     time2 = DateTimeCodec.readFromUVarInt(cdi, otherTz);
     assertEquals(time.getMillis(), time2.getMillis());
   }
+
+  @Test
+  public void testEnumAndSet() {}
 }

--- a/tikv-client/src/test/java/com/pingcap/tikv/types/DataTypeFactoryTest.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/types/DataTypeFactoryTest.java
@@ -37,7 +37,7 @@ public class DataTypeFactoryTest {
   }
 
   @Test
-  public void of() throws Exception {
+  public void of() {
     mappingTest(MySQLType.TypeBit, BitType.class);
     mappingTest(MySQLType.TypeLong, IntegerType.class);
     mappingTest(MySQLType.TypeTiny, IntegerType.class);

--- a/tikv-client/src/test/java/com/pingcap/tikv/types/RealTypeTest.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/types/RealTypeTest.java
@@ -26,7 +26,7 @@ import org.junit.Test;
 
 public class RealTypeTest {
   @Test
-  public void encodeTest() throws Exception {
+  public void encodeTest() {
     DataType type = RealType.DOUBLE;
     double originalVal = 666.66;
     byte[] encodedKey = encode(originalVal, EncodeType.KEY, type);


### PR DESCRIPTION
This PR let spark can read table with set or enum type. 
```
CREATE TABLE `set` (
  `id` int(11) NOT NULL AUTO_INCREMENT,
  `title` varchar(255) NOT NULL,
  `priority` set('Low','Medium','High') NOT NULL,
  PRIMARY KEY (`id`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin AUTO_INCREMENT=30001
```

For above table, before this PR, spark cannot read. But it can after this PR. 