### PR TITLE
fix some issues about data source api

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -108,7 +108,6 @@
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
             <version>${mysql.connector.version}</version>
-            <scope>${spark.scope}</scope>
         </dependency>
       <!--for using tidb datanucleus's adapter-->
         <dependency>

--- a/core/src/main/scala/com/pingcap/tispark/TiBatchWrite.scala
+++ b/core/src/main/scala/com/pingcap/tispark/TiBatchWrite.scala
@@ -24,12 +24,14 @@ import com.pingcap.tikv.row.ObjectRowImpl
 import com.pingcap.tikv.types.DataType
 import com.pingcap.tikv.util.{BackOffer, ConcreteBackOffer, KeyRangeUtils}
 import com.pingcap.tikv.{TiBatchWriteUtils, _}
+import com.pingcap.tispark.utils.TiUtil
 import gnu.trove.list.array.TLongArrayList
 import org.apache.spark.Partitioner
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException
 import org.apache.spark.sql.{Row, TiContext}
 import org.slf4j.LoggerFactory
+
 import scala.collection.JavaConverters._
 
 /**
@@ -329,7 +331,7 @@ object TiBatchWrite {
     for (i <- 0 until fieldCount) {
       val data = sparkRow.get(i)
       val sparkDataType = sparkRow.schema(i).dataType
-      val tiDataType = TiUtils.fromSparkType(sparkDataType)
+      val tiDataType = TiUtil.fromSparkType(sparkDataType)
       tiRow.set(i, tiDataType, data)
     }
     tiRow

--- a/core/src/main/scala/com/pingcap/tispark/TiBatchWrite.scala
+++ b/core/src/main/scala/com/pingcap/tispark/TiBatchWrite.scala
@@ -43,7 +43,8 @@ object TiBatchWrite {
   type TiRow = com.pingcap.tikv.row.Row
   type TiDataType = com.pingcap.tikv.types.DataType
   // TODO: port this val into conf
-  private val skipCommitSecondaryKey = true
+  // disabled because of this bug: https://internal.pingcap.net/jira/browse/TISPARK-127
+  private val skipCommitSecondaryKey = false
   private val fraction = 0.01
 
   private def calcRDDSize(rdd: RDD[Row]): Long =

--- a/core/src/main/scala/com/pingcap/tispark/TiBatchWrite.scala
+++ b/core/src/main/scala/com/pingcap/tispark/TiBatchWrite.scala
@@ -47,8 +47,8 @@ object TiBatchWrite {
   private val fraction = 0.01
 
   private def calcRDDSize(rdd: RDD[Row]): Long =
-  // TODO: this is only approximate estimate
-  // change to key value form for better approximation.
+    // TODO: this is only approximate estimate
+    // change to key value form for better approximation.
     rdd
       .map(_.mkString(",").getBytes("UTF-8").length.toLong)
       .reduce(_ + _) //add the sizes together

--- a/core/src/main/scala/com/pingcap/tispark/TiDBOptions.scala
+++ b/core/src/main/scala/com/pingcap/tispark/TiDBOptions.scala
@@ -27,13 +27,22 @@ class TiDBOptions(@transient val parameters: CaseInsensitiveMap[String]) extends
 
   import TiDBOptions._
 
+  private val optParamPrefix = "spark.tispark."
+
   def this(parameters: Map[String, String]) = {
     this(CaseInsensitiveMap(TiDBOptions.mergeWithSparkConf(parameters)))
   }
 
   private def checkAndGet(name: String): String = {
-    require(parameters.isDefinedAt(name), s"Option '$name' is required.")
-    parameters(name)
+    require(
+      parameters.isDefinedAt(name) || parameters.isDefinedAt(s"$optParamPrefix$name"),
+      s"Option '$name' is required."
+    )
+    if (parameters.isDefinedAt(name)) {
+      parameters(name)
+    } else {
+      parameters(s"$optParamPrefix$name")
+    }
   }
 
   // ------------------------------------------------------------

--- a/core/src/main/scala/com/pingcap/tispark/examples/TiBatchWritePressureTest.scala
+++ b/core/src/main/scala/com/pingcap/tispark/examples/TiBatchWritePressureTest.scala
@@ -47,8 +47,6 @@ object TiBatchWritePressureTest {
       .setIfMissing("tidb.port", "4000")
       .setIfMissing("tidb.user", "root")
       .setIfMissing("spark.tispark.pd.addresses", "172.16.30.81:2379")
-      .setIfMissing("spark.tispark.plan.allow_index_read", "true")
-      .setIfMissing("spark.tispark.pd.addresses", "172.16.30.81:2379")
       .setIfMissing("spark.tispark.show_rowid", "true")
 
     val spark = SparkSession.builder.config(sparkConf).getOrCreate()

--- a/core/src/main/scala/com/pingcap/tispark/examples/TiDataSourceExample.scala
+++ b/core/src/main/scala/com/pingcap/tispark/examples/TiDataSourceExample.scala
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-package com.pingcap.tispark
+package com.pingcap.tispark.examples
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.{DataFrame, SQLContext, SaveMode, SparkSession}
@@ -50,12 +50,11 @@ object TiDataSourceExample {
     // e.g. spark.tispark.plan.allow_agg_pushdown, spark.tispark.plan.allow_index_read, etc.
     // spark.tispark.plan.allow_index_read is optional
     val tidbOptions: Map[String, String] = Map(
-      "tidb.addr" -> "127.0.0.1",
+      "tidb.addr" -> "tidb",
       "tidb.password" -> "",
       "tidb.port" -> "4000",
       "tidb.user" -> "root",
-      "spark.tispark.pd.addresses" -> "127.0.0.1:2379",
-      "spark.tispark.plan.allow_index_read" -> "true"
+      "spark.tispark.pd.addresses" -> "pd0:2379"
     )
 
     val df = sqlContext.read
@@ -73,11 +72,11 @@ object TiDataSourceExample {
     // e.g. spark.tispark.plan.allow_agg_pushdown, spark.tispark.plan.allow_index_read, etc.
     // spark.tispark.plan.allow_index_read is optional
     val tidbOptions: Map[String, String] = Map(
-      "tidb.addr" -> "127.0.0.1",
+      "tidb.addr" -> "tidb",
       "tidb.password" -> "",
       "tidb.port" -> "4000",
       "tidb.user" -> "root",
-      "spark.tispark.pd.addresses" -> "127.0.0.1:2379",
+      "spark.tispark.pd.addresses" -> "pd0:2379",
       "spark.tispark.plan.allow_index_read" -> "true"
     )
 
@@ -98,11 +97,11 @@ object TiDataSourceExample {
     // e.g. spark.tispark.plan.allow_agg_pushdown, spark.tispark.plan.allow_index_read, etc.
     // spark.tispark.plan.allow_index_read is optional
     val tidbOptions: Map[String, String] = Map(
-      "tidb.addr" -> "127.0.0.1",
+      "tidb.addr" -> "tidb",
       "tidb.password" -> "",
       "tidb.port" -> "4000",
       "tidb.user" -> "root",
-      "spark.tispark.pd.addresses" -> "127.0.0.1:2379",
+      "spark.tispark.pd.addresses" -> "pd0:2379",
       "spark.tispark.plan.allow_index_read" -> "true"
     )
 
@@ -136,12 +135,11 @@ object TiDataSourceExample {
                       |OPTIONS (
                       |  database 'tpch_test',
                       |  table 'CUSTOMER',
-                      |  tidb.addr '127.0.0.1',
+                      |  tidb.addr 'tidb',
                       |  tidb.password '',
                       |  tidb.port '4000',
                       |  tidb.user 'root',
-                      |  spark.tispark.pd.addresses '127.0.0.1:2379',
-                      |  spark.tispark.plan.allow_index_read 'true'
+                      |  spark.tispark.pd.addresses 'pd0:2379'
                       |)
        """.stripMargin)
 
@@ -165,12 +163,11 @@ object TiDataSourceExample {
                       |OPTIONS (
                       |  database 'tpch_test',
                       |  table 'CUSTOMER',
-                      |  tidb.addr '127.0.0.1',
+                      |  tidb.addr 'tidb',
                       |  tidb.password '',
                       |  tidb.port '4000',
                       |  tidb.user 'root',
-                      |  spark.tispark.pd.addresses '127.0.0.1:2379',
-                      |  spark.tispark.plan.allow_index_read 'true'
+                      |  spark.tispark.pd.addresses 'pd0:2379'
                       |)
        """.stripMargin)
 
@@ -186,12 +183,11 @@ object TiDataSourceExample {
                       |OPTIONS (
                       |  database 'tpch_test',
                       |  table 'CUSTOMER',
-                      |  tidb.addr '127.0.0.1',
+                      |  tidb.addr 'tidb',
                       |  tidb.password '',
                       |  tidb.port '4000',
                       |  tidb.user 'root',
-                      |  spark.tispark.pd.addresses '127.0.0.1:2379',
-                      |  spark.tispark.plan.allow_index_read 'true'
+                      |  spark.tispark.pd.addresses 'pd0:2379'
                       |)
        """.stripMargin)
 
@@ -202,12 +198,11 @@ object TiDataSourceExample {
                       |OPTIONS (
                       |  database 'tpch_test',
                       |  table 'target_table',
-                      |  tidb.addr '127.0.0.1',
+                      |  tidb.addr 'tidb',
                       |  tidb.password '',
                       |  tidb.port '4000',
                       |  tidb.user 'root',
-                      |  spark.tispark.pd.addresses '127.0.0.1:2379',
-                      |  spark.tispark.plan.allow_index_read 'true'
+                      |  spark.tispark.pd.addresses 'pd0:2379'
                       |)
        """.stripMargin)
 

--- a/core/src/main/scala/com/pingcap/tispark/examples/TiDataSourceExampleWithExtensions.scala
+++ b/core/src/main/scala/com/pingcap/tispark/examples/TiDataSourceExampleWithExtensions.scala
@@ -27,12 +27,11 @@ object TiDataSourceExampleWithExtensions {
       .setIfMissing("spark.master", "local[*]")
       .setIfMissing("spark.app.name", getClass.getName)
       .setIfMissing("spark.sql.extensions", "org.apache.spark.sql.TiExtensions")
-      .setIfMissing("tidb.addr", "127.0.0.1")
-      .setIfMissing("tidb.password", "")
-      .setIfMissing("tidb.port", "4000")
-      .setIfMissing("tidb.user", "root")
-      .setIfMissing("spark.tispark.pd.addresses", "127.0.0.1:2379")
-      .setIfMissing("spark.tispark.plan.allow_index_read", "true")
+      .setIfMissing("spark.tispark.tidb.addr", "tidb")
+      .setIfMissing("spark.tispark.tidb.password", "")
+      .setIfMissing("spark.tispark.tidb.port", "4000")
+      .setIfMissing("spark.tispark.tidb.user", "root")
+      .setIfMissing("spark.tispark.pd.addresses", "pd0:2379")
 
     val spark = SparkSession.builder.config(sparkConf).getOrCreate()
     val sqlContext = spark.sqlContext
@@ -59,12 +58,11 @@ object TiDataSourceExampleWithExtensions {
   def usingConfigInDataSource(sqlContext: SQLContext): Unit = {
     // tidb config priority: data source config > spark config
     val tidbOptions: Map[String, String] = Map(
-      "tidb.addr" -> "127.0.0.1",
+      "tidb.addr" -> "tidb",
       "tidb.password" -> "",
       "tidb.port" -> "4000",
       "tidb.user" -> "root",
-      "spark.tispark.pd.addresses" -> "127.0.0.1:2379",
-      "spark.tispark.plan.allow_index_read" -> "true"
+      "spark.tispark.pd.addresses" -> "pd0:2379"
     )
 
     val df = sqlContext.read

--- a/core/src/main/scala/com/pingcap/tispark/examples/TiExtensionsExample.scala
+++ b/core/src/main/scala/com/pingcap/tispark/examples/TiExtensionsExample.scala
@@ -28,11 +28,10 @@ object TiExtensionsExample {
       .setIfMissing("spark.master", "local[*]")
       .setIfMissing("spark.app.name", getClass.getName)
       .setIfMissing("spark.sql.extensions", "org.apache.spark.sql.TiExtensions")
-      .setIfMissing("tidb.addr", "127.0.0.1")
+      .setIfMissing("tidb.addr", "tidb")
       .setIfMissing("tidb.port", "4000")
       .setIfMissing("tidb.user", "root")
-      .setIfMissing("spark.tispark.pd.addresses", "127.0.0.1:2379")
-      .setIfMissing("spark.tispark.plan.allow_index_read", "true")
+      .setIfMissing("spark.tispark.pd.addresses", "pd0:2379")
 
     val spark = SparkSession.builder.config(sparkConf).getOrCreate()
 

--- a/docs/datasource_api_userguide.md
+++ b/docs/datasource_api_userguide.md
@@ -47,12 +47,11 @@ val sqlContext = spark.sqlContext
 // e.g. spark.tispark.plan.allow_agg_pushdown, spark.tispark.plan.allow_index_read, etc.
 // spark.tispark.plan.allow_index_read is optional
 val tidbOptions: Map[String, String] = Map(
-  "tidb.addr" -> "127.0.0.1",
+  "tidb.addr" -> "tidb",
   "tidb.password" -> "",
   "tidb.port" -> "4000",
   "tidb.user" -> "root",
-  "spark.tispark.pd.addresses" -> "127.0.0.1:2379",
-  "spark.tispark.plan.allow_index_read" -> "true"
+  "spark.tispark.pd.addresses" -> "pd0:2379"
 )
 
 val df = sqlContext.read
@@ -68,17 +67,23 @@ df.show()
 
 ## Write using scala
 ```scala
+import org.apache.spark.sql.SaveMode
+
 val tidbOptions: Map[String, String] = Map(
-  "tidb.addr" -> "127.0.0.1",
+  "tidb.addr" -> "tidb",
   "tidb.password" -> "",
   "tidb.port" -> "4000",
   "tidb.user" -> "root",
-  "spark.tispark.pd.addresses" -> "127.0.0.1:2379",
-  "spark.tispark.plan.allow_index_read" -> "true"
+  "spark.tispark.pd.addresses" -> "pd0:2379"
 )
 
 // data to write
-val df: DataFrame = _
+val df = sqlContext.read
+  .format("tidb")
+  .options(tidbOptions)
+  .option("database", "tpch_test")
+  .option("table", "ORDERS")
+  .load()
 
 // Overwrite
 // if target_table_overwrite does not exist, it will be created automatically
@@ -108,15 +113,14 @@ CREATE TABLE test1
   OPTIONS (
     database 'tpch_test',
     table 'CUSTOMER',
-    tidb.addr '127.0.0.1',
+    tidb.addr 'tidb',
     tidb.password '',
     tidb.port '4000',
     tidb.user 'root',
-    spark.tispark.pd.addresses '127.0.0.1:2379',
-    spark.tispark.plan.allow_index_read 'true'
-  );
+    spark.tispark.pd.addresses 'pd0:2379'
+  )
 
-select C_NAME from test1 where C_CUSTKEY = 1;
+select C_NAME from test1 where C_CUSTKEY = 1
 ```
 
 ### Write using spark sql
@@ -125,45 +129,45 @@ CREATE TABLE writeUsingSparkSQLAPI_src
   USING tidb
   OPTIONS (
     database 'tpch_test',
-    table 'CUSTOMER',
-    tidb.addr '127.0.0.1',
+    table 'ORDERS',
+    tidb.addr 'tidb',
     tidb.password '',
     tidb.port '4000',
     tidb.user 'root',
-    spark.tispark.pd.addresses '127.0.0.1:2379',
-    spark.tispark.plan.allow_index_read 'true'
-  );
+    spark.tispark.pd.addresses 'pd0:2379'
+  )
 
 // target_table should exist in tidb
+// create table target_table like ORDERS
 CREATE TABLE writeUsingSparkSQLAPI_dest
   USING tidb
   OPTIONS (
     database 'tpch_test',
     table 'target_table',
-    tidb.addr '127.0.0.1',
+    tidb.addr 'tidb',
     tidb.password '',
     tidb.port '4000',
     tidb.user 'root',
-    spark.tispark.pd.addresses '127.0.0.1:2379',
-    spark.tispark.plan.allow_index_read 'true'
-  );
+    spark.tispark.pd.addresses 'pd0:2379'
+  )
+
+// insert into select
+insert into writeUsingSparkSQLAPI_dest select * from writeUsingSparkSQLAPI_src
+
+// insert overwrite select
+insert overwrite table writeUsingSparkSQLAPI_dest select * from writeUsingSparkSQLAPI_src
 
 // insert into values
 insert into writeUsingSparkSQLAPI_dest values
-     (1000,
-     "Customer#000001000",
-     "AnJ5lxtLjioClr2khl9pb8NLxG2",
-     9,
-     "19-407-425-2584",
-     2209.81,
-     "AUTOMOBILE",
-     ". even, express theodolites upo");
-
-// insert into select
-insert into writeUsingSparkSQLAPI_dest select * from writeUsingSparkSQLAPI_src;
-
-// insert overwrite select
-insert overwrite table writeUsingSparkSQLAPI_dest select * from writeUsingSparkSQLAPI_src;
+     (888888,
+     370,
+     0,
+     172799.49,
+     "1996-01-02",
+     " 5-LOW",
+     "Clerk#000000951",
+     0,
+     "nstructions sleep furiously among")
 ```
 
 ## Using the Spark Connector With Extensions Enabled
@@ -175,12 +179,12 @@ val sparkConf = new SparkConf()
   .setIfMissing("spark.master", "local[*]")
   .setIfMissing("spark.app.name", getClass.getName)
   .setIfMissing("spark.sql.extensions", "org.apache.spark.sql.TiExtensions")
-  .setIfMissing("tidb.addr", "127.0.0.1")
-  .setIfMissing("tidb.password", "")
-  .setIfMissing("tidb.port", "4000")
-  .setIfMissing("tidb.user", "root")
-  .setIfMissing("spark.tispark.pd.addresses", "127.0.0.1:2379")
-  .setIfMissing("spark.tispark.plan.allow_index_read", "true")
+  .setIfMissing("spark.tispark.pd.addresses", "pd0:2379")
+  .setIfMissing("spark.tispark.tidb.addr", "tidb")
+  .setIfMissing("spark.tispark.tidb.password", "")
+  .setIfMissing("spark.tispark.tidb.port", "4000")
+  .setIfMissing("spark.tispark.tidb.user", "root")
+ 
 
 val spark = SparkSession.builder.config(sparkConf).getOrCreate()
 val sqlContext = spark.sqlContext
@@ -203,11 +207,18 @@ df.show()
 
 ### Write using scala
 ```scala
+import org.apache.spark.sql.SaveMode
+
 // use tidb config in spark config if does not provide in data source config
 val tidbOptions: Map[String, String] = Map()
 
 // data to write
-val df: DataFrame = _
+val df = sqlContext.read
+  .format("tidb")
+  .options(tidbOptions)
+  .option("database", "tpch_test")
+  .option("table", "ORDERS")
+  .load()
 
 // Overwrite
 // if target_table_overwrite does not exist, it will be created automatically
@@ -236,12 +247,11 @@ TiDB config can be overwrite in data source options, thus one can connect to a d
 ```scala
 // tidb config priority: data source config > spark config
 val tidbOptions: Map[String, String] = Map(
-  "tidb.addr" -> "127.0.0.1",
+  "tidb.addr" -> "tidb",
   "tidb.password" -> "",
   "tidb.port" -> "4000",
   "tidb.user" -> "root",
-  "spark.tispark.pd.addresses" -> "127.0.0.1:2379",
-  "spark.tispark.plan.allow_index_read" -> "true"
+  "spark.tispark.pd.addresses" -> "pd0:2379"
 )
 
 val df = sqlContext.read
@@ -258,14 +268,14 @@ df.show()
 ## TiDB Options
 The following is TiDB-specific options, which can be passed in through `TiDBOptions` or `SparkConf`.
 
-|    Key    | required | Description |
-| ---------- | --- | --- |
-| spark.tispark.pd.addresses | true | PD Cluster Addresses, split by comma |
-| tidb.addr | true | TiDB Address, currently only support one instance |
-| tidb.port | true | TiDB Port |
-| tidb.user | true | TiDB User |
-| tidb.password | true | TiDB Password |
-| database | true | TiDB Database |
-| table | true | TiDB Table |
+|    Key    | Short Name | Required | Description |
+| ---------- | --- | --- | --- |
+| spark.tispark.pd.addresses | - | true | PD Cluster Addresses, split by comma |
+| spark.tispark.tidb.addr | tidb.addr | true | TiDB Address, currently only support one instance |
+| spark.tispark.tidb.port | tidb.port | true | TiDB Port |
+| spark.tispark.tidb.user | tidb.user | true | TiDB User |
+| spark.tispark.tidb.password | tidb.password | true | TiDB Password |
+| database | - | true | TiDB Database |
+| table | - | true | TiDB Table |
 
 TiSpark's common options can also be passed in, e.g. `spark.tispark.plan.allow_agg_pushdown`, `spark.tispark.plan.allow_index_read`, etc.

--- a/docs/datasource_api_userguide.md
+++ b/docs/datasource_api_userguide.md
@@ -23,10 +23,135 @@ Since TiDB is a database that supports transaction, TiDB Spark Connector also su
 2. no data in DataFrame will be written to TiDB successfully, if conflicts exist
 3. no partial changes is visible to other session until commit.
 
-## Using the Spark Connector Without Extensions Enabled
+## Using the Spark Connector With Extensions Enabled
 The connector adheres to the standard Spark API, but with the addition of TiDB-specific options.
 
-The connector can be used both with or without extensions enabled. Here's examples about how to use it without extensions.
+The connector can be used both with or without extensions enabled. Here's examples about how to use it with extensions.
+
+### init SparkConf
+```scala
+val sparkConf = new SparkConf()
+  .setIfMissing("spark.master", "local[*]")
+  .setIfMissing("spark.app.name", getClass.getName)
+  .setIfMissing("spark.sql.extensions", "org.apache.spark.sql.TiExtensions")
+  .setIfMissing("spark.tispark.pd.addresses", "pd0:2379")
+  .setIfMissing("spark.tispark.tidb.addr", "tidb")
+  .setIfMissing("spark.tispark.tidb.password", "")
+  .setIfMissing("spark.tispark.tidb.port", "4000")
+  .setIfMissing("spark.tispark.tidb.user", "root")
+ 
+
+val spark = SparkSession.builder.config(sparkConf).getOrCreate()
+val sqlContext = spark.sqlContext
+```
+
+### Read using scala
+```scala
+// use tidb config in spark config if does not provide in data source config
+val tidbOptions: Map[String, String] = Map()
+val df = sqlContext.read
+  .format("tidb")
+  .options(tidbOptions)
+  .option("database", "tpch_test")
+  .option("table", "CUSTOMER")
+  .load()
+  .filter("C_CUSTKEY = 1")
+  .select("C_NAME")
+df.show()
+```
+
+### Write using scala
+```scala
+import org.apache.spark.sql.SaveMode
+
+// use tidb config in spark config if does not provide in data source config
+val tidbOptions: Map[String, String] = Map()
+
+// data to write
+val df = sqlContext.read
+  .format("tidb")
+  .options(tidbOptions)
+  .option("database", "tpch_test")
+  .option("table", "ORDERS")
+  .load()
+
+// Overwrite
+// if target_table_overwrite does not exist, it will be created automatically
+df.write
+  .format("tidb")
+  .options(tidbOptions)
+  .option("database", "tpch_test")
+  .option("table", "target_table_overwrite")
+  .mode(SaveMode.Overwrite)
+  .save()
+
+// Append
+// if target_table_append does not exist, it will be created automatically
+df.write
+  .format("tidb")
+  .options(tidbOptions)
+  .option("database", "tpch_test")
+  .option("table", "target_table_append")
+  .mode(SaveMode.Append)
+  .save()
+```
+
+### Write using spark sql
+```sql
+// target_table should exist in tidb
+// create table target_table like ORDERS
+CREATE TABLE writeUsingSparkSQLAPI_dest
+  USING tidb
+  OPTIONS (
+    database 'tpch_test',
+    table 'target_table'
+  )
+
+// insert into values
+insert into writeUsingSparkSQLAPI_dest values
+     (888888,
+     370,
+     0,
+     172799.49,
+     "1996-01-02",
+     " 5-LOW",
+     "Clerk#000000951",
+     0,
+     "nstructions sleep furiously among")
+
+// insert into select
+insert into writeUsingSparkSQLAPI_dest select * from tpch_test.ORDERS
+
+// insert overwrite select
+insert overwrite table writeUsingSparkSQLAPI_dest select * from tpch_test.ORDERS
+```
+
+### Use another TiDB
+TiDB config can be overwrite in data source options, thus one can connect to a different TiDB.
+
+```scala
+// tidb config priority: data source config > spark config
+val tidbOptions: Map[String, String] = Map(
+  "tidb.addr" -> "tidb",
+  "tidb.password" -> "",
+  "tidb.port" -> "4000",
+  "tidb.user" -> "root",
+  "spark.tispark.pd.addresses" -> "pd0:2379"
+)
+
+val df = sqlContext.read
+  .format("tidb")
+  .options(tidbOptions)
+  .option("database", "tpch_test")
+  .option("table", "CUSTOMER")
+  .load()
+  .filter("C_CUSTKEY = 1")
+  .select("C_NAME")
+df.show()
+```
+
+## Using the Spark Connector Without Extensions Enabled
+Let's see how to use the connector without extensions enabled.
 
 ### init SparkConf
 ```scala
@@ -150,13 +275,7 @@ CREATE TABLE writeUsingSparkSQLAPI_dest
     tidb.user 'root',
     spark.tispark.pd.addresses 'pd0:2379'
   )
-
-// insert into select
-insert into writeUsingSparkSQLAPI_dest select * from writeUsingSparkSQLAPI_src
-
-// insert overwrite select
-insert overwrite table writeUsingSparkSQLAPI_dest select * from writeUsingSparkSQLAPI_src
-
+  
 // insert into values
 insert into writeUsingSparkSQLAPI_dest values
      (888888,
@@ -168,102 +287,15 @@ insert into writeUsingSparkSQLAPI_dest values
      "Clerk#000000951",
      0,
      "nstructions sleep furiously among")
+     
+// insert into select
+insert into writeUsingSparkSQLAPI_dest select * from writeUsingSparkSQLAPI_src
+
+// insert overwrite select
+insert overwrite table writeUsingSparkSQLAPI_dest select * from writeUsingSparkSQLAPI_src
 ```
 
-## Using the Spark Connector With Extensions Enabled
-Let's see how to use the connector with extensions enabled.
 
-### init SparkConf
-```scala
-val sparkConf = new SparkConf()
-  .setIfMissing("spark.master", "local[*]")
-  .setIfMissing("spark.app.name", getClass.getName)
-  .setIfMissing("spark.sql.extensions", "org.apache.spark.sql.TiExtensions")
-  .setIfMissing("spark.tispark.pd.addresses", "pd0:2379")
-  .setIfMissing("spark.tispark.tidb.addr", "tidb")
-  .setIfMissing("spark.tispark.tidb.password", "")
-  .setIfMissing("spark.tispark.tidb.port", "4000")
-  .setIfMissing("spark.tispark.tidb.user", "root")
- 
-
-val spark = SparkSession.builder.config(sparkConf).getOrCreate()
-val sqlContext = spark.sqlContext
-```
-
-### Read using scala
-```scala
-// use tidb config in spark config if does not provide in data source config
-val tidbOptions: Map[String, String] = Map()
-val df = sqlContext.read
-  .format("tidb")
-  .options(tidbOptions)
-  .option("database", "tpch_test")
-  .option("table", "CUSTOMER")
-  .load()
-  .filter("C_CUSTKEY = 1")
-  .select("C_NAME")
-df.show()
-```
-
-### Write using scala
-```scala
-import org.apache.spark.sql.SaveMode
-
-// use tidb config in spark config if does not provide in data source config
-val tidbOptions: Map[String, String] = Map()
-
-// data to write
-val df = sqlContext.read
-  .format("tidb")
-  .options(tidbOptions)
-  .option("database", "tpch_test")
-  .option("table", "ORDERS")
-  .load()
-
-// Overwrite
-// if target_table_overwrite does not exist, it will be created automatically
-df.write
-  .format("tidb")
-  .options(tidbOptions)
-  .option("database", "tpch_test")
-  .option("table", "target_table_overwrite")
-  .mode(SaveMode.Overwrite)
-  .save()
-
-// Append
-// if target_table_append does not exist, it will be created automatically
-df.write
-  .format("tidb")
-  .options(tidbOptions)
-  .option("database", "tpch_test")
-  .option("table", "target_table_append")
-  .mode(SaveMode.Append)
-  .save()
-```
-
-### Use another TiDB
-TiDB config can be overwrite in data source options, thus one can connect to a different TiDB.
-
-```scala
-// tidb config priority: data source config > spark config
-val tidbOptions: Map[String, String] = Map(
-  "tidb.addr" -> "tidb",
-  "tidb.password" -> "",
-  "tidb.port" -> "4000",
-  "tidb.user" -> "root",
-  "spark.tispark.pd.addresses" -> "pd0:2379"
-)
-
-val df = sqlContext.read
-  .format("tidb")
-  .options(tidbOptions)
-  .option("database", "tpch_test")
-  .option("table", "CUSTOMER")
-  .load()
-  .filter("C_CUSTKEY = 1")
-  .select("C_NAME")
-df.show()
-```
 
 ## TiDB Options
 The following is TiDB-specific options, which can be passed in through `TiDBOptions` or `SparkConf`.

--- a/tikv-client/src/main/java/com/pingcap/tikv/PDClient.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/PDClient.java
@@ -71,6 +71,7 @@ public class PDClient extends AbstractGRPCClient<PDBlockingStub, PDStub>
 
   /**
    * Sends request to pd to scatter region.
+   *
    * @param left represents a region info
    */
   public void scatterRegion(TiRegion left) {

--- a/tikv-client/src/main/java/com/pingcap/tikv/region/RegionStoreClient.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/region/RegionStoreClient.java
@@ -765,8 +765,9 @@ public class RegionStoreClient extends AbstractGRPCClient<TikvBlockingStub, Tikv
   }
 
   /**
-   * Send SplitRegion request to tikv split a region at splitKey.
-   * splitKey must between current region's start key and end key.
+   * Send SplitRegion request to tikv split a region at splitKey. splitKey must between current
+   * region's start key and end key.
+   *
    * @param splitKey is the split point for a specific region.
    * @return a split region info.
    */


### PR DESCRIPTION
1. mysql connector should packaged in target jar, since tispark will use jdbc to connect to tidb
2. 127.0.0.1 -> pd0 & tidb, user can run example without change a single line (edit /etc/hosts)
3. add parameter prefix `spark.tispark.`, since all parameters in spark-defaults.conf should start with `spark.tispark.`