### PR TITLE
Fix prefix length is larger than the value used. 

### DIFF
--- a/core/src/test/scala/org/apache/spark/sql/expression/index/PrefixIndexTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/index/PrefixIndexTestSuite.scala
@@ -57,6 +57,7 @@ class PrefixIndexTestSuite extends BaseTiSparkSuite {
     explainAndRunTest("select a, b from prefix where b LIKE 'ÿ%'", skipJDBC = true)
     explainAndRunTest("select a, b from prefix where b LIKE '%b'")
     explainAndRunTest("select a, b from prefix where b LIKE '%'")
+    explainAndRunTest("select * from prefix where b = 'b'")
   }
 
   // https://github.com/pingcap/tispark/issues/397

--- a/core/src/test/scala/org/apache/spark/sql/expression/index/PrefixIndexTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/index/PrefixIndexTestSuite.scala
@@ -35,6 +35,7 @@ class PrefixIndexTestSuite extends BaseTiSparkSuite {
     explainAndRunTest("select a, b from prefix where a = 1 and b = \"bbb\"")
     explainAndRunTest("select b from prefix where b = \"bbc\"")
     explainAndRunTest("select b from prefix where b != \"bbc\"")
+    explainAndRunTest("select * from prefix where b = 'b'")
     explainAndRunTest("select b from prefix where b >= \"bbc\" and b < \"bbd\"")
     // FIXME: following test results in INDEX range [bb, bb] and TABLE range (-INF, bbc), while the table range should have been [bb, bb]
     // FYI, the predicate is [[b] LESS_THAN "bbc"], Not(IsNull([b])), [[b] EQUAL "bb"]
@@ -57,7 +58,6 @@ class PrefixIndexTestSuite extends BaseTiSparkSuite {
     explainAndRunTest("select a, b from prefix where b LIKE 'ÿ%'", skipJDBC = true)
     explainAndRunTest("select a, b from prefix where b LIKE '%b'")
     explainAndRunTest("select a, b from prefix where b LIKE '%'")
-    explainAndRunTest("select * from prefix where b = 'b'")
   }
 
   // https://github.com/pingcap/tispark/issues/397

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/Converter.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/Converter.java
@@ -88,10 +88,12 @@ public class Converter {
   static byte[] convertUtf8ToBytes(Object val, int prefixLength) {
     requireNonNull(val, "val is null");
     if (val instanceof byte[]) {
-      return new String((byte[]) val).substring(0, Math.min(((byte[]) val).length, prefixLength))
+      byte[] valByte = (byte[]) val;
+      return new String(valByte).substring(0, Math.min((valByte).length, prefixLength))
           .getBytes(StandardCharsets.UTF_8);
     } else if (val instanceof String) {
-      return ((String) val).substring(0, Math.min(((String) val).length(), prefixLength))
+      String valStr = (String)val;
+      return valStr.substring(0, Math.min(valStr.length(), prefixLength))
           .getBytes(StandardCharsets.UTF_8);
     }
     throw new TypeException(

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/Converter.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/Converter.java
@@ -88,9 +88,11 @@ public class Converter {
   static byte[] convertUtf8ToBytes(Object val, int prefixLength) {
     requireNonNull(val, "val is null");
     if (val instanceof byte[]) {
-      return new String((byte[]) val).substring(0, prefixLength).getBytes(StandardCharsets.UTF_8);
+      return new String((byte[]) val).substring(0, Math.min(((byte[]) val).length, prefixLength))
+          .getBytes(StandardCharsets.UTF_8);
     } else if (val instanceof String) {
-      return ((String) val).substring(0, prefixLength).getBytes(StandardCharsets.UTF_8);
+      return ((String) val).substring(0, Math.min(((String) val).length(), prefixLength))
+          .getBytes(StandardCharsets.UTF_8);
     }
     throw new TypeException(
         String.format("Cannot cast %s to bytes", val.getClass().getSimpleName()));

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/Converter.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/Converter.java
@@ -89,7 +89,7 @@ public class Converter {
     requireNonNull(val, "val is null");
     if (val instanceof byte[]) {
       byte[] valByte = (byte[]) val;
-      return new String(valByte).substring(0, Math.min((valByte).length, prefixLength))
+      return new String(valByte).substring(0, Math.min(valByte.length, prefixLength))
           .getBytes(StandardCharsets.UTF_8);
     } else if (val instanceof String) {
       String valStr = (String)val;


### PR DESCRIPTION
With the following schema:

```
 CREATE TABLE `idx` (
  `c_id` text DEFAULT NULL,
  KEY `c_id` (`c_id`(10))
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
```
the query `select * from idx where c_id == 'dairy'` will fail. This pr fixes this. 