### PR TITLE
Add DateCodec tests to achieve full coverage in codec code path

### DIFF
--- a/tikv-client/src/main/java/com/pingcap/tikv/catalog/CatalogTransaction.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/catalog/CatalogTransaction.java
@@ -114,6 +114,9 @@ public class CatalogTransaction {
     List<Pair<ByteString, ByteString>> fields = new ArrayList<>();
     while (iterator.hasNext()) {
       Kvrpcpb.KvPair kv = iterator.next();
+      if (kv == null || kv.getKey() == null) {
+        continue;
+      }
       if (!KeyUtils.hasPrefix(kv.getKey(), encodedKey)) {
         break;
       }

--- a/tikv-client/src/main/java/com/pingcap/tikv/codec/CodecDataInput.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/codec/CodecDataInput.java
@@ -36,13 +36,6 @@ public class CodecDataInput implements DataInput {
       this.count = buf.length;
     }
 
-    public UnSyncByteArrayInputStream(byte buf[], int offset, int length) {
-      this.buf = buf;
-      this.pos = offset;
-      this.count = Math.min(offset + length, buf.length);
-      this.mark = offset;
-    }
-
     public int read() {
       return (pos < count) ? (buf[pos++] & 0xff) : -1;
     }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/15857134/50534831-7861be80-0b7d-11e9-9295-8a892669c473.png)
CodeDataInput and CodeDataOutput are implemented by DataInput and DataOutput. So they will not be counted in coverage.