### PR TITLE
Make ti version usable without selecting database

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/extensions/rules.scala
+++ b/core/src/main/scala/org/apache/spark/sql/extensions/rules.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.execution.datasources.LogicalRelation
 case class TiResolutionRule(getOrCreateTiContext: SparkSession => TiContext)(
   sparkSession: SparkSession
 ) extends Rule[LogicalPlan] {
-  protected lazy val tiContext: TiContext = getOrCreateTiContext(sparkSession)
+  protected val tiContext: TiContext = getOrCreateTiContext(sparkSession)
   private lazy val autoLoad = tiContext.autoLoad
   protected lazy val meta: MetaManager = tiContext.meta
   private lazy val tiCatalog = tiContext.tiCatalog


### PR DESCRIPTION
Fix #543 