### PR TITLE
Fix partition parser bug

### DIFF
--- a/tikv-client/src/main/java/com/pingcap/tikv/parser/AstBuilder.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/parser/AstBuilder.java
@@ -105,6 +105,11 @@ public class AstBuilder extends MySqlParserBaseVisitor<Expression> {
       return parseIntOrLongOrDec(val);
     }
 
+    if (ctx.ZERO_DECIMAL() != null) {
+      String val = ctx.ZERO_DECIMAL().getSymbol().getText();
+      return parseIntOrLongOrDec(val);
+    }
+
     throw new UnsupportedSyntaxException(ctx.toString() + ": it is not supported.");
   }
 

--- a/tikv-client/src/test/java/com/pingcap/tikv/parser/TiParserTest.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/parser/TiParserTest.java
@@ -116,6 +116,10 @@ public class TiParserTest {
     Expression and = parser.parseExpression(sql);
     Assert.assertEquals(and.toString(), "[[[id] LESS_THAN 1] AND [[id] GREATER_EQUAL 3]]");
 
+    sql = "id < 1 and id >= 0";
+    and = parser.parseExpression(sql);
+    Assert.assertEquals(and.toString(), "[[[id] LESS_THAN 1] AND [[id] GREATER_EQUAL 0]]");
+
     sql = "''";
     stringLiteral = parser.parseExpression(sql);
     Assert.assertEquals(stringLiteral, Constant.create("''"));


### PR DESCRIPTION
Zero_Decimal is not considered. When it tries to parse "id < 0", it throws an exception. 