### PR TITLE
Fix default value bug

### DIFF
--- a/core/src/test/scala/org/apache/spark/sql/AlterTableTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/AlterTableTestSuite.scala
@@ -47,7 +47,7 @@ class AlterTableTestSuite extends BaseTiSparkSuite {
 
   // https://github.com/pingcap/tispark/issues/313
   // https://github.com/pingcap/tikv-client-lib-java/issues/198
-  ignore("Default value information not fetched") {
+  test("Default value information not fetched") {
     alterTable("varchar(45)", "\"a\"", "\"b\"", "\"c\"")
     alterTable(
       "datetime",

--- a/core/src/test/scala/org/apache/spark/sql/BaseTiSparkSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/BaseTiSparkSuite.scala
@@ -43,6 +43,13 @@ class BaseTiSparkSuite extends QueryTest with SharedSQLContext {
     dfData(df, schema)
   }
 
+  protected def querySparkJdbc(query:String): List[List[Any]] = {
+    val df = jdbc.sql(query)
+    val schema = df.schema.fields
+
+    dfData(df, schema)
+  }
+
   protected def queryTiDB(query: String): List[List[Any]] = {
     val resultSet = tidbStmt.executeQuery(query)
     val rsMetaData = resultSet.getMetaData
@@ -187,8 +194,13 @@ class BaseTiSparkSuite extends QueryTest with SharedSQLContext {
   protected def judge(str: String, skipped: Boolean = false, checkLimit: Boolean = true): Unit =
     assert(execDBTSAndJudge(str, skipped, checkLimit))
 
-  private def compSparkWithTiDB(sql: String, checkLimit: Boolean = true): Boolean =
-    compSqlResult(sql, querySpark(sql), queryTiDB(sql), checkLimit)
+  private def compSparkWithTiDB(sql: String, checkLimit: Boolean = true): Boolean = {
+    val sparkStr = querySpark(sql)
+    val tidbStr = queryTiDB(sql)
+    println(sparkStr)
+    println(tidbStr)
+    compSqlResult(sql, sparkStr, tidbStr, checkLimit)
+  }
 
   protected def execDBTSAndJudge(str: String,
                                  skipped: Boolean = false,
@@ -348,7 +360,8 @@ class BaseTiSparkSuite extends QueryTest with SharedSQLContext {
 
     if (!skipJDBC && r2 == null) {
       try {
-        r2 = querySpark(qJDBC)
+//        r2 = querySpark(qJDBC)
+        r2 = querySparkJdbc(qSpark)
       } catch {
         case e: Throwable =>
           logger.warn(s"Spark with JDBC failed when executing:$qJDBC", e) // JDBC failed

--- a/core/src/test/scala/org/apache/spark/sql/BaseTiSparkSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/BaseTiSparkSuite.scala
@@ -43,13 +43,6 @@ class BaseTiSparkSuite extends QueryTest with SharedSQLContext {
     dfData(df, schema)
   }
 
-  protected def querySparkJdbc(query:String): List[List[Any]] = {
-    val df = jdbc.sql(query)
-    val schema = df.schema.fields
-
-    dfData(df, schema)
-  }
-
   protected def queryTiDB(query: String): List[List[Any]] = {
     val resultSet = tidbStmt.executeQuery(query)
     val rsMetaData = resultSet.getMetaData
@@ -360,8 +353,7 @@ class BaseTiSparkSuite extends QueryTest with SharedSQLContext {
 
     if (!skipJDBC && r2 == null) {
       try {
-//        r2 = querySpark(qJDBC)
-        r2 = querySparkJdbc(qSpark)
+        r2 = querySpark(qJDBC)
       } catch {
         case e: Throwable =>
           logger.warn(s"Spark with JDBC failed when executing:$qJDBC", e) // JDBC failed

--- a/core/src/test/scala/org/apache/spark/sql/BaseTiSparkSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/BaseTiSparkSuite.scala
@@ -187,13 +187,8 @@ class BaseTiSparkSuite extends QueryTest with SharedSQLContext {
   protected def judge(str: String, skipped: Boolean = false, checkLimit: Boolean = true): Unit =
     assert(execDBTSAndJudge(str, skipped, checkLimit))
 
-  private def compSparkWithTiDB(sql: String, checkLimit: Boolean = true): Boolean = {
-    val sparkStr = querySpark(sql)
-    val tidbStr = queryTiDB(sql)
-    println(sparkStr)
-    println(tidbStr)
-    compSqlResult(sql, sparkStr, tidbStr, checkLimit)
-  }
+  private def compSparkWithTiDB(sql: String, checkLimit: Boolean = true): Boolean =
+    compSqlResult(sql, querySpark(sql), queryTiDB(sql), checkLimit)
 
   protected def execDBTSAndJudge(str: String,
                                  skipped: Boolean = false,

--- a/tikv-client/src/main/java/com/pingcap/tikv/meta/TiColumnInfo.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/meta/TiColumnInfo.java
@@ -52,8 +52,7 @@ public class TiColumnInfo implements Serializable {
     return new TiColumnInfo(-1, "_tidb_rowid", offset, IntegerType.ROW_ID_TYPE, true);
   }
 
-  @VisibleForTesting
-  private static final int PK_MASK = 0x2;
+  @VisibleForTesting private static final int PK_MASK = 0x2;
 
   @JsonCreator
   public TiColumnInfo(

--- a/tikv-client/src/main/java/com/pingcap/tikv/meta/TiColumnInfo.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/meta/TiColumnInfo.java
@@ -43,7 +43,6 @@ public class TiColumnInfo implements Serializable {
   private final boolean isPrimaryKey;
   private final String defaultValue;
   private final String originDefaultValue;
-
   // this version is from ColumnInfo which is used to address compatible issue.
   // If version is 0 then timestamp's default value will be read and decoded as local timezone.
   // if version is 1 then timestamp's default value will be read and decoded as utc.

--- a/tikv-client/src/main/java/com/pingcap/tikv/meta/TiColumnInfo.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/meta/TiColumnInfo.java
@@ -175,7 +175,7 @@ public class TiColumnInfo implements Serializable {
 
   private ByteString getOriginDefaultValueAsByteString() {
     CodecDataOutput cdo = new CodecDataOutput();
-    type.encode(cdo, EncodeType.VALUE, type.getOriginDefaultValue(originDefaultValue));
+    type.encode(cdo, EncodeType.VALUE, type.getOriginDefaultValue(originDefaultValue, version));
     return cdo.toByteString();
   }
 

--- a/tikv-client/src/main/java/com/pingcap/tikv/meta/TiTableInfo.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/meta/TiTableInfo.java
@@ -45,7 +45,6 @@ public class TiTableInfo implements Serializable {
   private final long maxIndexId;
   private final long oldSchemaId;
   private final TiPartitionInfo partitionInfo;
-  private TiPartitionExpr partitionExpr;
 
   @JsonCreator
   public TiTableInfo(
@@ -116,19 +115,19 @@ public class TiTableInfo implements Serializable {
     return comment;
   }
 
-  public long getAutoIncId() {
+  private long getAutoIncId() {
     return autoIncId;
   }
 
-  public long getMaxColumnId() {
+  private long getMaxColumnId() {
     return maxColumnId;
   }
 
-  public long getMaxIndexId() {
+  private long getMaxIndexId() {
     return maxIndexId;
   }
 
-  public long getOldSchemaId() {
+  private long getOldSchemaId() {
     return oldSchemaId;
   }
 
@@ -136,7 +135,7 @@ public class TiTableInfo implements Serializable {
     return partitionInfo;
   }
 
-  public TableInfo toProto() {
+  TableInfo toProto() {
     return TableInfo.newBuilder()
         .setTableId(getId())
         .addAllColumns(
@@ -146,7 +145,7 @@ public class TiTableInfo implements Serializable {
 
   // Only Integer Column will be a PK column
   // and there exists only one PK column
-  public TiColumnInfo getPrimaryKeyColumn() {
+  TiColumnInfo getPrimaryKeyColumn() {
     if (isPkHandle()) {
       for (TiColumnInfo col : getColumns()) {
         if (col.isPrimaryKey()) {
@@ -174,7 +173,8 @@ public class TiTableInfo implements Serializable {
                 col.getSchemaState(),
                 col.getOriginDefaultValue(),
                 col.getDefaultValue(),
-                col.getComment());
+                col.getComment(),
+                col.getVersion());
         newColumns.add(newCol.copyWithoutPrimaryKey());
       }
       newColumns.add(TiColumnInfo.getRowIdColumn(getColumns().size()));

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/BytesType.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/BytesType.java
@@ -96,7 +96,7 @@ public class BytesType extends DataType {
 
   /** {@inheritDoc} */
   @Override
-  public Object getOriginDefaultValueNonNull(String value) {
+  public Object getOriginDefaultValueNonNull(String value, long version) {
     return value;
   }
 }

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/Converter.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/Converter.java
@@ -101,9 +101,15 @@ public class Converter {
       DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss").withZone(localTimeZone);
   private static final DateTimeFormatter localDateFormatter =
       DateTimeFormat.forPattern("yyyy-MM-dd").withZone(localTimeZone);
+  public static final DateTimeFormatter UTC_TIME_FORMATTER =
+      DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss").withZone(DateTimeZone.UTC);
 
   public static DateTimeZone getLocalTimezone() {
     return localTimeZone;
+  }
+
+  public static DateTime strToDateTime(String value, DateTimeFormatter formatter) {
+    return DateTime.parse(value, formatter);
   }
 
   /**
@@ -120,7 +126,7 @@ public class Converter {
     } else if (val instanceof String) {
       // interpret string as in local timezone
       try {
-        return DateTime.parse((String) val, localDateTimeFormatter);
+        return strToDateTime((String)val, localDateTimeFormatter);
       } catch (Exception e) {
         throw new TypeException(
             String.format("Error parsing string %s to datetime", (String) val), e);

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/Converter.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/Converter.java
@@ -126,7 +126,7 @@ public class Converter {
     } else if (val instanceof String) {
       // interpret string as in local timezone
       try {
-        return strToDateTime((String)val, localDateTimeFormatter);
+        return strToDateTime((String) val, localDateTimeFormatter);
       } catch (Exception e) {
         throw new TypeException(
             String.format("Error parsing string %s to datetime", (String) val), e);

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/DataType.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/DataType.java
@@ -49,6 +49,15 @@ public abstract class DataType implements Serializable {
   public static final int NoDefaultValueFlag = 4096; /* Field doesn't have a default value */
   public static final int OnUpdateNowFlag = 8192; /* Field is set to NOW on UPDATE */
   public static final int NumFlag = 32768; /* Field is a num (for clients) */
+  public static final long COLUMN_VERSION_FLAG = 1;
+
+  public long getVersion() {
+    return version;
+  }
+
+  public void setVersion(long version) {
+    this.version = version;
+  }
 
   public enum EncodeType {
     KEY,
@@ -68,6 +77,9 @@ public abstract class DataType implements Serializable {
   protected final int collation;
   protected final long length;
   private final List<String> elems;
+
+
+  private long version;
 
   protected DataType(TiColumnInfo.InternalTypeHolder holder) {
     this.tp = MySQLType.fromTypeCode(holder.getTp());
@@ -353,8 +365,6 @@ public abstract class DataType implements Serializable {
         length,
         decimal,
         charset,
-        "",
-        "",
         Collation.translate(collation),
         elems);
   }

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/DataType.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/DataType.java
@@ -349,12 +349,6 @@ public abstract class DataType implements Serializable {
 
   public InternalTypeHolder toTypeHolder() {
     return new InternalTypeHolder(
-        getTypeCode(),
-        flag,
-        length,
-        decimal,
-        charset,
-        Collation.translate(collation),
-        elems);
+        getTypeCode(), flag, length, decimal, charset, Collation.translate(collation), elems);
   }
 }

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/DataType.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/DataType.java
@@ -51,14 +51,6 @@ public abstract class DataType implements Serializable {
   public static final int NumFlag = 32768; /* Field is a num (for clients) */
   public static final long COLUMN_VERSION_FLAG = 1;
 
-  public long getVersion() {
-    return version;
-  }
-
-  public void setVersion(long version) {
-    this.version = version;
-  }
-
   public enum EncodeType {
     KEY,
     VALUE,
@@ -77,9 +69,6 @@ public abstract class DataType implements Serializable {
   protected final int collation;
   protected final long length;
   private final List<String> elems;
-
-
-  private long version;
 
   protected DataType(TiColumnInfo.InternalTypeHolder holder) {
     this.tp = MySQLType.fromTypeCode(holder.getTp());
@@ -227,11 +216,11 @@ public abstract class DataType implements Serializable {
    * @param value a int value represents in string
    * @return a int object
    */
-  public abstract Object getOriginDefaultValueNonNull(String value);
+  public abstract Object getOriginDefaultValueNonNull(String value, long version);
 
-  public Object getOriginDefaultValue(String value) {
+  public Object getOriginDefaultValue(String value, long version) {
     if (value == null) return null;
-    return getOriginDefaultValueNonNull(value);
+    return getOriginDefaultValueNonNull(value, version);
   }
 
   public int getCollationCode() {

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/DateTimeType.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/DateTimeType.java
@@ -60,7 +60,7 @@ public class DateTimeType extends AbstractDateTimeType {
   }
 
   @Override
-  public DateTime getOriginDefaultValueNonNull(String value) {
+  public DateTime getOriginDefaultValueNonNull(String value, long version) {
     return Converter.convertToDateTime(value);
   }
 }

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/DateType.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/DateType.java
@@ -43,7 +43,7 @@ public class DateType extends AbstractDateTimeType {
   }
 
   @Override
-  public Date getOriginDefaultValueNonNull(String value) {
+  public Date getOriginDefaultValueNonNull(String value, long version) {
     return Converter.convertToDate(value);
   }
 

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/DecimalType.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/DecimalType.java
@@ -72,7 +72,7 @@ public class DecimalType extends DataType {
 
   /** {@inheritDoc} */
   @Override
-  public Object getOriginDefaultValueNonNull(String value) {
+  public Object getOriginDefaultValueNonNull(String value, long version) {
     return new BigDecimal(value);
   }
 }

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/EnumType.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/EnumType.java
@@ -73,7 +73,7 @@ public class EnumType extends DataType {
 
   /** {@inheritDoc} */
   @Override
-  public Object getOriginDefaultValueNonNull(String value) {
+  public Object getOriginDefaultValueNonNull(String value, long version) {
     return value;
   }
 }

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/IntegerType.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/IntegerType.java
@@ -135,7 +135,7 @@ public class IntegerType extends DataType {
 
   /** {@inheritDoc} */
   @Override
-  public Object getOriginDefaultValueNonNull(String value) {
+  public Object getOriginDefaultValueNonNull(String value, long version) {
     return Integer.parseInt(value);
   }
 

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/JsonType.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/JsonType.java
@@ -368,7 +368,7 @@ public class JsonType extends DataType {
   }
 
   @Override
-  public Object getOriginDefaultValueNonNull(String value) {
+  public Object getOriginDefaultValueNonNull(String value, long version) {
     throw new AssertionError("json can't have a default value");
   }
 }

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/RealType.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/RealType.java
@@ -84,7 +84,7 @@ public class RealType extends DataType {
 
   /** {@inheritDoc} */
   @Override
-  public Object getOriginDefaultValueNonNull(String value) {
+  public Object getOriginDefaultValueNonNull(String value, long version) {
     return Double.parseDouble(value);
   }
 }

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/SetType.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/SetType.java
@@ -111,7 +111,7 @@ public class SetType extends DataType {
 
   /** {@inheritDoc} */
   @Override
-  public Object getOriginDefaultValueNonNull(String value) {
+  public Object getOriginDefaultValueNonNull(String value, long version) {
     return value;
   }
 }

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/TimeType.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/TimeType.java
@@ -90,7 +90,7 @@ public class TimeType extends DataType {
   }
 
   @Override
-  public Object getOriginDefaultValueNonNull(String value) {
+  public Object getOriginDefaultValueNonNull(String value, long version) {
     return Converter.convertStrToDuration(value);
   }
 }

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/TimestampType.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/TimestampType.java
@@ -72,10 +72,13 @@ public class TimestampType extends AbstractDateTimeType {
   }
 
   @Override
-  public DateTime getOriginDefaultValueNonNull(String value) {
-    LocalDateTime localDateTime = Converter.strToDateTime(value, UTC_TIME_FORMATTER)
+  public DateTime getOriginDefaultValueNonNull(String value, long version) {
+    if(version == DataType.COLUMN_VERSION_FLAG) {
+      LocalDateTime localDateTime = Converter.strToDateTime(value, UTC_TIME_FORMATTER)
         .withZone(DateTimeZone.getDefault()).toLocalDateTime();
-    return localDateTime.toDateTime();
+      return localDateTime.toDateTime();
+    }
+    return Converter.convertToDateTime(value);
   }
 
   /** {@inheritDoc} */

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/TimestampType.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/TimestampType.java
@@ -73,9 +73,11 @@ public class TimestampType extends AbstractDateTimeType {
 
   @Override
   public DateTime getOriginDefaultValueNonNull(String value, long version) {
-    if(version == DataType.COLUMN_VERSION_FLAG) {
-      LocalDateTime localDateTime = Converter.strToDateTime(value, UTC_TIME_FORMATTER)
-        .withZone(DateTimeZone.getDefault()).toLocalDateTime();
+    if (version == DataType.COLUMN_VERSION_FLAG) {
+      LocalDateTime localDateTime =
+          Converter.strToDateTime(value, UTC_TIME_FORMATTER)
+              .withZone(DateTimeZone.getDefault())
+              .toLocalDateTime();
       return localDateTime.toDateTime();
     }
     return Converter.convertToDateTime(value);

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/TimestampType.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/TimestampType.java
@@ -17,6 +17,8 @@
 
 package com.pingcap.tikv.types;
 
+import static com.pingcap.tikv.types.Converter.UTC_TIME_FORMATTER;
+
 import com.pingcap.tikv.codec.Codec.DateTimeCodec;
 import com.pingcap.tikv.codec.CodecDataInput;
 import com.pingcap.tikv.codec.CodecDataOutput;
@@ -24,6 +26,7 @@ import com.pingcap.tikv.meta.TiColumnInfo;
 import java.sql.Timestamp;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
+import org.joda.time.LocalDateTime;
 
 /**
  * Timestamp in TiDB is represented as packed long including year/month and etc. When stored, it is
@@ -70,13 +73,15 @@ public class TimestampType extends AbstractDateTimeType {
 
   @Override
   public DateTime getOriginDefaultValueNonNull(String value) {
-    return Converter.convertToDateTime(value);
+    LocalDateTime localDateTime = Converter.strToDateTime(value, UTC_TIME_FORMATTER)
+        .withZone(DateTimeZone.getDefault()).toLocalDateTime();
+    return localDateTime.toDateTime();
   }
 
   /** {@inheritDoc} */
   @Override
   protected void encodeProto(CodecDataOutput cdo, Object value) {
-    DateTime dt = Converter.convertToDateTime(value);
+    DateTime dt = Converter.convertToDateTime(value).toDateTime(DateTimeZone.UTC);
     DateTimeCodec.writeDateTimeProto(cdo, dt, Converter.getLocalTimezone());
   }
 }

--- a/tikv-client/src/test/java/com/pingcap/tikv/predicates/ScanAnalyzerTest.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/predicates/ScanAnalyzerTest.java
@@ -64,9 +64,8 @@ public class ScanAnalyzerTest {
             0,
             "",
             "",
-            "",
-            "",
-            ImmutableList.of());
+            ImmutableList.of()
+        );
 
     DataType typePrefix = DataTypeFactory.of(holder);
     return new MetaUtils.TableBuilder()
@@ -366,8 +365,6 @@ public class ScanAnalyzerTest {
             0,
             3, // indicating a prefix type
             0,
-            "",
-            "",
             "",
             "",
             ImmutableList.of());

--- a/tikv-client/src/test/java/com/pingcap/tikv/predicates/ScanAnalyzerTest.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/predicates/ScanAnalyzerTest.java
@@ -64,8 +64,7 @@ public class ScanAnalyzerTest {
             0,
             "",
             "",
-            ImmutableList.of()
-        );
+            ImmutableList.of());
 
     DataType typePrefix = DataTypeFactory.of(holder);
     return new MetaUtils.TableBuilder()

--- a/tikv-client/src/test/java/com/pingcap/tikv/types/DataTypeFactoryTest.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/types/DataTypeFactoryTest.java
@@ -26,7 +26,7 @@ import org.junit.Test;
 public class DataTypeFactoryTest {
 
   private static InternalTypeHolder createHolder(MySQLType type) {
-    return new InternalTypeHolder(type.getTypeCode(), 0, 0, 0, "",  "", ImmutableList.of());
+    return new InternalTypeHolder(type.getTypeCode(), 0, 0, 0, "", "", ImmutableList.of());
   }
 
   private void mappingTest(MySQLType type, Class<? extends DataType> cls) {

--- a/tikv-client/src/test/java/com/pingcap/tikv/types/DataTypeFactoryTest.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/types/DataTypeFactoryTest.java
@@ -26,7 +26,7 @@ import org.junit.Test;
 public class DataTypeFactoryTest {
 
   private static InternalTypeHolder createHolder(MySQLType type) {
-    return new InternalTypeHolder(type.getTypeCode(), 0, 0, 0, "", "", "", "", ImmutableList.of());
+    return new InternalTypeHolder(type.getTypeCode(), 0, 0, 0, "",  "", ImmutableList.of());
   }
 
   private void mappingTest(MySQLType type, Class<? extends DataType> cls) {


### PR DESCRIPTION
This PR fixes timestamp's default value bug. 

TiDB used to store timestamp value at local timezone, but they recently change to store timestamp value at utc. This PR brings the changes to our codebase. 