### PR TITLE
Fix set type

### DIFF
--- a/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
@@ -254,66 +254,7 @@ class IssueTestSuite extends BaseTiSparkSuite {
     judge("select cast(count(1) as char(20)) from `tmp_empty_tbl`")
   }
 
-  test("json support") {
-    tidbStmt.execute("drop table if exists t")
-    tidbStmt.execute("create table t(json_doc json)")
-    tidbStmt.execute(
-      """insert into t values  ('null'),
-          ('true'),
-          ('false'),
-          ('0'),
-          ('1'),
-          ('-1'),
-          ('2147483647'),
-          ('-2147483648'),
-          ('9223372036854775807'),
-          ('-9223372036854775808'),
-          ('0.5'),
-          ('-0.5'),
-          ('""'),
-          ('"a"'),
-          ('"\\t"'),
-          ('"\\n"'),
-          ('"\\""'),
-          ('"\\u0001"'),
-          ('[]'),
-          ('"中文"'),
-          (JSON_ARRAY(null, false, true, 0, 0.5, "hello", JSON_ARRAY("nested_array"), JSON_OBJECT("nested", "object"))),
-          (JSON_OBJECT("a", null, "b", true, "c", false, "d", 0, "e", 0.5, "f", "hello", "nested_array", JSON_ARRAY(1, 2, 3), "nested_object", JSON_OBJECT("hello", 1)))"""
-    )
-    refreshConnections()
 
-    runTest(
-      "select json_doc from t",
-      skipJDBC = true,
-      rTiDB = List(
-        List("null"),
-        List(true),
-        List(false),
-        List(0),
-        List(1),
-        List(-1),
-        List(2147483647),
-        List(-2147483648),
-        List(9223372036854775807L),
-        List(-9223372036854775808L),
-        List(0.5),
-        List(-0.5),
-        List("\"\""),
-        List("\"a\""),
-        List("\"\\t\""),
-        List("\"\\n\""),
-        List("\"\\\"\""),
-        List("\"\\u0001\""),
-        List("[]"),
-        List("\"中文\""),
-        List("[null,false,true,0,0.5,\"hello\",[\"nested_array\"],{\"nested\":\"object\"}]"),
-        List(
-          "{\"a\":null,\"b\":true,\"c\":false,\"d\":0,\"e\":0.5,\"f\":\"hello\",\"nested_array\":[1,2,3],\"nested_object\":{\"hello\":1}}"
-        )
-      )
-    )
-  }
 
   override def afterAll(): Unit =
     try {

--- a/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
@@ -15,80 +15,10 @@
 
 package org.apache.spark.sql
 
-import com.pingcap.tikv.types.Converter
 import com.pingcap.tispark.TiConfigConst
 import org.apache.spark.sql.functions.{col, sum}
 
 class IssueTestSuite extends BaseTiSparkSuite {
-  test("adding time type index test") {
-    tidbStmt.execute("drop table if exists t_t")
-    tidbStmt.execute("CREATE TABLE `t_t` (`t` time(3), index `idx_t`(t))")
-    // NOTE: jdbc only allows time in day range whereas mysql time has much
-    // larger range.
-    tidbStmt.execute("INSERT INTO t_t (t) VALUES('18:59:59'),('17:59:59'),('12:59:59')")
-    refreshConnections()
-    val df = spark.sql("select * from t_t")
-    val data = dfData(df, df.schema.fields)
-    assert(data(0)(0).asInstanceOf[Long].equals(Converter.convertStrToDuration("18:59:59")))
-    assert(data(1)(0).asInstanceOf[Long].equals(Converter.convertStrToDuration("17:59:59")))
-    assert(data(2)(0).asInstanceOf[Long].equals(Converter.convertStrToDuration("12:59:59")))
-
-    val where = spark.sql("select * from t_t where t = 46799000000000")
-    val wheredata = dfData(where, where.schema.fields)
-    assert(wheredata(0)(0).asInstanceOf[Long].equals(Converter.convertStrToDuration("12:59:59")))
-  }
-
-  test("adding time type") {
-    tidbStmt.execute("drop table if exists t_t")
-    tidbStmt.execute("CREATE TABLE `t_t` (`t` time(3))")
-    // NOTE: jdbc only allows time in day range whereas mysql time has much
-    // larger range.
-    tidbStmt.execute("INSERT INTO t_t (t) VALUES('18:59:59'),('17:59:59'),('12:59:59')")
-    refreshConnections()
-    val df = spark.sql("select * from t_t")
-    val data = dfData(df, df.schema.fields)
-    assert(data(0)(0).asInstanceOf[Long].equals(Converter.convertStrToDuration("18:59:59")))
-    assert(data(1)(0).asInstanceOf[Long].equals(Converter.convertStrToDuration("17:59:59")))
-    assert(data(2)(0).asInstanceOf[Long].equals(Converter.convertStrToDuration("12:59:59")))
-
-    val where = spark.sql("select * from t_t where t = 46799000000000")
-    val wheredata = dfData(where, where.schema.fields)
-    assert(wheredata(0)(0).asInstanceOf[Long].equals(Converter.convertStrToDuration("12:59:59")))
-  }
-
-  test("adding year type") {
-    tidbStmt.execute("drop table if exists y_t")
-    tidbStmt.execute("CREATE TABLE `y_t` (`y4` year(4))")
-    tidbStmt.execute("INSERT INTO y_t (y4) VALUES(1912),(2012),(2112)")
-    refreshConnections()
-    judge("select * from y_t")
-    judge("select * from y_t where y4 = 2112")
-  }
-
-  test("adding set and enum") {
-    tidbStmt.execute("drop table if exists set_t")
-    tidbStmt.execute("drop table if exists enum_t")
-    tidbStmt.execute(
-      "CREATE TABLE `set_t` (" +
-        "`priority` set('Low','Medium','High') NOT NULL)"
-    )
-    tidbStmt.execute("INSERT INTO set_t(priority) VALUES('High')")
-    tidbStmt.execute("INSERT INTO set_t(priority) VALUES('Medium')")
-    tidbStmt.execute("INSERT INTO set_t(priority) VALUES('Low')")
-    tidbStmt.execute(
-      "CREATE TABLE `enum_t` (" +
-        "`priority` set('Low','Medium','High') NOT NULL)"
-    )
-    tidbStmt.execute("INSERT INTO enum_t(priority) VALUES('High')")
-    tidbStmt.execute("INSERT INTO enum_t(priority) VALUES('Medium')")
-    tidbStmt.execute("INSERT INTO enum_t(priority) VALUES('Low')")
-    refreshConnections()
-    judge("select * from set_t")
-    judge("select * from set_t where priority = 'High'")
-    judge("select * from enum_t")
-    judge("select * from enum_t where priority = 'High'")
-  }
-
   test("cannot resolve column name when specifying table.column") {
     spark.sql("select full_data_type_table.id_dt from full_data_type_table").explain(true)
     judge("select full_data_type_table.id_dt from full_data_type_table")
@@ -100,35 +30,6 @@ class IssueTestSuite extends BaseTiSparkSuite {
     judge(
       "select full_data_type_table.id_dt from full_data_type_table join full_data_type_table_idx on full_data_type_table.id_dt = full_data_type_table_idx.id_dt"
     )
-  }
-
-  test("partition read") {
-    tidbStmt.execute("DROP TABLE IF EXISTS `partition_t`")
-    tidbStmt.execute("""
-                       |CREATE TABLE `partition_t` (
-                       |  `id` int(11) DEFAULT NULL,
-                       |  `name` varchar(50) DEFAULT NULL,
-                       |  `purchased` date DEFAULT NULL
-                       |) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin
-                       |PARTITION BY RANGE ( `id` ) (
-                       |  PARTITION p0 VALUES LESS THAN (1990),
-                       |  PARTITION p1 VALUES LESS THAN (1995),
-                       |  PARTITION p2 VALUES LESS THAN (2000),
-                       |  PARTITION p3 VALUES LESS THAN (2005)
-                       |)
-      """.stripMargin)
-    tidbStmt.execute("insert into partition_t values (1, \"dede1\", \"1989-01-01\")")
-    tidbStmt.execute("insert into partition_t values (2, \"dede2\", \"1991-01-01\")")
-    tidbStmt.execute("insert into partition_t values (3, \"dede3\", \"1996-01-01\")")
-    tidbStmt.execute("insert into partition_t values (4, \"dede4\", \"1998-01-01\")")
-    tidbStmt.execute("insert into partition_t values (5, \"dede5\", \"2001-01-01\")")
-    tidbStmt.execute("insert into partition_t values (6, \"dede6\", \"2006-01-01\")")
-    tidbStmt.execute("insert into partition_t values (7, \"dede7\", \"2007-01-01\")")
-    tidbStmt.execute("insert into partition_t values (8, \"dede8\", \"2008-01-01\")")
-    refreshConnections()
-    assert(spark.sql("select * from partition_t").count() == 8)
-    judge("select count(*) from partition_t where id = 1", checkLimit = false)
-    judge("select id from partition_t group by id", checkLimit = false)
   }
 
   test("test date") {

--- a/core/src/test/scala/org/apache/spark/sql/TiDBTypeTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/TiDBTypeTestSuite.scala
@@ -1,0 +1,84 @@
+package org.apache.spark.sql
+
+import com.pingcap.tikv.types.Converter
+
+class TiDBTypeTestSuite extends BaseTiSparkSuite {
+  test("adding time type index test") {
+    tidbStmt.execute("drop table if exists t_t")
+    tidbStmt.execute("CREATE TABLE `t_t` (`t` time(3), index `idx_t`(t))")
+    // NOTE: jdbc only allows time in day range whereas mysql time has much
+    // larger range.
+    tidbStmt.execute("INSERT INTO t_t (t) VALUES('18:59:59'),('17:59:59'),('12:59:59')")
+    refreshConnections()
+    val df = spark.sql("select * from t_t")
+    val data = dfData(df, df.schema.fields)
+    assert(data(0)(0).asInstanceOf[Long].equals(Converter.convertStrToDuration("18:59:59")))
+    assert(data(1)(0).asInstanceOf[Long].equals(Converter.convertStrToDuration("17:59:59")))
+    assert(data(2)(0).asInstanceOf[Long].equals(Converter.convertStrToDuration("12:59:59")))
+
+    val where = spark.sql("select * from t_t where t = 46799000000000")
+    val wheredata = dfData(where, where.schema.fields)
+    assert(wheredata(0)(0).asInstanceOf[Long].equals(Converter.convertStrToDuration("12:59:59")))
+  }
+
+  test("adding time type") {
+    tidbStmt.execute("drop table if exists t_t")
+    tidbStmt.execute("CREATE TABLE `t_t` (`t` time(3))")
+    // NOTE: jdbc only allows time in day range whereas mysql time has much
+    // larger range.
+    tidbStmt.execute("INSERT INTO t_t (t) VALUES('18:59:59'),('17:59:59'),('12:59:59')")
+    refreshConnections()
+    val df = spark.sql("select * from t_t")
+    val data = dfData(df, df.schema.fields)
+    assert(data(0)(0).asInstanceOf[Long].equals(Converter.convertStrToDuration("18:59:59")))
+    assert(data(1)(0).asInstanceOf[Long].equals(Converter.convertStrToDuration("17:59:59")))
+    assert(data(2)(0).asInstanceOf[Long].equals(Converter.convertStrToDuration("12:59:59")))
+
+    val where = spark.sql("select * from t_t where t = 46799000000000")
+    val wheredata = dfData(where, where.schema.fields)
+    assert(wheredata(0)(0).asInstanceOf[Long].equals(Converter.convertStrToDuration("12:59:59")))
+  }
+
+  test("adding year type") {
+    tidbStmt.execute("drop table if exists y_t")
+    tidbStmt.execute("CREATE TABLE `y_t` (`y4` year(4))")
+    tidbStmt.execute("INSERT INTO y_t (y4) VALUES(1912),(2012),(2112)")
+    refreshConnections()
+    judge("select * from y_t")
+    judge("select * from y_t where y4 = 2112")
+  }
+
+  test("adding set and enum") {
+    tidbStmt.execute("drop table if exists set_t")
+    tidbStmt.execute("drop table if exists enum_t")
+    tidbStmt.execute(
+      "CREATE TABLE `set_t` (" +
+        "`priority` set('Low','Medium','High') NOT NULL)"
+    )
+    tidbStmt.execute("INSERT INTO set_t(priority) VALUES('High')")
+    tidbStmt.execute("INSERT INTO set_t(priority) VALUES('Medium')")
+    tidbStmt.execute("INSERT INTO set_t(priority) VALUES('Low')")
+    tidbStmt.execute(
+      "CREATE TABLE `enum_t` (" +
+        "`priority` set('Low','Medium','High') NOT NULL)"
+    )
+    tidbStmt.execute("INSERT INTO enum_t(priority) VALUES('High')")
+    tidbStmt.execute("INSERT INTO enum_t(priority) VALUES('Medium')")
+    tidbStmt.execute("INSERT INTO enum_t(priority) VALUES('Low')")
+    refreshConnections()
+    judge("select * from set_t")
+    judge("select * from set_t where priority = 'High'")
+    judge("select * from enum_t")
+    judge("select * from enum_t where priority = 'High'")
+  }
+
+  override def afterAll(): Unit =
+    try {
+      tidbStmt.execute("drop table if exists set_t")
+      tidbStmt.execute("drop table if exists enum_t")
+      tidbStmt.execute("drop table if exists t_t")
+      tidbStmt.execute("drop table if exists y_t")
+    } finally {
+      super.afterAll()
+    }
+}

--- a/core/src/test/scala/org/apache/spark/sql/TiDBTypeTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/TiDBTypeTestSuite.scala
@@ -52,12 +52,14 @@ class TiDBTypeTestSuite extends BaseTiSparkSuite {
     tidbStmt.execute("drop table if exists set_t")
     tidbStmt.execute("drop table if exists enum_t")
     tidbStmt.execute(
-      "CREATE TABLE `set_t` (" +
-        "`priority` set('Low','Medium','High') NOT NULL)"
+      " CREATE TABLE `set_t` (\n  `col` " +
+        "set('1','2','3','4', '5', '6','7', '8', '9', '10', '11', '12', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22', '23', '24', '25', '26', '27', '28', '29','30','31', '32', '33', '34', '35', '36', '37', '38', '39', '40', '41', '42', '43', '44', '45', '46', '47', '48', '49','50','51', '52', '53', '54', '55', '56','57', '58', '59', '60', '61', '62', '63', '64')\n)"
     )
-    tidbStmt.execute("INSERT INTO set_t(priority) VALUES('High')")
-    tidbStmt.execute("INSERT INTO set_t(priority) VALUES('Medium')")
-    tidbStmt.execute("INSERT INTO set_t(priority) VALUES('Low')")
+//    tidbStmt.execute("INSERT INTO set_t(col) VALUES('1')")
+    //    tidbStmt.execute("INSERT INTO set_t(col) VALUES('1,3')"
+//    tidbStmt.execute("INSERT INTO set_t(col) VALUES('1,32')")
+//    tidbStmt.execute("INSERT INTO set_t(col) VALUES('1,63')")
+    tidbStmt.execute("INSERT INTO set_t(col) VALUES('1,64')")
     tidbStmt.execute(
       "CREATE TABLE `enum_t` (" +
         "`priority` set('Low','Medium','High') NOT NULL)"
@@ -67,7 +69,7 @@ class TiDBTypeTestSuite extends BaseTiSparkSuite {
     tidbStmt.execute("INSERT INTO enum_t(priority) VALUES('Low')")
     refreshConnections()
     judge("select * from set_t")
-    judge("select * from set_t where priority = 'High'")
+    judge("select * from set_t where col = '1'")
     judge("select * from enum_t")
     judge("select * from enum_t where priority = 'High'")
   }

--- a/core/src/test/scala/org/apache/spark/sql/TiDBTypeTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/TiDBTypeTestSuite.scala
@@ -55,10 +55,10 @@ class TiDBTypeTestSuite extends BaseTiSparkSuite {
       " CREATE TABLE `set_t` (\n  `col` " +
         "set('1','2','3','4', '5', '6','7', '8', '9', '10', '11', '12', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22', '23', '24', '25', '26', '27', '28', '29','30','31', '32', '33', '34', '35', '36', '37', '38', '39', '40', '41', '42', '43', '44', '45', '46', '47', '48', '49','50','51', '52', '53', '54', '55', '56','57', '58', '59', '60', '61', '62', '63', '64')\n)"
     )
-//    tidbStmt.execute("INSERT INTO set_t(col) VALUES('1')")
-    //    tidbStmt.execute("INSERT INTO set_t(col) VALUES('1,3')"
-//    tidbStmt.execute("INSERT INTO set_t(col) VALUES('1,32')")
-//    tidbStmt.execute("INSERT INTO set_t(col) VALUES('1,63')")
+    tidbStmt.execute("INSERT INTO set_t(col) VALUES('1')")
+    tidbStmt.execute("INSERT INTO set_t(col) VALUES('1,3')")
+    tidbStmt.execute("INSERT INTO set_t(col) VALUES('1,32')")
+    tidbStmt.execute("INSERT INTO set_t(col) VALUES('1,63')")
     tidbStmt.execute("INSERT INTO set_t(col) VALUES('1,64')")
     tidbStmt.execute(
       "CREATE TABLE `enum_t` (" +
@@ -74,12 +74,75 @@ class TiDBTypeTestSuite extends BaseTiSparkSuite {
     judge("select * from enum_t where priority = 'High'")
   }
 
+
+test("adding json support") {
+    tidbStmt.execute("drop table if exists t")
+    tidbStmt.execute("create table t(json_doc json)")
+    tidbStmt.execute(
+      """insert into t values  ('null'),
+          ('true'),
+          ('false'),
+          ('0'),
+          ('1'),
+          ('-1'),
+          ('2147483647'),
+          ('-2147483648'),
+          ('9223372036854775807'),
+          ('-9223372036854775808'),
+          ('0.5'),
+          ('-0.5'),
+          ('""'),
+          ('"a"'),
+          ('"\\t"'),
+          ('"\\n"'),
+          ('"\\""'),
+          ('"\\u0001"'),
+          ('[]'),
+          ('"中文"'),
+          (JSON_ARRAY(null, false, true, 0, 0.5, "hello", JSON_ARRAY("nested_array"), JSON_OBJECT("nested", "object"))),
+          (JSON_OBJECT("a", null, "b", true, "c", false, "d", 0, "e", 0.5, "f", "hello", "nested_array", JSON_ARRAY(1, 2, 3), "nested_object", JSON_OBJECT("hello", 1)))"""
+    )
+    refreshConnections()
+
+    runTest(
+      "select json_doc from t",
+      skipJDBC = true,
+      rTiDB = List(
+        List("null"),
+        List(true),
+        List(false),
+        List(0),
+        List(1),
+        List(-1),
+        List(2147483647),
+        List(-2147483648),
+        List(9223372036854775807L),
+        List(-9223372036854775808L),
+        List(0.5),
+        List(-0.5),
+        List("\"\""),
+        List("\"a\""),
+        List("\"\\t\""),
+        List("\"\\n\""),
+        List("\"\\\"\""),
+        List("\"\\u0001\""),
+        List("[]"),
+        List("\"中文\""),
+        List("[null,false,true,0,0.5,\"hello\",[\"nested_array\"],{\"nested\":\"object\"}]"),
+        List(
+          "{\"a\":null,\"b\":true,\"c\":false,\"d\":0,\"e\":0.5,\"f\":\"hello\",\"nested_array\":[1,2,3],\"nested_object\":{\"hello\":1}}"
+        )
+      )
+    )
+  }
+
   override def afterAll(): Unit =
     try {
       tidbStmt.execute("drop table if exists set_t")
       tidbStmt.execute("drop table if exists enum_t")
       tidbStmt.execute("drop table if exists t_t")
       tidbStmt.execute("drop table if exists y_t")
+      tidbStmt.execute("drop table if exists t")
     } finally {
       super.afterAll()
     }

--- a/tikv-client/src/main/java/com/pingcap/tikv/codec/Codec.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/codec/Codec.java
@@ -38,7 +38,7 @@ public class Codec {
   public static final int UVARINT_FLAG = 9;
   public static final int JSON_FLAG = 10;
   public static final int MAX_FLAG = 250;
-  private static final long SIGN_MASK = ~Long.MAX_VALUE;
+  public static final long SIGN_MASK = ~Long.MAX_VALUE;
 
   public static boolean isNullFlag(int flag) {
     return flag == NULL_FLAG;

--- a/tikv-client/src/main/java/com/pingcap/tikv/codec/Codec.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/codec/Codec.java
@@ -38,13 +38,13 @@ public class Codec {
   public static final int UVARINT_FLAG = 9;
   public static final int JSON_FLAG = 10;
   public static final int MAX_FLAG = 250;
+  private static final long SIGN_MASK = ~Long.MAX_VALUE;
 
   public static boolean isNullFlag(int flag) {
     return flag == NULL_FLAG;
   }
 
   public static class IntegerCodec {
-    private static final long SIGN_MASK = ~Long.MAX_VALUE;
 
     private static long flipSignBit(long v) {
       return v ^ SIGN_MASK;
@@ -332,9 +332,6 @@ public class Codec {
   }
 
   public static class RealCodec {
-
-    private static final long signMask = 0x8000000000000000L;
-
     /**
      * Decode as float
      *
@@ -354,7 +351,7 @@ public class Codec {
     private static long encodeDoubleToCmpLong(double val) {
       long u = Double.doubleToRawLongBits(val);
       if (val >= 0) {
-        u |= signMask;
+        u |= SIGN_MASK;
       } else {
         u = ~u;
       }

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/SetType.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/SetType.java
@@ -69,13 +69,14 @@ public class SetType extends DataType {
     List<String> items = new ArrayList<>();
     int length = this.getElems().size();
     for (int i = 0; i < length; i++) {
-      if ((number & setIndexValue[i]) > 0) {
+      long checker = number & setIndexValue[i];
+      if (checker != 0) {
         items.add(this.getElems().get(i));
         number &= setIndexInvertValue[i];
       }
     }
 
-    if (number != 0) {
+    if (number != Long.MIN_VALUE && number != 0) {
       throw new TypeException(String.format("invalid number %d for Set %s", number, getElems()));
     }
 

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/SetType.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/SetType.java
@@ -69,6 +69,9 @@ public class SetType extends DataType {
     List<String> items = new ArrayList<>();
     int length = this.getElems().size();
     for (int i = 0; i < length; i++) {
+      // Long.MIN_VALUE is -9223372036854775808 with 1000...000 binary string.
+      // setIndexValue[63] is also Long.MIN_VALUE, hence number & setIndexValue yields
+      // Long.MIN_VALUE which is not 0(other cases will yield 0)
       long checker = number & setIndexValue[i];
       if (checker != 0) {
         items.add(this.getElems().get(i));
@@ -76,7 +79,7 @@ public class SetType extends DataType {
       }
     }
 
-    if (number != Long.MIN_VALUE && number != 0) {
+    if (number != 0) {
       throw new TypeException(String.format("invalid number %d for Set %s", number, getElems()));
     }
 

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/SetType.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/SetType.java
@@ -42,7 +42,7 @@ public class SetType extends DataType {
   private long[] initSetIndexInvertVal() {
     long[] tmpArr = new long[64];
     for (int i = 0; i < 64; i++) {
-      tmpArr[i] ^= 1 << i;
+      tmpArr[i] = setIndexValue[i] ^ -1L;
     }
     return tmpArr;
   }
@@ -50,7 +50,7 @@ public class SetType extends DataType {
   private long[] initSetIndexVal() {
     long[] tmpArr = new long[64];
     for (int i = 0; i < 64; i++) {
-      tmpArr[i] = 1 << i;
+      tmpArr[i] = 1L << i;
     }
     return tmpArr;
   }
@@ -72,7 +72,7 @@ public class SetType extends DataType {
       }
     }
 
-    if (number == 0) {
+    if (number != 0) {
       throw new TypeException(String.format("invalid number %d for Set %s", number, getElems()));
     }
 

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/SetType.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/SetType.java
@@ -42,6 +42,8 @@ public class SetType extends DataType {
   private long[] initSetIndexInvertVal() {
     long[] tmpArr = new long[64];
     for (int i = 0; i < 64; i++) {
+      // In TiDB code base, it is taking complement of original value.
+      // setIndexInvertValue[i] = ^setIndexValue[i] is invalid in Java.
       tmpArr[i] = setIndexValue[i] ^ -1L;
     }
     return tmpArr;
@@ -63,9 +65,10 @@ public class SetType extends DataType {
   @Override
   protected Object decodeNotNull(int flag, CodecDataInput cdi) {
     if (flag != Codec.UVARINT_FLAG) throw new TypeException("Invalid IntegerType flag: " + flag);
-    int number = (int) IntegerCodec.readUVarLong(cdi);
+    long number = IntegerCodec.readUVarLong(cdi);
     List<String> items = new ArrayList<>();
-    for (int i = 0; i < this.getElems().size(); i++) {
+    int length = this.getElems().size();
+    for (int i = 0; i < length; i++) {
       if ((number & setIndexValue[i]) > 0) {
         items.add(this.getElems().get(i));
         number &= setIndexInvertValue[i];


### PR DESCRIPTION
This PR fixes a bug in Set Type when inserting multiple set value. 

With the following scheama:
```
CREATE TABLE myset (col SET('a', 'b', 'c', 'd'));
INSERT INTO myset (col) VALUES ('a,d'), ('d,a'), ('a,d,a'), ('a,d,d'), ('d,a,d');
```
Before this PR:
```
+----+
| col|
+----+
| a  |
| a  |
| a  |
| a  |
| a  |
+----+
```

After this PR:

```
+------+
| col  |
+------+
| a,d  |
| a,d  |
| a,d  |
| a,d  |
| a,d  |
+------+
```



