### PR TITLE
fix scala compile warning

### DIFF
--- a/core/src/test/scala/org/apache/spark/sql/txn/TxnTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/txn/TxnTestSuite.scala
@@ -82,7 +82,7 @@ class TxnTestSuite extends BaseTiSparkSuite {
    * @param doQuery the query operation
    * @return thread
    */
-  protected def doThread(i: Int, doQuery: () => Unit): Thread =
+  protected def doThread(i: Int, doQuery: => Unit): Thread =
     new Thread {
       override def run() {
         while (try {


### PR DESCRIPTION
Before this PR, the following will be printed out 

```
[WARNING] /Users/zhexuany/repo/scala/tispark/core/src/test/scala/org/apache/spark/sql/txn/TxnTestSuite.scala:89: warning: a pure expression does nothing in statement position; you may be omitting necessary parentheses
[WARNING]                  doQuery
[WARNING]                  ^
[WARNING] one warning found
```

This PR fixes this. 