### PR TITLE
fix a bug when perform index scan on partition table. 

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/TiStrategy.scala
+++ b/core/src/main/scala/org/apache/spark/sql/TiStrategy.scala
@@ -256,7 +256,7 @@ case class TiStrategy(getOrCreateTiContext: SparkSession => TiContext)(sparkSess
     val scanPlan: ScanPlan = if (allowIndexDoubleRead()) {
       // We need to prepare downgrade information in case of index scan downgrade happens.
       tableScanPlan.getFilters.asScala.foreach { dagRequest.addDowngradeFilter }
-      scanBuilder.buildIndexScan(
+      scanBuilder.buildScan(
         // need to bind all columns needed
         tiColumns.map { _.getColumnInfo }.asJava,
         tiFilters.asJava,
@@ -268,6 +268,7 @@ case class TiStrategy(getOrCreateTiContext: SparkSession => TiContext)(sparkSess
     }
 
     dagRequest.addRanges(scanPlan.getKeyRanges)
+    dagRequest.setPrunedPartInfo(scanPlan.getPrunedPartInfo)
     scanPlan.getFilters.asScala.foreach { dagRequest.addFilter }
     if (scanPlan.isIndexScan) {
       dagRequest.setIndexInfo(scanPlan.getIndex)

--- a/core/src/main/scala/org/apache/spark/sql/TiStrategy.scala
+++ b/core/src/main/scala/org/apache/spark/sql/TiStrategy.scala
@@ -256,7 +256,7 @@ case class TiStrategy(getOrCreateTiContext: SparkSession => TiContext)(sparkSess
     val scanPlan: ScanPlan = if (allowIndexDoubleRead()) {
       // We need to prepare downgrade information in case of index scan downgrade happens.
       tableScanPlan.getFilters.asScala.foreach { dagRequest.addDowngradeFilter }
-      scanBuilder.buildScan(
+      scanBuilder.buildIndexScan(
         // need to bind all columns needed
         tiColumns.map { _.getColumnInfo }.asJava,
         tiFilters.asJava,

--- a/core/src/main/scala/org/apache/spark/sql/execution/CoprocessorRDD.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/CoprocessorRDD.scala
@@ -220,10 +220,9 @@ case class RegionTaskExec(child: SparkPlan,
             new ExecutorCompletionService[util.Iterator[TiRow]](session.getThreadPoolForIndexScan)
           var rowIterator: util.Iterator[TiRow] = null
 
-
-           // After `splitAndSortHandlesByRegion`, ranges in the task are arranged in order
+          // After `splitAndSortHandlesByRegion`, ranges in the task are arranged in order
           // TODO: Maybe we can optimize splitAndSortHandlesByRegion if we are sure the handles are in same region?
-          def generateIndexTasks(handles: TLongArrayList):util.List[RegionTask] = {
+          def generateIndexTasks(handles: TLongArrayList): util.List[RegionTask] = {
             var indexTasks: util.List[RegionTask] = new util.ArrayList[RegionTask]()
             if (!dagRequest.getTableInfo.isPartitionEnabled) {
               indexTasks.addAll(

--- a/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
@@ -261,7 +261,6 @@ class IssueTestSuite extends BaseTiSparkSuite {
       tidbStmt.execute("drop table if exists t1")
       tidbStmt.execute("drop table if exists t2")
       tidbStmt.execute("drop table if exists single_read")
-      tidbStmt.execute("DROP TABLE IF EXISTS `partition_t`")
       tidbStmt.execute("drop table if exists set_t")
       tidbStmt.execute("drop table if exists enum_t")
     } finally {

--- a/core/src/test/scala/org/apache/spark/sql/PartitionTableSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/PartitionTableSuite.scala
@@ -17,7 +17,9 @@ package org.apache.spark.sql
 
 class PartitionTableSuite extends BaseTiSparkSuite {
   test("index scan on partition table") {
-    tidbStmt.execute("CREATE TABLE `pt` (   `id` int(11) DEFAULT NULL, `y` date DEFAULT NULL,   index `idx_y`(`y`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin PARTITION BY RANGE ( id ) (   PARTITION p0 VALUES LESS THAN (2),   PARTITION p1 VALUES LESS THAN (4),   PARTITION p2 VALUES LESS THAN (6) );")
+    tidbStmt.execute(
+      "CREATE TABLE `pt` (   `id` int(11) DEFAULT NULL, `y` date DEFAULT NULL,   index `idx_y`(`y`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin PARTITION BY RANGE ( id ) (   PARTITION p0 VALUES LESS THAN (2),   PARTITION p1 VALUES LESS THAN (4),   PARTITION p2 VALUES LESS THAN (6) );"
+    )
     tidbStmt.execute("insert into `pt` values(1, '1995-10-10')")
     tidbStmt.execute("insert into `pt` values(2, '1996-10-10')")
     tidbStmt.execute("insert into `pt` values(3, '1997-10-10')")

--- a/core/src/test/scala/org/apache/spark/sql/PartitionTableSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/PartitionTableSuite.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql
+
+class PartitionTableSuite extends BaseTiSparkSuite {
+  test("index scan on partition table") {
+    tidbStmt.execute("CREATE TABLE `pt` (   `id` int(11) DEFAULT NULL, `y` date DEFAULT NULL,   index `idx_y`(`y`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin PARTITION BY RANGE ( id ) (   PARTITION p0 VALUES LESS THAN (2),   PARTITION p1 VALUES LESS THAN (4),   PARTITION p2 VALUES LESS THAN (6) );")
+    tidbStmt.execute("insert into `pt` values(1, '1995-10-10')")
+    tidbStmt.execute("insert into `pt` values(2, '1996-10-10')")
+    tidbStmt.execute("insert into `pt` values(3, '1997-10-10')")
+    tidbStmt.execute("insert into `pt` values(4, '1998-10-10')")
+    tidbStmt.execute("insert into `pt` values(5, '1999-10-10')")
+    refreshConnections()
+    judge("select * from pt where y = date'1996-10-10'")
+  }
+  override def afterAll(): Unit =
+    try {
+      tidbStmt.execute("drop table if exists pt")
+    } finally {
+      super.afterAll()
+    }
+}

--- a/tikv-client/src/main/java/com/pingcap/tikv/meta/TiDAGRequest.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/meta/TiDAGRequest.java
@@ -49,6 +49,15 @@ import java.util.stream.Collectors;
  * <p>Used for constructing a new DAG request to TiKV
  */
 public class TiDAGRequest implements Serializable {
+
+  public TiPartitionInfo getPrunedPartInfo() {
+    return prunedPartInfo;
+  }
+
+  public void setPrunedPartInfo(TiPartitionInfo prunedPartInfo) {
+    this.prunedPartInfo = prunedPartInfo;
+  }
+
   public static class Builder {
     private List<String> requiredCols = new ArrayList<>();
     private List<Expression> filters = new ArrayList<>();
@@ -176,6 +185,7 @@ public class TiDAGRequest implements Serializable {
           .build();
 
   private TiTableInfo tableInfo;
+  private TiPartitionInfo prunedPartInfo;
   private TiIndexInfo indexInfo;
   private final List<ColumnRef> fields = new ArrayList<>();
   private final List<Expression> filters = new ArrayList<>();

--- a/tikv-client/src/main/java/com/pingcap/tikv/meta/TiPartitionInfo.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/meta/TiPartitionInfo.java
@@ -25,17 +25,30 @@ import java.util.List;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class TiPartitionInfo implements Serializable {
 
-  public static enum PartitionType {
+  public enum PartitionType {
     RangePartition,
     HashPartition,
     ListPartition,
+    InvalidPartition,
   }
 
-  private final long type;
+  private final PartitionType type;
   private final String expr;
   private final List<CIStr> columns;
   private final boolean enable;
   private final List<TiPartitionDef> defs;
+
+  private PartitionType toPartType(int tp) {
+    switch (tp) {
+      case 1:
+       return PartitionType.RangePartition;
+      case 2:
+        return PartitionType.HashPartition;
+      case 3:
+        return PartitionType.ListPartition;
+    }
+    return PartitionType.InvalidPartition;
+  }
 
   @VisibleForTesting
   @JsonCreator
@@ -45,7 +58,9 @@ public class TiPartitionInfo implements Serializable {
       @JsonProperty("columns") List<CIStr> columns,
       @JsonProperty("enable") boolean enable,
       @JsonProperty("definitions") List<TiPartitionDef> defs) {
-    this.type = type;
+    // Part type only contains limited amount, so long to int conversion
+    // should be safe.
+    this.type = toPartType((int)type);
     this.expr = expr;
     this.columns = columns;
     this.enable = enable;

--- a/tikv-client/src/main/java/com/pingcap/tikv/meta/TiPartitionInfo.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/meta/TiPartitionInfo.java
@@ -41,7 +41,7 @@ public class TiPartitionInfo implements Serializable {
   private PartitionType toPartType(int tp) {
     switch (tp) {
       case 1:
-       return PartitionType.RangePartition;
+        return PartitionType.RangePartition;
       case 2:
         return PartitionType.HashPartition;
       case 3:
@@ -60,7 +60,7 @@ public class TiPartitionInfo implements Serializable {
       @JsonProperty("definitions") List<TiPartitionDef> defs) {
     // Part type only contains limited amount, so long to int conversion
     // should be safe.
-    this.type = toPartType((int)type);
+    this.type = toPartType((int) type);
     this.expr = expr;
     this.columns = columns;
     this.enable = enable;

--- a/tikv-client/src/main/java/com/pingcap/tikv/meta/TiTableInfo.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/meta/TiTableInfo.java
@@ -23,7 +23,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import com.pingcap.tidb.tipb.TableInfo;
 import com.pingcap.tikv.exception.TiClientInternalException;
-import com.pingcap.tikv.expression.visitor.MetaResolver;
 import com.pingcap.tikv.meta.TiColumnInfo.InternalTypeHolder;
 import com.pingcap.tikv.types.DataType;
 import com.pingcap.tikv.types.DataTypeFactory;
@@ -206,18 +205,5 @@ public class TiTableInfo implements Serializable {
   public boolean isPartitionEnabled() {
     if (partitionInfo == null) return false;
     return partitionInfo.isEnable();
-  }
-
-  public void setPartitionExpr(TiPartitionExpr partitionExpr) {
-    MetaResolver.resolve(partitionExpr.getRanges(), this);
-    MetaResolver.resolve(partitionExpr.getUpperBound(), this);
-    if (partitionExpr.canPruned()) {
-      MetaResolver.resolve(partitionExpr.getColumn(), this);
-    }
-    this.partitionExpr = partitionExpr;
-  }
-
-  public TiPartitionExpr getPartitionExpr() {
-    return partitionExpr;
   }
 }

--- a/tikv-client/src/main/java/com/pingcap/tikv/operation/iterator/IndexScanIterator.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/operation/iterator/IndexScanIterator.java
@@ -80,7 +80,7 @@ public class IndexScanIterator implements Iterator<Row> {
                       RangeSplitter.newSplitter(session.getRegionManager())
                           .splitAndSortHandlesByRegion(table.getId(), handles));
                 } else {
-                  for (TiPartitionDef pDef : table.getPartitionInfo().getDefs()) {
+                  for (TiPartitionDef pDef : dagReq.getPrunedPartInfo().getDefs()) {
                     tasks.addAll(
                         RangeSplitter.newSplitter(session.getRegionManager())
                             .splitAndSortHandlesByRegion(pDef.getId(), handles));

--- a/tikv-client/src/main/java/com/pingcap/tikv/predicates/ScanAnalyzer.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/predicates/ScanAnalyzer.java
@@ -104,13 +104,13 @@ public class ScanAnalyzer {
   }
 
   // build a scan for debug purpose.
-  public ScanPlan buildScan(
+  public ScanPlan buildIndexScan(
       List<TiColumnInfo> columnList, List<Expression> conditions, TiTableInfo table) {
-    return buildScan(columnList, conditions, table, null);
+    return buildIndexScan(columnList, conditions, table, null);
   }
 
   // Build scan plan picking access path with lowest cost by estimation
-  public ScanPlan buildScan(
+  public ScanPlan buildIndexScan(
       List<TiColumnInfo> columnList,
       List<Expression> conditions,
       TiTableInfo table,
@@ -118,7 +118,7 @@ public class ScanAnalyzer {
     ScanPlan minPlan = buildTableScan(conditions, table, tableStatistics);
     double minCost = minPlan.getCost();
     for (TiIndexInfo index : table.getIndices()) {
-      ScanPlan plan = buildScan(columnList, conditions, index, table, tableStatistics);
+      ScanPlan plan = buildIndexScan(columnList, conditions, index, table, tableStatistics);
       if (plan.getCost() < minCost) {
         minPlan = plan;
         minCost = plan.getCost();
@@ -130,10 +130,10 @@ public class ScanAnalyzer {
   public ScanPlan buildTableScan(
       List<Expression> conditions, TiTableInfo table, TableStatistics tableStatistics) {
     TiIndexInfo pkIndex = TiIndexInfo.generateFakePrimaryKeyIndex(table);
-    return buildScan(table.getColumns(), conditions, pkIndex, table, tableStatistics);
+    return buildIndexScan(table.getColumns(), conditions, pkIndex, table, tableStatistics);
   }
 
-  public ScanPlan buildScan(
+  public ScanPlan buildIndexScan(
       List<TiColumnInfo> columnList,
       List<Expression> conditions,
       TiIndexInfo index,

--- a/tikv-client/src/main/java/com/pingcap/tikv/predicates/ScanSpec.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/predicates/ScanSpec.java
@@ -95,7 +95,7 @@ public class ScanSpec {
       Optional<Expression> newRangePred =
           rangePredicates.isEmpty()
               ? Optional.empty()
-              : Optional.of(mergeCNFExpressions(rangePredicates));
+              : Optional.ofNullable(mergeCNFExpressions(rangePredicates));
       pushedPredicates.addAll(rangePredicates);
 
       Set<Expression> newResidualPredicates = new HashSet<>(residualPredicates);

--- a/tikv-client/src/main/java/com/pingcap/tikv/predicates/ScanSpec.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/predicates/ScanSpec.java
@@ -105,14 +105,6 @@ public class ScanSpec {
         }
       }
 
-      Optional<DataType> rangeType;
-      if (rangeColumn == null) {
-        rangeType = Optional.empty();
-      } else {
-        TiColumnInfo col = table.getColumn(rangeColumn.getOffset());
-        rangeType = Optional.of(col.getType());
-      }
-
       return new ScanSpec(ImmutableList.copyOf(points), newRangePred, newResidualPredicates);
     }
   }

--- a/tikv-client/src/main/java/com/pingcap/tikv/tools/RegionUtils.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/tools/RegionUtils.java
@@ -61,7 +61,7 @@ public class RegionUtils {
     requireNonNull(table, String.format("Table not found %s.%s", databaseName, tableName));
     ScanAnalyzer builder = new ScanAnalyzer();
     ScanAnalyzer.ScanPlan scanPlan =
-        builder.buildIndexScan(ImmutableList.of(), ImmutableList.of(), table);
+        builder.buildScan(ImmutableList.of(), ImmutableList.of(), table);
     return RangeSplitter.newSplitter(session.getRegionManager())
         .splitRangeByRegion(scanPlan.getKeyRanges());
   }

--- a/tikv-client/src/main/java/com/pingcap/tikv/tools/RegionUtils.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/tools/RegionUtils.java
@@ -61,7 +61,7 @@ public class RegionUtils {
     requireNonNull(table, String.format("Table not found %s.%s", databaseName, tableName));
     ScanAnalyzer builder = new ScanAnalyzer();
     ScanAnalyzer.ScanPlan scanPlan =
-        builder.buildScan(ImmutableList.of(), ImmutableList.of(), table);
+        builder.buildIndexScan(ImmutableList.of(), ImmutableList.of(), table);
     return RangeSplitter.newSplitter(session.getRegionManager())
         .splitRangeByRegion(scanPlan.getKeyRanges());
   }

--- a/tikv-client/src/test/java/com/pingcap/tikv/predicates/ScanAnalyzerTest.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/predicates/ScanAnalyzerTest.java
@@ -92,7 +92,8 @@ public class ScanAnalyzerTest {
 
     ScanAnalyzer scanAnalyzer = new ScanAnalyzer();
 
-    List<Coprocessor.KeyRange> keyRanges = scanAnalyzer.buildTableScanKeyRange(table, irs);
+    List<Coprocessor.KeyRange> keyRanges =
+        scanAnalyzer.buildTableScanKeyRange(table, irs, table.getPartitionInfo());
 
     assertEquals(keyRanges.size(), 1);
 
@@ -125,7 +126,8 @@ public class ScanAnalyzerTest {
 
     ScanAnalyzer scanAnalyzer = new ScanAnalyzer();
 
-    List<Coprocessor.KeyRange> keyRanges = scanAnalyzer.buildIndexScanKeyRange(table, index, irs);
+    List<Coprocessor.KeyRange> keyRanges =
+        scanAnalyzer.buildIndexScanKeyRange(table, index, irs, table.getPartitionInfo());
 
     assertEquals(keyRanges.size(), 1);
 
@@ -153,7 +155,7 @@ public class ScanAnalyzerTest {
         expressionToIndexRanges(
             result.getPointPredicates(), result.getRangePredicate(), table, index);
 
-    keyRanges = scanAnalyzer.buildIndexScanKeyRange(table, index, irs);
+    keyRanges = scanAnalyzer.buildIndexScanKeyRange(table, index, irs, table.getPartitionInfo());
 
     assertEquals(keyRanges.size(), 1);
 

--- a/tikv-client/src/test/java/com/pingcap/tikv/predicates/ScanAnalyzerTest.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/predicates/ScanAnalyzerTest.java
@@ -268,7 +268,7 @@ public class ScanAnalyzerTest {
     TiIndexInfo index = TiIndexInfo.generateFakePrimaryKeyIndex(table);
     ScanAnalyzer scanBuilder = new ScanAnalyzer();
     ScanAnalyzer.ScanPlan scanPlan =
-        scanBuilder.buildScan(ImmutableList.of(), ImmutableList.of(), index, table, null);
+        scanBuilder.buildIndexScan(ImmutableList.of(), ImmutableList.of(), index, table, null);
 
     ByteString startKey = RowKey.toRowKey(table.getId(), Long.MIN_VALUE).toByteString();
     ByteString endKey = RowKey.createBeyondMax(table.getId()).toByteString();


### PR DESCRIPTION
Say, we have a schema:
```
CREATE TABLE `pt` (
  `id` int(11) DEFAULT NULL,
  `y` date DEFAULT NULL,
  index `idx_y`(`y`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin
PARTITION BY RANGE ( id ) (
  PARTITION p0 VALUES LESS THAN (2),
  PARTITION p1 VALUES LESS THAN (4),
  PARTITION p2 VALUES LESS THAN (6)
);
```
and insert some values:
```
insert into `pt` values(1, '1995-10-10')
insert into `pt` values(2, '1996-10-10')
insert into `pt` values(3, '1997-10-10')
insert into `pt` values(4, '1998-10-10')
```
Before this PR, `select * from pt where y = date'1998-10-10'`yields empty result. After this PR, such query return correct result. 