### PR TITLE
Ignore AlterTable test for CI

### DIFF
--- a/core/src/test/scala/org/apache/spark/sql/AlterTableTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/AlterTableTestSuite.scala
@@ -47,7 +47,7 @@ class AlterTableTestSuite extends BaseTiSparkSuite {
 
   // https://github.com/pingcap/tispark/issues/313
   // https://github.com/pingcap/tikv-client-lib-java/issues/198
-  test("Default value information not fetched") {
+  ignore("Default value information not fetched") {
     alterTable("varchar(45)", "\"a\"", "\"b\"", "\"c\"")
     alterTable(
       "datetime",


### PR DESCRIPTION
Current test reveals unexpected result due to new TiDB version. Ignore this test for CI before we fix it in TiDB. 