### PR TITLE
fix unspported part expr bug

### DIFF
--- a/tikv-client/src/main/java/com/pingcap/tikv/exception/UnsupportedPartitionExprException.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/exception/UnsupportedPartitionExprException.java
@@ -1,0 +1,7 @@
+package com.pingcap.tikv.exception;
+
+public class UnsupportedPartitionExprException extends RuntimeException {
+  public UnsupportedPartitionExprException(String msg) {
+    super(msg);
+  }
+}


### PR DESCRIPTION
This was found when we want to support spark 2.4. In Spark 2.3.3, "purchased = data"1995-10-10" " is not pushed down to java side when purchased is a timestamp. While, in Spark 2.4, such filter can be pushed down to java side. 