### PR TITLE
Add retry for getRegion requests when regionId returns 0

### DIFF
--- a/tikv-client/src/main/java/com/pingcap/tikv/PDClient.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/PDClient.java
@@ -16,6 +16,8 @@
 package com.pingcap.tikv;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.pingcap.tikv.operation.PDErrorHandler.getRegionResponseErrorExtractor;
+import static com.pingcap.tikv.pd.PDError.buildFromPdpbError;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.net.HostAndPort;
@@ -70,7 +72,9 @@ public class PDClient extends AbstractGRPCClient<PDBlockingStub, PDStub>
     Supplier<TsoRequest> request = () -> tsoReq;
 
     PDErrorHandler<TsoResponse> handler =
-        new PDErrorHandler<>(r -> r.getHeader().hasError() ? r.getHeader().getError() : null, this);
+        new PDErrorHandler<>(
+            r -> r.getHeader().hasError() ? buildFromPdpbError(r.getHeader().getError()) : null,
+            this);
 
     TsoResponse resp = callWithRetry(backOffer, PDGrpc.METHOD_TSO, request, handler);
     Timestamp timestamp = resp.getTimestamp();
@@ -87,7 +91,7 @@ public class PDClient extends AbstractGRPCClient<PDBlockingStub, PDStub>
         () -> GetRegionRequest.newBuilder().setHeader(header).setRegionKey(encodedKey).build();
 
     PDErrorHandler<GetRegionResponse> handler =
-        new PDErrorHandler<>(r -> r.getHeader().hasError() ? r.getHeader().getError() : null, this);
+        new PDErrorHandler<>(getRegionResponseErrorExtractor, this);
 
     GetRegionResponse resp = callWithRetry(backOffer, PDGrpc.METHOD_GET_REGION, request, handler);
     return new TiRegion(
@@ -108,7 +112,7 @@ public class PDClient extends AbstractGRPCClient<PDBlockingStub, PDStub>
         () -> GetRegionRequest.newBuilder().setHeader(header).setRegionKey(key).build();
 
     PDErrorHandler<GetRegionResponse> handler =
-        new PDErrorHandler<>(r -> r.getHeader().hasError() ? r.getHeader().getError() : null, this);
+        new PDErrorHandler<>(getRegionResponseErrorExtractor, this);
 
     callAsyncWithRetry(backOffer, PDGrpc.METHOD_GET_REGION, request, responseObserver, handler);
     return responseObserver.getFuture();
@@ -119,7 +123,7 @@ public class PDClient extends AbstractGRPCClient<PDBlockingStub, PDStub>
     Supplier<GetRegionByIDRequest> request =
         () -> GetRegionByIDRequest.newBuilder().setHeader(header).setRegionId(id).build();
     PDErrorHandler<GetRegionResponse> handler =
-        new PDErrorHandler<>(r -> r.getHeader().hasError() ? r.getHeader().getError() : null, this);
+        new PDErrorHandler<>(getRegionResponseErrorExtractor, this);
 
     GetRegionResponse resp =
         callWithRetry(backOffer, PDGrpc.METHOD_GET_REGION_BY_ID, request, handler);
@@ -142,7 +146,7 @@ public class PDClient extends AbstractGRPCClient<PDBlockingStub, PDStub>
     Supplier<GetRegionByIDRequest> request =
         () -> GetRegionByIDRequest.newBuilder().setHeader(header).setRegionId(id).build();
     PDErrorHandler<GetRegionResponse> handler =
-        new PDErrorHandler<>(r -> r.getHeader().hasError() ? r.getHeader().getError() : null, this);
+        new PDErrorHandler<>(getRegionResponseErrorExtractor, this);
 
     callAsyncWithRetry(
         backOffer, PDGrpc.METHOD_GET_REGION_BY_ID, request, responseObserver, handler);
@@ -154,7 +158,9 @@ public class PDClient extends AbstractGRPCClient<PDBlockingStub, PDStub>
     Supplier<GetStoreRequest> request =
         () -> GetStoreRequest.newBuilder().setHeader(header).setStoreId(storeId).build();
     PDErrorHandler<GetStoreResponse> handler =
-        new PDErrorHandler<>(r -> r.getHeader().hasError() ? r.getHeader().getError() : null, this);
+        new PDErrorHandler<>(
+            r -> r.getHeader().hasError() ? buildFromPdpbError(r.getHeader().getError()) : null,
+            this);
 
     GetStoreResponse resp = callWithRetry(backOffer, PDGrpc.METHOD_GET_STORE, request, handler);
     return resp.getStore();
@@ -168,7 +174,9 @@ public class PDClient extends AbstractGRPCClient<PDBlockingStub, PDStub>
     Supplier<GetStoreRequest> request =
         () -> GetStoreRequest.newBuilder().setHeader(header).setStoreId(storeId).build();
     PDErrorHandler<GetStoreResponse> handler =
-        new PDErrorHandler<>(r -> r.getHeader().hasError() ? r.getHeader().getError() : null, this);
+        new PDErrorHandler<>(
+            r -> r.getHeader().hasError() ? buildFromPdpbError(r.getHeader().getError()) : null,
+            this);
 
     callAsyncWithRetry(backOffer, PDGrpc.METHOD_GET_STORE, request, responseObserver, handler);
     return responseObserver.getFuture();

--- a/tikv-client/src/main/java/com/pingcap/tikv/pd/PDError.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/pd/PDError.java
@@ -1,0 +1,104 @@
+/*
+ *
+ * Copyright 2018 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.pingcap.tikv.pd;
+
+import com.pingcap.tikv.kvproto.Pdpb;
+
+public final class PDError {
+  private final Pdpb.Error error;
+
+  private final ErrorType errorType;
+
+  public enum ErrorType {
+    PD_ERROR,
+    REGION_PEER_NOT_ELECTED
+  }
+
+  private PDError(Pdpb.Error error) {
+    this.error = error;
+    this.errorType = ErrorType.PD_ERROR;
+  }
+
+  private PDError(Pdpb.Error error, ErrorType errorType) {
+    this.error = error;
+    this.errorType = errorType;
+  }
+
+  public static PDError buildFromPdpbError(Pdpb.Error error) {
+    return new PDError(error);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static Builder newBuilder(Pdpb.Error error) {
+    return new Builder(error);
+  }
+
+  public Pdpb.Error getError() {
+    return error;
+  }
+
+  public ErrorType getErrorType() {
+    return errorType;
+  }
+
+  public String getMessage() {
+    return getError().getMessage();
+  }
+
+  @Override
+  public String toString() {
+    return "\nErrorType: " + errorType + "\nError: " + error;
+  }
+
+  public static final class RegionPeerNotElected {
+    private static final String ERROR_MESSAGE = "Region Peer not elected. Please try later";
+    private static final Pdpb.Error DEFAULT_ERROR =
+        Pdpb.Error.newBuilder().setMessage(ERROR_MESSAGE).build();
+    private static final ErrorType ERROR_TYPE = ErrorType.REGION_PEER_NOT_ELECTED;
+    public static final PDError DEFAULT_INSTANCE =
+        PDError.newBuilder(DEFAULT_ERROR).setErrorType(ERROR_TYPE).build();
+  }
+
+  public static final class Builder {
+    private Pdpb.Error error_;
+    private ErrorType errorType_ = ErrorType.PD_ERROR;
+
+    public Builder() {}
+
+    public Builder(Pdpb.Error error) {
+      this.error_ = error;
+    }
+
+    public Builder setError(Pdpb.Error error) {
+      this.error_ = error;
+      return this;
+    }
+
+    public Builder setErrorType(ErrorType errorType) {
+      this.errorType_ = errorType;
+      return this;
+    }
+
+    public PDError build() {
+      return new PDError(error_, errorType_);
+    }
+  }
+}


### PR DESCRIPTION
When retrieved region id in getRegionResponse is zero, it indicates that region peer is not elected yet, so we should wait for a short period of time and retry rather than initializing TiRegion with this zero-id.