### PR TITLE
Update scalafmt and specify sourceDirectory

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -54,13 +54,6 @@
     </dependencies>
 
     <build>
-        <sourceDirectory>${tispark.sourceDirectory}</sourceDirectory>
-        <testSourceDirectory>${tispark.testSourceDirectory}</testSourceDirectory>
-        <resources>
-            <resource>
-                <directory>${tispark.resourcesDirectory}</directory>
-            </resource>
-        </resources>
         <extensions>
             <extension>
                 <groupId>kr.motd.maven</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -65,10 +65,6 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <protobuf.version>3.1.0</protobuf.version>
         <spark.version>2.3.2</spark.version>
-        <tispark.version>${project.parent.version}</tispark.version>
-        <tispark.sourceDirectory>src/main/scala</tispark.sourceDirectory>
-        <tispark.testSourceDirectory>src/test/scala</tispark.testSourceDirectory>
-        <tispark.resourcesDirectory>src/main/resources</tispark.resourcesDirectory>
         <scala.binary.version>2.11</scala.binary.version>
         <scala.version>2.11</scala.version>
         <scalatest.version>3.0.4</scalatest.version>


### PR DESCRIPTION
We do not need to specify project.build.sourceDirectory anymore because we can override them in configuration.