### PR TITLE
Add spark reference pattern

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/TiStrategy.scala
+++ b/core/src/main/scala/org/apache/spark/sql/TiStrategy.scala
@@ -44,12 +44,16 @@ import org.apache.spark.sql.types._
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 
-// TODO: Too many hacks here since we hijack the planning
-// but we don't have full control over planning stage
-// We cannot pass context around during planning so
-// a re-extract needed for push-down since
-// a plan tree might contain Join which causes a single tree
-// have multiple plans to push-down
+/**
+ * CHECK Spark [[org.apache.spark.sql.Strategy]]
+ *
+ * TODO: Too many hacks here since we hijack the planning
+ * but we don't have full control over planning stage
+ * We cannot pass context around during planning so
+ * a re-extract needed for push-down since
+ * a plan tree might contain Join which causes a single tree
+ * have multiple plans to push-down
+ */
 case class TiStrategy(getOrCreateTiContext: SparkSession => TiContext)(sparkSession: SparkSession)
     extends Strategy
     with Logging {

--- a/core/src/main/scala/org/apache/spark/sql/execution/command/databases.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/command/databases.scala
@@ -17,7 +17,7 @@ package org.apache.spark.sql.execution.command
 import org.apache.spark.sql.{Row, SparkSession, TiContext}
 
 /**
- * Overwrites [[org.apache.spark.sql.execution.command.SetDatabaseCommand]]
+ * CHECK Spark [[org.apache.spark.sql.execution.command.SetDatabaseCommand]]
  *
  * @param tiContext tiContext which contains our catalog info
  * @param delegate original SetDatabaseCommand
@@ -31,7 +31,7 @@ case class TiSetDatabaseCommand(tiContext: TiContext, delegate: SetDatabaseComma
 }
 
 /**
- * Overwrites [[org.apache.spark.sql.execution.command.ShowDatabasesCommand]]
+ * CHECK Spark [[org.apache.spark.sql.execution.command.ShowDatabasesCommand]]
  *
  * @param tiContext tiContext which contains our catalog info
  * @param delegate original ShowDatabasesCommand

--- a/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
@@ -23,7 +23,7 @@ import org.apache.spark.sql.{AnalysisException, Row, SparkSession, TiContext}
 import scala.collection.mutable.ArrayBuffer
 
 /**
- * Overwrites [[org.apache.spark.sql.execution.command.ShowTablesCommand]]
+ * CHECK Spark [[org.apache.spark.sql.execution.command.ShowTablesCommand]]
  *
  * @param tiContext tiContext which contains our catalog info
  * @param delegate original ShowTablesCommand
@@ -52,7 +52,7 @@ case class TiShowTablesCommand(tiContext: TiContext, delegate: ShowTablesCommand
 }
 
 /**
- * Overwrites [[org.apache.spark.sql.execution.command.DescribeTableCommand]]
+ * CHECK Spark [[org.apache.spark.sql.execution.command.DescribeTableCommand]]
  *
  * @param tiContext tiContext which contains our catalog info
  * @param delegate original DescribeTableCommand

--- a/core/src/main/scala/org/apache/spark/sql/extensions/parser.scala
+++ b/core/src/main/scala/org/apache/spark/sql/extensions/parser.scala
@@ -52,7 +52,7 @@ case class TiParser(getOrCreateTiContext: SparkSession => TiContext)(sparkSessio
   /**
    * WAR to lead Spark to consider this relation being on local files.
    * Otherwise Spark will lookup this relation in his session catalog.
-   * See [[org.apache.spark.sql.catalyst.analysis.Analyzer.ResolveRelations.resolveRelation]] for detail.
+   * CHECK Spark [[org.apache.spark.sql.catalyst.analysis.Analyzer.ResolveRelations.resolveRelation]] for details.
    */
   private val qualifyTableIdentifier: PartialFunction[LogicalPlan, LogicalPlan] = {
     case r @ UnresolvedRelation(tableIdentifier) if needQualify(tableIdentifier) =>


### PR DESCRIPTION
Use `CHECK Spark` pattern when we reference Spark classes. So that we ca find the references when we update Spark version quickly.