### PR TITLE
TISPARK-78: Adjust type mapping relationship

### DIFF
--- a/core/src/main/scala/com/pingcap/tispark/TiConfigConst.scala
+++ b/core/src/main/scala/com/pingcap/tispark/TiConfigConst.scala
@@ -42,4 +42,5 @@ object TiConfigConst {
 
   val SNAPSHOT_ISOLATION_LEVEL: String = "SI"
   val READ_COMMITTED_ISOLATION_LEVEL: String = "RC"
+  val TYPE_SYSTEM_VERSION: String = "spark.tispark.type_system_version"
 }

--- a/core/src/main/scala/com/pingcap/tispark/TiDBRelation.scala
+++ b/core/src/main/scala/com/pingcap/tispark/TiDBRelation.scala
@@ -40,7 +40,11 @@ case class TiDBRelation(session: TiSession,
     .getTable(tableRef.databaseName, tableRef.tableName)
     .getOrElse(throw new TiClientInternalException("Table not exist"))
 
-  override lazy val schema: StructType = TiUtil.getSchemaFromTable(table)
+  override lazy val schema: StructType =
+    TiUtil.getSchemaFromTable(
+      table,
+      sqlContext.sparkSession.conf.get(TiConfigConst.TYPE_SYSTEM_VERSION, "0").toInt
+    )
 
   override def sizeInBytes: Long = tableRef.sizeInBytes
 

--- a/core/src/main/spark-2.3/org/apache/spark/sql/catalyst/catalog/TiDirectExternalCatalog.scala
+++ b/core/src/main/spark-2.3/org/apache/spark/sql/catalyst/catalog/TiDirectExternalCatalog.scala
@@ -16,6 +16,7 @@
 package org.apache.spark.sql.catalyst.catalog
 
 import com.pingcap.tispark.utils.TiUtil
+import com.pingcap.tispark.{TiConfigConst}
 import org.apache.spark.sql.TiContext
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.{NoSuchDatabaseException, NoSuchTableException}
@@ -38,7 +39,8 @@ class TiDirectExternalCatalog(tiContext: TiContext) extends ExternalCatalog {
 
   override def getTable(db: String, table: String): CatalogTable = {
     val schema = TiUtil.getSchemaFromTable(
-      meta.getTable(db, table).getOrElse(throw new NoSuchTableException(db, table))
+      meta.getTable(db, table).getOrElse(throw new NoSuchTableException(db, table)),
+      tiContext.conf.getInt(TiConfigConst.TYPE_SYSTEM_VERSION, 0)
     )
 
     CatalogTable(

--- a/core/src/main/spark-2.4/org/apache/spark/sql/catalyst/catalog/TiDirectExternalCatalog.scala
+++ b/core/src/main/spark-2.4/org/apache/spark/sql/catalyst/catalog/TiDirectExternalCatalog.scala
@@ -16,6 +16,7 @@
 package org.apache.spark.sql.catalyst.catalog
 
 import com.pingcap.tispark.utils.TiUtil
+import com.pingcap.tispark.{TiConfigConst}
 import org.apache.spark.sql.TiContext
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.{NoSuchDatabaseException, NoSuchTableException}
@@ -38,7 +39,8 @@ class TiDirectExternalCatalog(tiContext: TiContext) extends ExternalCatalog {
 
   override def getTable(db: String, table: String): CatalogTable = {
     val schema = TiUtil.getSchemaFromTable(
-      meta.getTable(db, table).getOrElse(throw new NoSuchTableException(db, table))
+      meta.getTable(db, table).getOrElse(throw new NoSuchTableException(db, table),
+        tiContext.conf.getInt(TiConfigConst.TYPE_SYSTEM_VERSION, 0))
     )
 
     CatalogTable(

--- a/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCWriteSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCWriteSuite.scala
@@ -1,0 +1,47 @@
+package org.apache.spark.sql.jdbc
+
+import com.pingcap.tispark.TiConfigConst
+import org.apache.spark.sql.BaseTiSparkSuite
+import org.apache.spark.sql.execution.datasources.jdbc.JdbcUtils
+import org.apache.spark.sql.execution.datasources.jdbc.JdbcRelationProvider
+import org.apache.spark.sql.types.{DoubleType, IntegerType, LongType}
+
+class JDBCWriteSuite extends BaseTiSparkSuite {
+  test("write into tidb using jdbc") {
+    setCurrentDatabase("tispark_test")
+    tidbStmt.execute("create table t1 (c1 int)")
+    tidbStmt.execute("create table t3 (c1 int, d1 double)")
+    tidbStmt.execute("insert into t1 values(2)")
+    refreshConnections()
+
+    val jdbcDf = spark.sql("select round(c1) from t3_j")
+    val df1 = spark.sql("select * from t1")
+    val rows = df1.collect()
+    val schema = jdbcDf.schema
+    val it = rows.toIterator
+    var i = 0
+    while (it.hasNext) {
+      val value = it.next()
+      schema.fields(i).dataType match {
+        case LongType    => value.getLong(i)
+        case IntegerType =>
+        case DoubleType  => value.getDouble(i)
+      }
+      value.anyNull
+      i += 1
+    }
+    spark.conf.set(TiConfigConst.TYPE_SYSTEM_VERSION, 1)
+
+    val df2 = spark.sql("select * from t1")
+    assert(df2.schema.fields(0).dataType == IntegerType)
+  }
+
+  override def afterAll(): Unit =
+    try {
+      tidbStmt.execute("drop table if exists t1")
+      tidbStmt.execute("drop table if exists t2")
+      tidbStmt.execute("drop table if exists t3")
+    } finally {
+      super.afterAll()
+    }
+}

--- a/tikv-client/src/main/java/com/pingcap/tikv/TiConfiguration.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/TiConfiguration.java
@@ -44,6 +44,7 @@ public class TiConfiguration implements Serializable {
   private static final IsolationLevel DEF_ISOLATION_LEVEL = IsolationLevel.RC;
   private static final boolean DEF_SHOW_ROWID = false;
   private static final String DEF_DB_PREFIX = "";
+  private static final int TYPE_SYSTEM_VERSION = 0;
 
   private int timeout = DEF_TIMEOUT;
   private TimeUnit timeoutUnit = DEF_TIMEOUT_UNIT;
@@ -61,6 +62,7 @@ public class TiConfiguration implements Serializable {
   private int maxRequestKeyRangeSize = MAX_REQUEST_KEY_RANGE_SIZE;
   private boolean showRowId = DEF_SHOW_ROWID;
   private String dbPrefix = DEF_DB_PREFIX;
+  private int typeSystemVersion = TYPE_SYSTEM_VERSION;
 
   public static TiConfiguration createDefault(String pdAddrsStr) {
     Objects.requireNonNull(pdAddrsStr, "pdAddrsStr is null");
@@ -211,5 +213,13 @@ public class TiConfiguration implements Serializable {
 
   public void setDBPrefix(String dbPrefix) {
     this.dbPrefix = dbPrefix;
+  }
+
+  public int getTypeSystemVersion() {
+    return typeSystemVersion;
+  }
+
+  public void setTypeSystemVersion(int version) {
+    this.typeSystemVersion = version;
   }
 }


### PR DESCRIPTION
This PR will maps IntergerType.INT to IntegerType rather than LongType. 


In order to avoid compability issue, we introduce a configuration item. Once you set the value to 1, new code will work. 