### PR TITLE
Fix timestamp consistency

### DIFF
--- a/core/src/main/scala/com/pingcap/tispark/statistics/StatisticsHelper.scala
+++ b/core/src/main/scala/com/pingcap/tispark/statistics/StatisticsHelper.scala
@@ -21,7 +21,7 @@ import com.google.common.primitives.UnsignedLong
 import com.pingcap.tikv.expression.{ByItem, ColumnRef, ComparisonBinaryExpression, Constant}
 import com.pingcap.tikv.key.{Key, TypedKey}
 import com.pingcap.tikv.meta.TiDAGRequest.PushDownType
-import com.pingcap.tikv.meta.{TiDAGRequest, TiTableInfo}
+import com.pingcap.tikv.meta.{TiDAGRequest, TiTableInfo, TiTimestamp}
 import com.pingcap.tikv.row.Row
 import com.pingcap.tikv.statistics._
 import com.pingcap.tikv.types.{DataType, DataTypeFactory, MySQLType}
@@ -200,7 +200,7 @@ object StatisticsHelper {
 
   private[statistics] def buildHistogramsRequest(histTable: TiTableInfo,
                                                  targetTblId: Long,
-                                                 startTs: Long): TiDAGRequest =
+                                                 startTs: TiTimestamp): TiDAGRequest =
     TiDAGRequest.Builder
       .newBuilder()
       .setFullTableScan(histTable)
@@ -219,7 +219,7 @@ object StatisticsHelper {
 
   private[statistics] def buildMetaRequest(metaTable: TiTableInfo,
                                            targetTblId: Long,
-                                           startTs: Long): TiDAGRequest =
+                                           startTs: TiTimestamp): TiDAGRequest =
     TiDAGRequest.Builder
       .newBuilder()
       .setFullTableScan(metaTable)
@@ -233,7 +233,7 @@ object StatisticsHelper {
 
   private[statistics] def buildBucketRequest(bucketTable: TiTableInfo,
                                              targetTblId: Long,
-                                             startTs: Long): TiDAGRequest =
+                                             startTs: TiTimestamp): TiDAGRequest =
     TiDAGRequest.Builder
       .newBuilder()
       .setFullTableScan(bucketTable)

--- a/core/src/main/scala/com/pingcap/tispark/statistics/StatisticsManager.scala
+++ b/core/src/main/scala/com/pingcap/tispark/statistics/StatisticsManager.scala
@@ -150,7 +150,7 @@ object StatisticsManager {
     // load count, modify_count, version info
     loadMetaToTblStats(tblId, tblStatistic)
     val req = StatisticsHelper
-      .buildHistogramsRequest(histTable, tblId, snapshot.getTimestamp.getVersion)
+      .buildHistogramsRequest(histTable, tblId, snapshot.getTimestamp)
 
     val rows = readDAGRequest(req)
     if (rows.isEmpty) return
@@ -197,7 +197,7 @@ object StatisticsManager {
 
   private def loadMetaToTblStats(tableId: Long, tableStatistics: TableStatistics): Unit = {
     val req =
-      StatisticsHelper.buildMetaRequest(metaTable, tableId, snapshot.getTimestamp.getVersion)
+      StatisticsHelper.buildMetaRequest(metaTable, tableId, snapshot.getTimestamp)
 
     val rows = readDAGRequest(req)
     if (rows.isEmpty) return
@@ -211,7 +211,7 @@ object StatisticsManager {
   private def statisticsResultFromStorage(tableId: Long,
                                           requests: Seq[StatisticsDTO]): Seq[StatisticsResult] = {
     val req =
-      StatisticsHelper.buildBucketRequest(bucketTable, tableId, snapshot.getTimestamp.getVersion)
+      StatisticsHelper.buildBucketRequest(bucketTable, tableId, snapshot.getTimestamp)
 
     val rows = readDAGRequest(req)
     if (rows.isEmpty) return Nil

--- a/core/src/main/scala/org/apache/spark/sql/TiStrategy.scala
+++ b/core/src/main/scala/org/apache/spark/sql/TiStrategy.scala
@@ -111,7 +111,9 @@ case class TiStrategy(getOrCreateTiContext: SparkSession => TiContext)(sparkSess
     dagRequest: TiDAGRequest
   ): SparkPlan = {
     val table = source.table
+    val ts = source.ts.getOrElse(source.session.getTimestamp)
     dagRequest.setTableInfo(table)
+    dagRequest.setStartTs(ts)
     // Need to resolve column info after add aggregation push downs
     dagRequest.resolve()
 
@@ -272,7 +274,10 @@ case class TiStrategy(getOrCreateTiContext: SparkSession => TiContext)(sparkSess
       // need to set isDoubleRead to true for dagRequest in case of double read
       dagRequest.setIsDoubleRead(scanPlan.isDoubleRead)
     }
+
+    val ts = source.ts.getOrElse(source.session.getTimestamp)
     dagRequest.setTableInfo(source.table)
+    dagRequest.setStartTs(ts)
     dagRequest.setEstimatedCount(scanPlan.getEstimatedRowCount)
     dagRequest
   }

--- a/core/src/main/scala/org/apache/spark/sql/tispark/TiRDD.scala
+++ b/core/src/main/scala/org/apache/spark/sql/tispark/TiRDD.scala
@@ -35,7 +35,6 @@ import scala.collection.mutable.ListBuffer
 class TiRDD(val dagRequest: TiDAGRequest,
             val tiConf: TiConfiguration,
             val tableRef: TiTableReference,
-            val ts: TiTimestamp,
             @transient private val session: TiSession,
             @transient private val sparkSession: SparkSession)
     extends RDD[Row](sparkSession.sparkContext, Nil) {
@@ -62,6 +61,11 @@ class TiRDD(val dagRequest: TiDAGRequest,
     private val tiPartition = split.asInstanceOf[TiPartition]
     private val session = TiSessionCache.getSession(tiConf)
     session.injectCallBackFunc(callBackFunc)
+    val ts = if (dagRequest.getStartTs == null) {
+      session.getTimestamp
+    } else {
+      dagRequest.getStartTs
+    }
     private val snapshot = session.createSnapshot(ts)
     private[this] val tasks = tiPartition.tasks
 

--- a/tikv-client/src/main/java/com/pingcap/tikv/meta/TiTimestamp.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/meta/TiTimestamp.java
@@ -16,6 +16,7 @@
 package com.pingcap.tikv.meta;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 /** TiTimestamp is the timestamp returned by timestamp oracle inside placement driver */
 public class TiTimestamp implements Serializable {
@@ -39,5 +40,21 @@ public class TiTimestamp implements Serializable {
 
   public long getLogical() {
     return this.logical;
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (other == this) {
+      return true;
+    }
+    if (!(other instanceof TiTimestamp)) {
+      return false;
+    }
+    return this.getVersion() == ((TiTimestamp) other).getVersion();
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getVersion());
   }
 }

--- a/tikv-client/src/test/java/com/pingcap/tikv/meta/TiDAGRequestTest.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/meta/TiDAGRequestTest.java
@@ -59,7 +59,7 @@ public class TiDAGRequestTest {
     dagRequest.addRequiredColumn(col1);
     dagRequest.setLimit(0);
     dagRequest.setTableInfo(table);
-    dagRequest.setStartTs(1);
+    dagRequest.setStartTs(new TiTimestamp(0, 1));
     dagRequest.buildScan(false);
   }
 
@@ -86,7 +86,7 @@ public class TiDAGRequestTest {
         .addGroupByItem(ByItem.create(ColumnRef.create("c2", table), true))
         .addOrderByItem(ByItem.create(ColumnRef.create("c3", table), false))
         .setTableInfo(table)
-        .setStartTs(666)
+        .setStartTs(new TiTimestamp(0, 666))
         .setTruncateMode(TiDAGRequest.TruncateMode.IgnoreTruncation)
         .setDistinct(true)
         .setIndexInfo(table.getIndices().get(0))

--- a/tikv-client/src/test/java/com/pingcap/tikv/operation/iterator/DAGIteratorTest.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/operation/iterator/DAGIteratorTest.java
@@ -36,6 +36,7 @@ import com.pingcap.tikv.meta.MetaUtils;
 import com.pingcap.tikv.meta.TiDAGRequest;
 import com.pingcap.tikv.meta.TiDAGRequest.PushDownType;
 import com.pingcap.tikv.meta.TiTableInfo;
+import com.pingcap.tikv.meta.TiTimestamp;
 import com.pingcap.tikv.operation.SchemaInfer;
 import com.pingcap.tikv.region.RegionStoreClient;
 import com.pingcap.tikv.region.TiRegion;
@@ -123,7 +124,7 @@ public class DAGIteratorTest {
     req.setTableInfo(table);
     req.addRequiredColumn(ColumnRef.create("c1"));
     req.addRequiredColumn(ColumnRef.create("c2"));
-    req.setStartTs(1);
+    req.setStartTs(new TiTimestamp(0, 1));
     req.resolve();
 
     List<KeyRange> keyRanges =


### PR DESCRIPTION
Previously a query which touches multiple table will be assigned different timestamp for each table.
This PR is to fix this issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tispark/550)
<!-- Reviewable:end -->
