### PR TITLE
log load data is enabled or not

### DIFF
--- a/core/src/test/scala/org/apache/spark/sql/test/SharedSQLContext.scala
+++ b/core/src/test/scala/org/apache/spark/sql/test/SharedSQLContext.scala
@@ -195,15 +195,20 @@ object SharedSQLContext extends Logging {
       _tidbConnection = DriverManager.getConnection(jdbcUrl, jdbcUsername, jdbcPassword)
       _statement = _tidbConnection.createStatement()
 
+      if (loadData) {
+        logger.info("load data is enabled")
+      } else {
+        logger.info("load data is disabled")
+      }
       if (loadData && !forceNotLoad) {
-        logger.warn("Loading TiSparkTestData")
+        logger.info("Loading TiSparkTestData")
         // Load index test data
         var queryString = resourceToString(
           s"tispark-test/IndexTest.sql",
           classLoader = Thread.currentThread().getContextClassLoader
         )
         _statement.execute(queryString)
-        logger.warn("Load IndexTest.sql successfully.")
+        logger.info("Load IndexTest.sql successfully.")
         // Load expression test data
         queryString = resourceToString(
           s"tispark-test/TiSparkTest.sql",

--- a/core/src/test/scala/org/apache/spark/sql/test/SharedSQLContext.scala
+++ b/core/src/test/scala/org/apache/spark/sql/test/SharedSQLContext.scala
@@ -187,7 +187,7 @@ object SharedSQLContext extends Logging {
 
       val jdbcPort = Integer.parseInt(getOrElse(_tidbConf, TiDB_PORT, "4000"))
 
-      val loadData = getFlag(_tidbConf, SHOULD_LOAD_DATA)
+      val loadData = getOrElse(_tidbConf, SHOULD_LOAD_DATA,"true").toLowerCase.toBoolean
 
       jdbcUrl =
         s"jdbc:mysql://$jdbcHostname:$jdbcPort/?user=$jdbcUsername&password=$jdbcPassword&useUnicode=true&characterEncoding=UTF-8&zeroDateTimeBehavior=convertToNull&useSSL=false&rewriteBatchedStatements=true"


### PR DESCRIPTION
This can help us to quickly address the real problem when ci has a failure. 