### PR TITLE
Fix cannot initialize pd if using ipv6 address

### DIFF
--- a/core/src/test/scala/org/apache/spark/sql/test/SharedSQLContext.scala
+++ b/core/src/test/scala/org/apache/spark/sql/test/SharedSQLContext.scala
@@ -190,7 +190,7 @@ object SharedSQLContext extends Logging {
       val loadData = getOrElse(_tidbConf, SHOULD_LOAD_DATA, "true").toLowerCase.toBoolean
 
       jdbcUrl =
-        s"jdbc:mysql://$jdbcHostname:$jdbcPort/?user=$jdbcUsername&password=$jdbcPassword&useUnicode=true&characterEncoding=UTF-8&zeroDateTimeBehavior=convertToNull&useSSL=false&rewriteBatchedStatements=true"
+        s"jdbc:mysql://address=(protocol=tcp)(host=$jdbcHostname)(port=$jdbcPort)/?user=$jdbcUsername&password=$jdbcPassword&useUnicode=true&characterEncoding=UTF-8&zeroDateTimeBehavior=convertToNull&useSSL=false&rewriteBatchedStatements=true"
 
       _tidbConnection = DriverManager.getConnection(jdbcUrl, jdbcUsername, jdbcPassword)
       _statement = _tidbConnection.createStatement()

--- a/tikv-client/src/main/java/com/pingcap/tikv/TiConfiguration.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/TiConfiguration.java
@@ -16,10 +16,10 @@
 package com.pingcap.tikv;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.net.HostAndPort;
 import com.pingcap.tikv.kvproto.Kvrpcpb.CommandPri;
 import com.pingcap.tikv.kvproto.Kvrpcpb.IsolationLevel;
 import java.io.Serializable;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -52,7 +52,7 @@ public class TiConfiguration implements Serializable {
   private TimeUnit metaReloadUnit = DEF_META_RELOAD_UNIT;
   private int metaReloadPeriod = DEF_META_RELOAD_PERIOD;
   private int maxFrameSize = DEF_MAX_FRAME_SIZE;
-  private List<HostAndPort> pdAddrs = new ArrayList<>();
+  private List<URI> pdAddrs = new ArrayList<>();
   private int indexScanBatchSize = DEF_INDEX_SCAN_BATCH_SIZE;
   private int indexScanConcurrency = DEF_INDEX_SCAN_CONCURRENCY;
   private int tableScanConcurrency = DEF_TABLE_SCAN_CONCURRENCY;
@@ -65,16 +65,16 @@ public class TiConfiguration implements Serializable {
   public static TiConfiguration createDefault(String pdAddrsStr) {
     Objects.requireNonNull(pdAddrsStr, "pdAddrsStr is null");
     TiConfiguration conf = new TiConfiguration();
-    conf.pdAddrs = strToHostAndPort(pdAddrsStr);
+    conf.pdAddrs = strToURI(pdAddrsStr);
     return conf;
   }
 
-  private static List<HostAndPort> strToHostAndPort(String addressStr) {
+  private static List<URI> strToURI(String addressStr) {
     Objects.requireNonNull(addressStr);
     String[] addrs = addressStr.split(",");
-    ImmutableList.Builder<HostAndPort> addrsBuilder = ImmutableList.builder();
+    ImmutableList.Builder<URI> addrsBuilder = ImmutableList.builder();
     for (String addr : addrs) {
-      addrsBuilder.add(HostAndPort.fromString(addr));
+      addrsBuilder.add(URI.create("http://" + addr));
     }
     return addrsBuilder.build();
   }
@@ -115,7 +115,7 @@ public class TiConfiguration implements Serializable {
     return this;
   }
 
-  public List<HostAndPort> getPdAddrs() {
+  public List<URI> getPdAddrs() {
     return pdAddrs;
   }
 

--- a/tikv-client/src/main/java/com/pingcap/tikv/codec/Codec.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/codec/Codec.java
@@ -17,7 +17,6 @@ package com.pingcap.tikv.codec;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.pingcap.tikv.exception.InvalidCodecFormatException;
 import gnu.trove.list.array.TIntArrayList;
 import java.math.BigDecimal;

--- a/tikv-client/src/main/java/com/pingcap/tikv/util/RangeSplitter.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/util/RangeSplitter.java
@@ -20,7 +20,6 @@ import static com.pingcap.tikv.util.KeyRangeUtils.formatByteString;
 import static com.pingcap.tikv.util.KeyRangeUtils.makeCoprocRange;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.net.HostAndPort;
 import com.google.protobuf.ByteString;
 import com.pingcap.tikv.exception.TiExpressionException;
 import com.pingcap.tikv.key.Key;
@@ -34,6 +33,7 @@ import com.pingcap.tikv.region.TiRegion;
 import gnu.trove.list.array.TLongArrayList;
 import gnu.trove.map.hash.TLongObjectHashMap;
 import java.io.Serializable;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -57,7 +57,7 @@ public class RangeSplitter {
       this.ranges = ranges;
       String host = null;
       try {
-        host = HostAndPort.fromString(store.getAddress()).getHostText();
+        host = URI.create(store.getAddress()).getHost();
       } catch (Exception ignored) {
       }
       this.host = host;

--- a/tikv-client/src/main/java/com/pingcap/tikv/util/RangeSplitter.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/util/RangeSplitter.java
@@ -57,7 +57,7 @@ public class RangeSplitter {
       this.ranges = ranges;
       String host = null;
       try {
-        host = URI.create(store.getAddress()).getHost();
+        host = URI.create("http://" + store.getAddress()).getHost();
       } catch (Exception ignored) {
       }
       this.host = host;

--- a/tikv-client/src/test/java/com/pingcap/tikv/catalog/CatalogTransactionTest.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/catalog/CatalogTransactionTest.java
@@ -24,7 +24,7 @@ import com.pingcap.tikv.meta.TiTableInfo;
 import java.util.List;
 import org.junit.Test;
 
-public class CatalogTransactionTest  extends CatalogTest {
+public class CatalogTransactionTest extends CatalogTest {
   @Test
   public void getLatestSchemaVersionTest() {
     MetaMockHelper helper = new MetaMockHelper(pdServer, kvServer);

--- a/tikv-client/src/test/java/com/pingcap/tikv/operation/SchemaInferTest.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/operation/SchemaInferTest.java
@@ -77,7 +77,7 @@ public class SchemaInferTest {
 
   private List<TiDAGRequest> makeSelectDAGReq(ByItem... byItems) {
     List<TiDAGRequest> reqs = new ArrayList<>();
-    for(ByItem byItem: byItems) {
+    for (ByItem byItem : byItems) {
       // select sum(number) from t1 group by name;
       TiDAGRequest dagRequest = new TiDAGRequest(TiDAGRequest.PushDownType.NORMAL);
       dagRequest.setTableInfo(table);
@@ -95,12 +95,11 @@ public class SchemaInferTest {
   public void selectAggWithGroupBySchemaInferTest() {
     // select sum(number) from t1 group by name;
     List<TiDAGRequest> dagRequests = makeSelectDAGReq(simpleGroupBy, complexGroupBy);
-    for(TiDAGRequest req: dagRequests) {
+    for (TiDAGRequest req : dagRequests) {
       List<DataType> dataTypes = SchemaInfer.create(req).getTypes();
       assertEquals(2, dataTypes.size());
       assertEquals(DecimalType.DECIMAL.getClass(), dataTypes.get(0).getClass());
       assertEquals(StringType.VARCHAR.getClass(), dataTypes.get(1).getClass());
     }
-
   }
 }


### PR DESCRIPTION
Previously: if the pd is using an ipv6 address, HostAndPort cannot resolve address correctly.