### PR TITLE
TISPARK-67: batch write framework: an ugly implementation

### DIFF
--- a/core/src/main/scala/com/pingcap/tispark/TiBatchWrite.scala
+++ b/core/src/main/scala/com/pingcap/tispark/TiBatchWrite.scala
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2017 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pingcap.tispark
+
+import com.pingcap.tikv.TiBatchWriteUtils
+import com.pingcap.tikv.codec.KeyUtils
+import com.pingcap.tikv.key.{Key, RowKey}
+import com.pingcap.tikv.region.TiRegion
+import com.pingcap.tikv.row.ObjectRowImpl
+import com.pingcap.tikv.util.KeyRangeUtils
+import org.apache.spark.Partitioner
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.TiContext
+import org.slf4j.LoggerFactory
+
+/**
+ * An ugly implementation of batch write framework, which will be
+ * replaced by spark api.
+ */
+object TiBatchWrite {
+  private final val logger = LoggerFactory.getLogger(getClass.getName)
+
+  type SparkRow = org.apache.spark.sql.Row
+  type TiRow = com.pingcap.tikv.row.Row
+  type TiDataType = com.pingcap.tikv.types.DataType
+
+  def writeToTiDB(rdd: RDD[SparkRow], tableRef: TiTableReference, tiContext: TiContext) {
+    // TODO: region pre-split
+    // pending: https://internal.pingcap.net/jira/browse/TISPARK-69
+
+    // TODO: lock table
+    // pending: https://internal.pingcap.net/jira/browse/TIDB-1628
+
+    // shuffle data in same task which belong to same region
+    val shuffledRDD = {
+      val tiKVRowRDD = rdd.map(sparkRow2TiKVRow)
+      shuffleToSameRegion(tiKVRowRDD, tableRef, tiContext)
+    }
+
+    // TODO: resolve lock
+    // why here? can we do resolve after receiving an error during writing data?
+
+    // take one row as primary key
+    val (primaryKey: SerializableKey, primaryRow: TiRow) = {
+      val takeOne = shuffledRDD.take(1)
+      if (takeOne.length == 0) {
+        logger.warn("there is no data in source rdd")
+        return
+      } else {
+        takeOne(0)
+      }
+    }
+    logger.info(s"primary key: $primaryKey primary row: $primaryRow")
+
+    // TODO: get timestamp as start_ts
+
+    // TODO: driver primary pre-write
+
+    // TODO: executors secondary pre-write
+
+    // TODO: driver primary commit
+
+    // TODO: executors secondary commit
+
+    // print for test
+    shuffledRDD.foreachPartition { iterator =>
+      println("==partition begin==")
+      iterator.foreach {
+        case (key, row) =>
+          println("key=" + key.toString + " row=" + row.toString)
+      }
+    }
+
+  }
+
+  private def shuffleToSameRegion(rdd: RDD[TiRow],
+                                  tableRef: TiTableReference,
+                                  tiContext: TiContext): RDD[(SerializableKey, TiRow)] = {
+    val regions = getRegions(tableRef, tiContext)
+    val tiRegionPartitioner = new TiRegionPartitioner(regions)
+    val databaseName = tableRef.databaseName
+    val tableName = tableRef.tableName
+    val session = tiContext.tiSession
+    val table = session.getCatalog.getTable(databaseName, tableName)
+    val tableId = table.getId
+
+    logger.info(
+      s"find ${regions.size} regions in database: $databaseName table: $tableName tableId: $tableId"
+    )
+
+    rdd
+      .map(row => (tiKVRow2Key(row, tableId), row))
+      .groupByKey(tiRegionPartitioner)
+      .map {
+        case (key, iterable) =>
+          // remove duplicate rows if key equals
+          (key, iterable.head)
+      }
+  }
+
+  private def getRegions(tableRef: TiTableReference, tiContext: TiContext): List[TiRegion] = {
+    import scala.collection.JavaConversions._
+    TiBatchWriteUtils
+      .getRegionsByTable(tiContext.tiSession, tableRef.databaseName, tableRef.tableName)
+      .toList
+  }
+
+  private def tiKVRow2Key(row: TiRow, tableId: Long): SerializableKey = {
+    // TODO: how to get primary key if exists || auto generate a primary key if does not exists
+    // pending: https://internal.pingcap.net/jira/browse/TISPARK-70
+    val handle = row.getLong(0)
+
+    val rowKey = RowKey.toRowKey(tableId, handle)
+    new SerializableKey(rowKey.getBytes)
+  }
+
+  private def sparkRow2TiKVRow(sparkRow: SparkRow): TiRow = {
+    val fieldCount = sparkRow.size
+    val tiRow = ObjectRowImpl.create(fieldCount)
+    for (i <- 0 until fieldCount) {
+      val data = sparkRow.get(i)
+      val sparkDataType = sparkRow.schema(i).dataType
+      val tiDataType = TiUtils.fromSparkType(sparkDataType)
+      tiRow.set(i, tiDataType, data)
+    }
+    tiRow
+  }
+}
+
+class TiRegionPartitioner(regions: List[TiRegion]) extends Partitioner {
+  override def numPartitions: Int = regions.length
+
+  override def getPartition(key: Any): Int = {
+    val serializableKey = key.asInstanceOf[SerializableKey]
+    val rawKey = Key.toRawKey(serializableKey.bytes)
+
+    regions.indices.foreach { i =>
+      val region = regions(i)
+      val range = KeyRangeUtils.makeRange(region.getStartKey, region.getEndKey)
+
+      if (range.contains(rawKey)) {
+        return i
+      }
+    }
+
+    0
+  }
+}
+
+class SerializableKey(val bytes: Array[Byte]) extends Serializable {
+  override def toString: String =
+    KeyUtils.formatBytes(bytes)
+}

--- a/core/src/main/scala/com/pingcap/tispark/TiBatchWrite.scala
+++ b/core/src/main/scala/com/pingcap/tispark/TiBatchWrite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2019 PingCAP, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,9 +28,9 @@ import org.apache.spark.sql.TiContext
 import org.slf4j.LoggerFactory
 
 /**
-  * An ugly implementation of batch write framework, which will be
-  * replaced by spark api.
-  */
+ * An ugly implementation of batch write framework, which will be
+ * replaced by spark api.
+ */
 object TiBatchWrite {
   private final val logger = LoggerFactory.getLogger(getClass.getName)
 
@@ -79,8 +79,8 @@ object TiBatchWrite {
 
   @throws(classOf[TableNotExistException])
   private def shuffleKeyToSameRegion(rdd: RDD[TiRow],
-                                  tableRef: TiTableReference,
-                                  tiContext: TiContext): RDD[(SerializableKey, TiRow)] = {
+                                     tableRef: TiTableReference,
+                                     tiContext: TiContext): RDD[(SerializableKey, TiRow)] = {
     val regions = getRegions(tableRef, tiContext)
     val tiRegionPartitioner = new TiRegionPartitioner(regions)
     val databaseName = tableRef.databaseName
@@ -106,7 +106,9 @@ object TiBatchWrite {
   @throws(classOf[TableNotExistException])
   private def getRegions(tableRef: TiTableReference, tiContext: TiContext): List[TiRegion] = {
     import scala.collection.JavaConversions._
-    TiBatchWriteUtils.getRegionsByTable(tiContext.tiSession, tableRef.databaseName, tableRef.tableName).toList
+    TiBatchWriteUtils
+      .getRegionsByTable(tiContext.tiSession, tableRef.databaseName, tableRef.tableName)
+      .toList
   }
 
   private def tiKVRow2Key(row: TiRow, tableId: Long): SerializableKey = {

--- a/core/src/test/scala/org/apache/spark/sql/TiBatchWriteSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/TiBatchWriteSuite.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql
+
+import com.pingcap.tispark.{TiBatchWrite, TiTableReference}
+import org.apache.spark.rdd.RDD
+import org.scalatest.Ignore
+
+@Ignore
+class TiBatchWriteSuite extends BaseTiSparkSuite {
+  test("ti batch write") {
+    sql("show databases").show()
+    sql("use tidb_tpch_test")
+    val df = sql("select * from CUSTOMER")
+    df.show()
+
+    val rdd: RDD[Row] = df.rdd
+    val tableRef: TiTableReference = TiTableReference("tidb_tpch_test", "test")
+    val tiContext: TiContext = this.ti
+    TiBatchWrite.writeToTiDB(rdd, tableRef, tiContext)
+  }
+}

--- a/core/src/test/scala/org/apache/spark/sql/TiBatchWriteSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/TiBatchWriteSuite.scala
@@ -23,7 +23,7 @@ import org.scalatest.Ignore
 class TiBatchWriteSuite extends BaseTiSparkSuite {
   test("ti batch write") {
     sql("show databases").show()
-    sql("use tidb_tpch_test")
+    setCurrentDatabase("tpch_test")
     val df = sql("select * from CUSTOMER")
     df.show()
 

--- a/tikv-client/src/main/java/com/pingcap/tikv/TiBatchWriteUtils.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/TiBatchWriteUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2019 PingCAP, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
 
 package com.pingcap.tikv;
 
-import com.pingcap.tikv.codec.KeyUtils;
 import com.pingcap.tikv.exception.TableNotExistException;
 import com.pingcap.tikv.key.Key;
 import com.pingcap.tikv.key.RowKey;
@@ -27,7 +26,7 @@ import java.util.List;
 
 public class TiBatchWriteUtils {
   public static List<TiRegion> getRegionsByTable(
-      TiSession session, String databaseName, String tableName) throws TableNotExistException {
+          TiSession session, String databaseName, String tableName) throws TableNotExistException {
     TiTableInfo table = session.getCatalog().getTable(databaseName, tableName);
 
     if (table == null) {
@@ -38,18 +37,9 @@ public class TiBatchWriteUtils {
       RowKey endRowKey = RowKey.createBeyondMax(table.getId());
 
       while (key.compareTo(endRowKey) < 0) {
-        System.out.println(KeyUtils.formatBytes(key.toByteString()));
         TiRegion region = session.getRegionManager().getRegionByKey(key.toByteString());
-        if (region == null) {
-          break;
-        } else {
-          regionList.add(region);
-          byte[] endKey = region.getEndKey().toByteArray();
-          if (endKey.length == 0) {
-            break;
-          }
-          key = Key.toRawKey(endKey);
-        }
+        regionList.add(region);
+        key = Key.toRawKey(region.getEndKey());
       }
       return regionList;
     }

--- a/tikv-client/src/main/java/com/pingcap/tikv/TiBatchWriteUtils.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/TiBatchWriteUtils.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pingcap.tikv;
+
+import com.pingcap.tikv.codec.KeyUtils;
+import com.pingcap.tikv.key.Key;
+import com.pingcap.tikv.key.RowKey;
+import com.pingcap.tikv.meta.TiTableInfo;
+import com.pingcap.tikv.region.TiRegion;
+import java.util.ArrayList;
+import java.util.List;
+
+public class TiBatchWriteUtils {
+  public static List<TiRegion> getRegionsByTable(
+      TiSession session, String databaseName, String tableName) {
+    ArrayList<TiRegion> regionList = new ArrayList<>();
+    TiTableInfo table = session.getCatalog().getTable(databaseName, tableName);
+
+    Key key = RowKey.createMin(table.getId());
+    RowKey endRowKey = RowKey.createBeyondMax(table.getId());
+
+    while (key.compareTo(endRowKey) < 0) {
+      System.out.println(KeyUtils.formatBytes(key.toByteString()));
+      TiRegion region = session.getRegionManager().getRegionByKey(key.toByteString());
+      if (region == null) {
+        break;
+      } else {
+        regionList.add(region);
+        key = Key.toRawKey(region.getEndKey().toByteArray());
+      }
+    }
+
+    return regionList;
+  }
+}

--- a/tikv-client/src/main/java/com/pingcap/tikv/exception/TableNotExistException.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/exception/TableNotExistException.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2017 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pingcap.tikv.exception;
+
+public class TableNotExistException extends RuntimeException {
+  private String databaseName;
+  private String tableName;
+
+  public TableNotExistException(String databaseName, String tableName) {
+    this.databaseName = databaseName;
+    this.tableName = tableName;
+  }
+}

--- a/tikv-client/src/main/java/com/pingcap/tikv/exception/TableNotExistException.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/exception/TableNotExistException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2019 PingCAP, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,7 @@
 package com.pingcap.tikv.exception;
 
 public class TableNotExistException extends RuntimeException {
-  private String databaseName;
-  private String tableName;
-
   public TableNotExistException(String databaseName, String tableName) {
-    this.databaseName = databaseName;
-    this.tableName = tableName;
+    super("table(" + tableName + ") does not exist in database(" + databaseName + ")");
   }
 }

--- a/tikv-client/src/main/java/com/pingcap/tikv/row/Row.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/row/Row.java
@@ -18,6 +18,7 @@
 package com.pingcap.tikv.row;
 
 import com.pingcap.tikv.types.DataType;
+import java.io.Serializable;
 import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;
@@ -26,7 +27,7 @@ import java.sql.Timestamp;
  * Even in case of mem-buffer-based row we can ignore field types when en/decoding if we put some
  * padding bits for fixed length and use fixed length index for var-length
  */
-public interface Row {
+public interface Row extends Serializable {
   void setNull(int pos);
 
   boolean isNull(int pos);


### PR DESCRIPTION
batch write framework
1. get table region info
2. shuffle by region
3. spark row -> tikv row
4. take one row as primary key