### PR TITLE
Fix outputoffset when build dag req

### DIFF
--- a/core/src/test/scala/org/apache/spark/sql/expression/LogicalAndOr0Suite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/LogicalAndOr0Suite.scala
@@ -21,6 +21,7 @@ import org.apache.spark.sql.BaseInitialOnceSuite
 
 class LogicalAndOr0Suite extends BaseInitialOnceSuite {
   private val allCases = Seq[String](
+    "select tp_char, tp_smallint, tp_char, tp_smallint, tp_char from full_data_type_table  where tp_char = tp_smallint and tp_char > 0",
     "select tp_char,tp_smallint from full_data_type_table  where tp_char = tp_smallint and tp_char > 0",
     "select tp_char,id_dt from full_data_type_table  where tp_char = id_dt and tp_char > 0",
     "select tp_nvarchar,tp_tinyint from full_data_type_table  where tp_nvarchar = tp_tinyint and tp_nvarchar > 0",

--- a/tikv-client/src/main/java/com/pingcap/tikv/operation/iterator/CoprocessIterator.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/operation/iterator/CoprocessIterator.java
@@ -60,6 +60,8 @@ public abstract class CoprocessIterator<T> implements Iterator<T> {
   public static CoprocessIterator<Row> getRowIterator(
       TiDAGRequest req, List<RegionTask> regionTasks, TiSession session) {
     return new DAGIterator<Row>(
+        // If index scan is a covering index, the logic is table scan
+        // so we need set isIndexScan to false.
         req.buildScan(req.isIndexScan() && !req.isDoubleRead()),
         regionTasks,
         session,


### PR DESCRIPTION
Say we have a query `select id, id, it, it from t`. 
In the past, we construct a DAG req as follows:

```
table scan 
    addCol
        id, id, it, it
        0    1,  2 , 3
DAGReqBuilder
    addOutputOffset 
        0 1 2 3
```

It works in old TiKV, but not in the latest tikv.

The expected table scan is as follow:

```
table scan 
    addCol
        id, it
        0    1
DAGReqBuilder
    addOutputOffset 
        0 0 1 1
```

This PR fixes this.

