### PR TITLE
Save Mode

### DIFF
--- a/core/src/main/scala/com/pingcap/tispark/TiBatchWrite.scala
+++ b/core/src/main/scala/com/pingcap/tispark/TiBatchWrite.scala
@@ -15,6 +15,8 @@
 
 package com.pingcap.tispark
 
+import java.util
+
 import com.pingcap.tikv.codec.{KeyUtils, TableCodec}
 import com.pingcap.tikv.exception.TiBatchWriteException
 import com.pingcap.tikv.key.{Key, RowKey}
@@ -28,8 +30,8 @@ import com.pingcap.tispark.utils.TiUtil
 import gnu.trove.list.array.TLongArrayList
 import org.apache.spark.Partitioner
 import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.TiContext
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException
-import org.apache.spark.sql.{Row, TiContext}
 import org.slf4j.LoggerFactory
 
 import scala.collection.JavaConverters._
@@ -44,19 +46,12 @@ object TiBatchWrite {
   type SparkRow = org.apache.spark.sql.Row
   type TiRow = com.pingcap.tikv.row.Row
   type TiDataType = com.pingcap.tikv.types.DataType
-  // TODO: port this val into conf
-  // disabled because of this bug: https://internal.pingcap.net/jira/browse/TISPARK-127
-  private val skipCommitSecondaryKey = false
-  private val fraction = 0.01
 
-  private def calcRDDSize(rdd: RDD[Row]): Long =
-    // TODO: this is only approximate estimate
-    // change to key value form for better approximation.
-    rdd
-      .map(_.mkString(",").getBytes("UTF-8").length.toLong)
-      .reduce(_ + _) //add the sizes together
+  private def calcRDDSize(rdd: RDD[(SerializableKey, TiRow, Array[Byte])]): Long =
+    rdd.map(_._3.length).reduce(_ + _)
 
-  private def estimateDataSize(sampledRDD: RDD[Row]) = {
+  private def estimateDataSize(sampledRDD: RDD[(SerializableKey, TiRow, Array[Byte])],
+                               options: TiDBOptions) = {
     // get all data size
     val sampleRDDSize = calcRDDSize(sampledRDD)
     logger.info(s"sample data size is ${sampleRDDSize / (1024 * 1024)} MB")
@@ -65,7 +60,7 @@ object TiBatchWrite {
     val sampleAvgRowSize = sampleRDDSize / sampleRowCount
     logger.info(s"sample avg row size is $sampleAvgRowSize")
 
-    val estimatedTotalSize = (sampleRowCount * sampleAvgRowSize) / fraction
+    val estimatedTotalSize = (sampleRowCount * sampleAvgRowSize) / options.sampleFraction
     val formatter = java.text.NumberFormat.getIntegerInstance
 
     val estimateInMB = estimatedTotalSize / (1024 * 1024)
@@ -73,12 +68,12 @@ object TiBatchWrite {
     (estimateInMB.toLong, sampleRowCount)
   }
 
-  def calculateSplitKeys(sampleRDD: RDD[Row],
-                         estimatedTotalSize: Long,
-                         sampleRDDCount: Long,
-                         tblInfo: TiTableInfo,
-                         isUpdate: Boolean,
-                         regionSplitNumber: Option[Int]): List[SerializableKey] = {
+  private def calculateSplitKeys(sampleRDD: RDD[(SerializableKey, TiRow, Array[Byte])],
+                                 estimatedTotalSize: Long,
+                                 sampleRDDCount: Long,
+                                 tblInfo: TiTableInfo,
+                                 isUpdate: Boolean,
+                                 regionSplitNumber: Option[Int]): List[SerializableKey] = {
 
     var regionNeed = (estimatedTotalSize / 96.0).toLong
     // update region split number if user want more region
@@ -92,8 +87,7 @@ object TiBatchWrite {
 
     // TODO check this write is update or not
     val handleRdd: RDD[Long] = sampleRDD
-      .map(sparkRow2TiKVRow)
-      .map(row => extractHandleId(row, tblInfo, isUpdate = false))
+      .map(obj => extractHandleId(obj._2, tblInfo, isUpdate = false))
       .sortBy(k => k)
     val step = sampleRDDCount / regionNeed
     val splitKeys = handleRdd
@@ -101,7 +95,9 @@ object TiBatchWrite {
       .filter {
         case (_, idx) => idx % step == 0
       }
-      .map { _._1 }
+      .map {
+        _._1
+      }
       .map(h => new SerializableKey(RowKey.toRowKey(tblInfo.getId, h).getBytes))
       .collect()
       .toList
@@ -113,25 +109,38 @@ object TiBatchWrite {
   @throws(classOf[NoSuchTableException])
   @throws(classOf[TiBatchWriteException])
   def writeToTiDB(rdd: RDD[SparkRow],
-                  tableRef: TiTableReference,
                   tiContext: TiContext,
+                  options: TiDBOptions,
                   regionSplitNumber: Option[Int] = None,
                   enableRegionPreSplit: Boolean = false) {
     // initialize
     val tiConf = tiContext.tiConf
     val tiSession = tiContext.tiSession
     val kvClient = tiSession.createTxnClient()
+    val tableRef = TiTableReference(options.database, options.table)
     val (tiTableInfo, colDataTypes, colIds) = getTableInfo(tableRef, tiContext)
+
+    // spark row to tikv row
     val tiKVRowRDD = rdd.map(sparkRow2TiKVRow)
 
+    // deduplicate
+    val deduplicateRDD = deduplicate(tiKVRowRDD, tableRef, tiTableInfo, tiContext, options)
+
+    // encode tirow
+    val encodedTiRowRDD = deduplicateRDD.map {
+      case (key, tiRow) => (key, tiRow, encodeTiRow(tiRow, colDataTypes, colIds))
+    }
+
+    // region pre-split
     if (enableRegionPreSplit) {
       logger.info("region pre split is enabled.")
-      val sampleRDD = rdd.sample(withReplacement = false, fraction = fraction)
-      val (dataSize, sampleRDDCount) = estimateDataSize(sampleRDD)
+      val sampleRDD =
+        encodedTiRowRDD.sample(withReplacement = false, fraction = options.sampleFraction)
+      val (dataSize, sampleRDDCount) = estimateDataSize(sampleRDD, options)
 
       tiContext.tiSession.splitRegionAndScatter(
         calculateSplitKeys(
-          sampleRDD,
+          encodedTiRowRDD,
           dataSize,
           sampleRDDCount,
           tiTableInfo,
@@ -146,11 +155,11 @@ object TiBatchWrite {
 
     // shuffle data in same task which belong to same region
     val shuffledRDD = {
-      shuffleKeyToSameRegion(tiKVRowRDD, tableRef, tiTableInfo, tiContext)
+      shuffleKeyToSameRegion(encodedTiRowRDD, tableRef, tiTableInfo, tiContext)
     }.cache()
 
     // take one row as primary key
-    val (primaryKey: SerializableKey, primaryRow: TiRow) = {
+    val (primaryKey: SerializableKey, primaryRow: Array[Byte]) = {
       val takeOne = shuffledRDD.take(1)
       if (takeOne.length == 0) {
         logger.warn("there is no data in source rdd")
@@ -175,8 +184,7 @@ object TiBatchWrite {
     val ti2PCClient = new TiBatchWrite2PCClient(kvClient, startTs)
     val prewritePrimaryBackoff =
       ConcreteBackOffer.newCustomBackOff(BackOffer.BATCH_PREWRITE_BACKOFF)
-    val encodedRow = encodeTiRow(primaryRow, colDataTypes, colIds)
-    ti2PCClient.prewritePrimaryKey(prewritePrimaryBackoff, primaryKey.bytes, encodedRow)
+    ti2PCClient.prewritePrimaryKey(prewritePrimaryBackoff, primaryKey.bytes, primaryRow)
 
     // executors secondary pre-write
     finalWriteRDD.foreachPartition { iterator =>
@@ -188,10 +196,7 @@ object TiBatchWrite {
 
       val pairs = iterator.map {
         case (key, row) =>
-          new TiBatchWrite2PCClient.BytePairWrapper(
-            key.bytes,
-            encodeTiRow(row, colDataTypes, colIds)
-          )
+          new TiBatchWrite2PCClient.BytePairWrapper(key.bytes, row)
       }.asJava
 
       ti2PCClientOnExecutor
@@ -210,7 +215,7 @@ object TiBatchWrite {
     ti2PCClient.commitPrimaryKey(commitPrimaryBackoff, primaryKey.bytes, commitTs)
 
     // executors secondary commit
-    if (!skipCommitSecondaryKey) {
+    if (!options.skipCommitSecondaryKey) {
       finalWriteRDD.foreachPartition { iterator =>
         val tiSessionOnExecutor = new TiSession(tiConf)
         val kvClientOnExecutor = tiSessionOnExecutor.createTxnClient()
@@ -256,10 +261,52 @@ object TiBatchWrite {
   }
 
   @throws(classOf[NoSuchTableException])
-  private def shuffleKeyToSameRegion(rdd: RDD[TiRow],
+  @throws(classOf[TiBatchWriteException])
+  private def deduplicate(rdd: RDD[TiRow],
+                          tableRef: TiTableReference,
+                          tiTableInfo: TiTableInfo,
+                          tiContext: TiContext,
+                          options: TiDBOptions): RDD[(SerializableKey, TiRow)] = {
+    val databaseName = tableRef.databaseName
+    val tableName = tableRef.tableName
+    val session = tiContext.tiSession
+    val table = session.getCatalog.getTable(databaseName, tableName)
+    if (table == null) {
+      throw new NoSuchTableException(databaseName, tableName)
+    }
+    val tableId = table.getId
+
+    val shuffledRDD = rdd
+      .map(row => (tiKVRow2Key(row, tableId, tiTableInfo, isUpdate = false), row))
+      .groupByKey()
+
+    if (!options.deduplicate) {
+      val duplicateCountRDD = shuffledRDD.flatMap {
+        case (_, iterable) =>
+          if (iterable.size > 1) {
+            Some(iterable.size)
+          } else {
+            None
+          }
+      }
+
+      if (!duplicateCountRDD.isEmpty()) {
+        throw new TiBatchWriteException("data conflicts! set the parameter deduplicate.")
+      }
+    }
+
+    shuffledRDD.map {
+      case (key, iterable) =>
+        // remove duplicate rows if key equals
+        (key, iterable.head)
+    }
+  }
+
+  @throws(classOf[NoSuchTableException])
+  private def shuffleKeyToSameRegion(rdd: RDD[(SerializableKey, TiRow, Array[Byte])],
                                      tableRef: TiTableReference,
                                      tiTableInfo: TiTableInfo,
-                                     tiContext: TiContext): RDD[(SerializableKey, TiRow)] = {
+                                     tiContext: TiContext): RDD[(SerializableKey, Array[Byte])] = {
     val databaseName = tableRef.databaseName
     val tableName = tableRef.tableName
     val session = tiContext.tiSession
@@ -277,11 +324,11 @@ object TiBatchWrite {
     )
 
     rdd
-      .map(row => (tiKVRow2Key(row, tableId, tiTableInfo, isUpdate = false), row))
+      .map(obj => (obj._1, obj._3))
       .groupByKey(tiRegionPartitioner)
       .map {
         case (key, iterable) =>
-          // remove duplicate rows if key equals
+          // remove duplicate rows if key equals (should not happen, cause already deduplicated)
           (key, iterable.head)
       }
   }
@@ -385,4 +432,7 @@ class SerializableKey(val bytes: Array[Byte]) extends Serializable {
       case that: SerializableKey => this.bytes.sameElements(that.bytes)
       case _                     => false
     }
+
+  override def hashCode(): Int =
+    util.Arrays.hashCode(bytes)
 }

--- a/core/src/main/scala/com/pingcap/tispark/TiDBDataSource.scala
+++ b/core/src/main/scala/com/pingcap/tispark/TiDBDataSource.scala
@@ -15,6 +15,7 @@
 
 package com.pingcap.tispark
 
+import com.pingcap.tikv.meta.TiTimestamp
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{DataFrame, SQLContext, SaveMode, TiContext}
@@ -42,7 +43,8 @@ class TiDBDataSource
     val options = new TiDBOptions(parameters)
     val tiContext = new TiContext(sqlContext.sparkSession, Some(options))
     val tableRef = TiTableReference(options.database, options.table)
-    TiDBRelation(tiContext.tiSession, tableRef, tiContext.meta, None, Some(options))(sqlContext)
+    val ts = tiContext.tiSession.createTxnClient().getTimestamp
+    TiDBRelation(tiContext.tiSession, tableRef, tiContext.meta, Some(ts), Some(options))(sqlContext)
   }
 
   /**

--- a/core/src/main/scala/com/pingcap/tispark/TiDBOptions.scala
+++ b/core/src/main/scala/com/pingcap/tispark/TiDBOptions.scala
@@ -58,14 +58,21 @@ class TiDBOptions(@transient val parameters: CaseInsensitiveMap[String]) extends
   // ------------------------------------------------------------
   // Optional parameters only for writing
   // ------------------------------------------------------------
-  // if to truncate the table from TiDB
-  val isTruncate: Boolean = parameters.getOrElse(TIDB_TRUNCATE, "false").toBoolean
 
   // the create table option , which can be table_options or partition_options.
   // E.g., "CREATE TABLE t (name string) ENGINE=InnoDB DEFAULT CHARSET=utf8"
   val createTableOptions: String = parameters.getOrElse(TIDB_CREATE_TABLE_OPTIONS, "")
 
   val createTableColumnTypes: Option[String] = parameters.get(TIDB_CREATE_TABLE_COLUMN_TYPES)
+
+  // if deduplicate is true, tispark will remove duplicate rows according to primary key before write to tidb
+  val deduplicate: Boolean = parameters.getOrElse(TIDB_DEDUPLICATE, "false").toBoolean
+
+  // TODO: disabled because of this bug: https://internal.pingcap.net/jira/browse/TISPARK-127
+  val skipCommitSecondaryKey: Boolean =
+    parameters.getOrElse(TIDB_SKIP_COMMIT_SECONDARY_KEY, "false").toBoolean
+
+  val sampleFraction: Double = parameters.getOrElse(TIDB_SAMPLE_FRACTION, "0.01").toDouble
 
   // ------------------------------------------------------------
   // Calculated parameters
@@ -100,7 +107,9 @@ object TiDBOptions {
   val TIDB_PASSWORD: String = newOption("tidb.password")
   val TIDB_DATABASE: String = newOption("database")
   val TIDB_TABLE: String = newOption("table")
-  val TIDB_TRUNCATE: String = newOption("truncate")
   val TIDB_CREATE_TABLE_OPTIONS: String = newOption("createTableOptions")
   val TIDB_CREATE_TABLE_COLUMN_TYPES: String = newOption("createTableColumnTypes")
+  val TIDB_DEDUPLICATE: String = newOption("deduplicate")
+  val TIDB_SKIP_COMMIT_SECONDARY_KEY = newOption("skipCommitSecondaryKey")
+  val TIDB_SAMPLE_FRACTION = newOption("sampleFraction")
 }

--- a/core/src/main/scala/com/pingcap/tispark/TiDBUtils.scala
+++ b/core/src/main/scala/com/pingcap/tispark/TiDBUtils.scala
@@ -60,11 +60,9 @@ object TiDBUtils {
   def saveTable(tiContext: TiContext,
                 df: DataFrame,
                 tableSchema: Option[StructType],
-                options: TiDBOptions): Unit = {
+                options: TiDBOptions): Unit =
     // TODO: use table schema
-    val tableRef = TiTableReference(options.database, options.table)
-    TiBatchWrite.writeToTiDB(df.rdd, tableRef, tiContext)
-  }
+    TiBatchWrite.writeToTiDB(df.rdd, tiContext, options)
 
   /**
    * Returns a factory for creating connections to the given TiDB URL.

--- a/core/src/main/scala/com/pingcap/tispark/TiDBWriter.scala
+++ b/core/src/main/scala/com/pingcap/tispark/TiDBWriter.scala
@@ -1,5 +1,6 @@
 package com.pingcap.tispark
 
+import com.pingcap.tikv.exception.TiBatchWriteException
 import org.apache.spark.sql.{DataFrame, SQLContext, SaveMode, TiContext}
 
 object TiDBWriter {
@@ -15,34 +16,14 @@ object TiDBWriter {
       val tableExists = TiDBUtils.tableExists(conn, options)
       if (tableExists) {
         saveMode match {
-          case SaveMode.Overwrite =>
-            if (options.isTruncate && TiDBUtils
-                  .isCascadingTruncateTable(options.url)
-                  .contains(false)) {
-              // In this case, we should truncate table and then load.
-              TiDBUtils.truncateTable(conn, options, tiContext)
-              val tableSchema = TiDBUtils.getSchemaOption(conn, options)
-              TiDBUtils.saveTable(tiContext, df, tableSchema, options)
-            } else {
-              // Otherwise, do not truncate the table, instead drop and recreate it
-              TiDBUtils.dropTable(conn, options, tiContext)
-              TiDBUtils.createTable(conn, df, options, tiContext)
-              TiDBUtils.saveTable(tiContext, df, Some(df.schema), options)
-            }
-
           case SaveMode.Append =>
             val tableSchema = TiDBUtils.getSchemaOption(conn, options)
             TiDBUtils.saveTable(tiContext, df, tableSchema, options)
 
-          case SaveMode.ErrorIfExists =>
-            throw new Exception(
-              s"Table or view '${options.dbtable}' already exists. SaveMode: ErrorIfExists."
+          case _ =>
+            throw new TiBatchWriteException(
+              s"SaveMode: $saveMode is not supported. TiSpark only support SaveMode.Append."
             )
-
-          case SaveMode.Ignore =>
-          // With `SaveMode.Ignore` mode, if table already exists, the save operation is expected
-          // to not save the contents of the DataFrame and to not change the existing data.
-          // Therefore, it is okay to do nothing here and then just return the relation below.
         }
       } else {
         TiDBUtils.createTable(conn, df, options, tiContext)

--- a/core/src/main/scala/com/pingcap/tispark/examples/TiBatchWritePressureTest.scala
+++ b/core/src/main/scala/com/pingcap/tispark/examples/TiBatchWritePressureTest.scala
@@ -15,11 +15,9 @@
 
 package com.pingcap.tispark.examples
 
-import com.pingcap.tispark.{TiBatchWrite, TiTableReference}
+import com.pingcap.tispark.{TiBatchWrite, TiDBOptions, TiTableReference}
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.{SparkSession, TiContext}
-import org.apache.spark.sql.functions.max
-import org.apache.spark.sql.functions.min
 
 object TiBatchWritePressureTest {
   def main(args: Array[String]) = {
@@ -59,8 +57,10 @@ object TiBatchWritePressureTest {
     val df = spark.sql(s"select * from $inputTable")
 
     // batch write
-    val tableRef: TiTableReference = TiTableReference(outputDatabase, outputTable)
-    TiBatchWrite.writeToTiDB(df.rdd, tableRef, ti, regionSplitNumber, enableRegionPreSplit)
+    val options = new TiDBOptions(
+      sparkConf.getAll.toMap ++ Map("database" -> outputDatabase, "table" -> outputTable)
+    )
+    TiBatchWrite.writeToTiDB(df.rdd, ti, options, regionSplitNumber, enableRegionPreSplit)
 
     // time
     val end = System.currentTimeMillis()

--- a/core/src/main/scala/com/pingcap/tispark/examples/TiDataSourceExample.scala
+++ b/core/src/main/scala/com/pingcap/tispark/examples/TiDataSourceExample.scala
@@ -16,7 +16,7 @@
 package com.pingcap.tispark.examples
 
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.{DataFrame, SQLContext, SaveMode, SparkSession}
+import org.apache.spark.sql.{DataFrame, SQLContext, SparkSession}
 
 /**
  * before run the code in IDE, please enable maven profile `local-debug`
@@ -107,16 +107,6 @@ object TiDataSourceExample {
 
     val df = readUsingDataSourceAPI(sqlContext)
 
-    // Overwrite
-    // if target_table_overwrite does not exist, it will be created automatically
-    df.write
-      .format("tidb")
-      .options(tidbOptions)
-      .option("database", "tpch_test")
-      .option("table", "target_table_overwrite")
-      .mode(SaveMode.Overwrite)
-      .save()
-
     // Append
     // if target_table_append does not exist, it will be created automatically
     df.write
@@ -124,7 +114,7 @@ object TiDataSourceExample {
       .options(tidbOptions)
       .option("database", "tpch_test")
       .option("table", "target_table_append")
-      .mode(SaveMode.Append)
+      .mode("append")
       .save()
   }
 
@@ -217,16 +207,11 @@ object TiDataSourceExample {
                      |2209.81,
                      |"AUTOMOBILE",
                      |". even, express theodolites upo")
-                   """.stripMargin)
+      """.stripMargin)
 
     // insert into select
     sqlContext.sql(s"""
                       |insert into writeUsingSparkSQLAPI_dest select * from writeUsingSparkSQLAPI_src
-       """.stripMargin).show()
-
-    // insert overwrite select
-    sqlContext.sql(s"""
-                      |insert overwrite table writeUsingSparkSQLAPI_dest select * from writeUsingSparkSQLAPI_src
        """.stripMargin).show()
   }
 }

--- a/core/src/main/scala/com/pingcap/tispark/examples/TiDataSourceExampleWithExtensions.scala
+++ b/core/src/main/scala/com/pingcap/tispark/examples/TiDataSourceExampleWithExtensions.scala
@@ -16,7 +16,7 @@
 package com.pingcap.tispark.examples
 
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.{DataFrame, SQLContext, SaveMode, SparkSession}
+import org.apache.spark.sql.{SQLContext, SparkSession}
 
 /**
  * before run the code in IDE, please enable maven profile `local-debug`

--- a/core/src/test/scala/com/pingcap/tispark/TiBatchWriteSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/TiBatchWriteSuite.scala
@@ -51,9 +51,13 @@ class TiBatchWriteSuite extends BaseTiSparkSuite {
       val df = sql(s"select * from $table")
 
       // batch write
-      val tableRef: TiTableReference =
-        TiTableReference(s"$dbPrefix$database", s"${batchWriteTablePrefix}_$table")
-      TiBatchWrite.writeToTiDB(df.rdd, tableRef, ti)
+      TiBatchWrite.writeToTiDB(
+        df.rdd,
+        ti,
+        new TiDBOptions(
+          tidbOptions + ("database" -> s"$dbPrefix$database", "table" -> s"${batchWriteTablePrefix}_$table")
+        )
+      )
 
       // refresh
       refreshConnections(TestTables(database, s"${batchWriteTablePrefix}_$table"))
@@ -75,14 +79,14 @@ class TiBatchWriteSuite extends BaseTiSparkSuite {
     val df = sql(s"select * from CUSTOMER")
 
     // batch write
-    val tableRef: TiTableReference =
-      TiTableReference(
-        s"$dbPrefix$database",
-        s"${batchWriteTablePrefix}_TABLE_NOT_EXISTS"
-      )
-
     intercept[NoSuchTableException] {
-      TiBatchWrite.writeToTiDB(df.rdd, tableRef, ti)
+      TiBatchWrite.writeToTiDB(
+        df.rdd,
+        ti,
+        new TiDBOptions(
+          tidbOptions + ("database" -> s"$dbPrefix$database", "table" -> s"${batchWriteTablePrefix}_TABLE_NOT_EXISTS")
+        )
+      )
     }
   }
 

--- a/core/src/test/scala/com/pingcap/tispark/datasource/BaseDataSourceSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/BaseDataSourceSuite.scala
@@ -24,7 +24,6 @@ class BaseDataSourceSuite(val testTable: String,
   protected var dbtableInSpark: String = _
 
   protected var tidbStmt: Statement = _
-  protected var tidbOptions: Map[String, String] = _
 
   override def beforeAll(): Unit = {
     enableTidbConfigPropertiesInjectedToSpark = _enableTidbConfigPropertiesInjectedToSpark
@@ -34,14 +33,6 @@ class BaseDataSourceSuite(val testTable: String,
     databaseInSpark = getTestDatabaseNameInSpark(database)
     dbtableInSpark = s"$databaseInSpark.$testTable"
     tidbStmt = tidbConn.createStatement()
-
-    tidbOptions = Map(
-      TiDB_ADDRESS -> tidbAddr,
-      TiDB_PASSWORD -> tidbPassword,
-      TiDB_PORT -> s"$tidbPort",
-      TiDB_USER -> tidbUser,
-      PD_ADDRESSES -> pdAddresses
-    )
   }
 
   protected def jdbcUpdate(query: String): Unit =

--- a/core/src/test/scala/com/pingcap/tispark/datasource/DataSourceWithExtensionsSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/DataSourceWithExtensionsSuite.scala
@@ -5,7 +5,7 @@ import org.apache.spark.sql.Row
 // with TiExtensions
 // will load tidb_config.properties to SparkConf
 class DataSourceWithExtensionsSuite
-    extends BaseDataSourceSuite("test_data_source_with_extensions", true) {
+    extends BaseDataSourceSuite("test_datasource_with_extensions", true) {
   // Values used for comparison
   private val row1 = Row(null, "Hello")
   private val row2 = Row(2, "TiDB")

--- a/core/src/test/scala/com/pingcap/tispark/datasource/FilterPushdownSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/FilterPushdownSuite.scala
@@ -4,7 +4,7 @@ import org.apache.spark.sql.Row
 
 // without TiExtensions
 // will not load tidb_config.properties to SparkConf
-class FilterPushdownSuite extends BaseDataSourceSuite("test_data_source_filter_pushdown") {
+class FilterPushdownSuite extends BaseDataSourceSuite("test_datasource_filter_pushdown") {
   // Values used for comparison
   private val row1 = Row(null, "Hello")
   private val row2 = Row(2, "TiDB")

--- a/core/src/test/scala/com/pingcap/tispark/datasource/UpsertSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/UpsertSuite.scala
@@ -7,12 +7,15 @@ import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructT
 
 // without TiExtensions
 // will not load tidb_config.properties to SparkConf
-class BasicDataSouceSuite extends BaseDataSourceSuite("test_datasource_basic") {
+class UpsertSuite extends BaseDataSourceSuite("test_datasource_upsert") {
   // Values used for comparison
   private val row1 = Row(null, "Hello")
   private val row2 = Row(2, "TiDB")
   private val row3 = Row(3, "Spark")
   private val row4 = Row(4, null)
+  private val row5 = Row(5, "Duplicate")
+
+  private val row3_v2 = Row(3, "TiSpark")
 
   private val schema = StructType(
     List(
@@ -27,47 +30,56 @@ class BasicDataSouceSuite extends BaseDataSourceSuite("test_datasource_basic") {
     jdbcUpdate(s"drop table if exists $dbtableInJDBC")
     jdbcUpdate(s"create table $dbtableInJDBC(i int, s varchar(128))")
     jdbcUpdate(
-      s"insert into $dbtableInJDBC values(null, 'Hello'), (2, 'TiDB')"
+      s"insert into $dbtableInJDBC values(null, 'Hello')"
     )
   }
 
-  test("Test Select") {
-    testSelect(dbtableInSpark, Seq(row1, row2))
+  test("Test upsert to table without primary key") {
+    // insert row2 row3
+    batchWrite(List(row2, row3))
+    testSelect(dbtableInSpark, Seq(row1, row2, row3))
+
+    // insert row4
+    batchWrite(List(row4))
+    testSelect(dbtableInSpark, Seq(row1, row2, row3, row4))
+
+    // deduplicate=false
+    // insert row5 row5
+    {
+      val caught = intercept[TiBatchWriteException] {
+        batchWrite(List(row5, row5))
+      }
+      assert(
+        caught.getMessage
+          .equals("data conflicts! set the parameter deduplicate.")
+      )
+    }
+
+    // deduplicate=true
+    // insert row5 row5
+    batchWrite(List(row5, row5), Some(Map("deduplicate" -> "true")))
+    testSelect(dbtableInSpark, Seq(row1, row2, row3, row4, row5))
+
+    // test update
+    // insert row3_v2
+    batchWrite(List(row3_v2))
+    testSelect(dbtableInSpark, Seq(row1, row2, row3_v2, row4, row5))
   }
 
-  test("Test Write Append") {
-    val data: RDD[Row] = sc.makeRDD(List(row3, row4))
-    val df = sqlContext.createDataFrame(data, schema)
+  test("Test upsert to table with primary key (primary key is handle)") {
+    //TODO
+  }
 
+  private def batchWrite(rows: List[Row], param: Option[Map[String, String]] = None): Unit = {
+    val data: RDD[Row] = sc.makeRDD(rows)
+    val df = sqlContext.createDataFrame(data, schema)
     df.write
       .format("tidb")
-      .options(tidbOptions)
+      .options(tidbOptions ++ param.getOrElse(Map.empty))
       .option("database", databaseInSpark)
       .option("table", testTable)
       .mode("append")
       .save()
-
-    testSelect(dbtableInSpark, Seq(row1, row2, row3, row4))
-  }
-
-  test("Test Write Overwrite") {
-    val data: RDD[Row] = sc.makeRDD(List(row3, row4))
-    val df = sqlContext.createDataFrame(data, schema)
-
-    val caught = intercept[TiBatchWriteException] {
-      df.write
-        .format("tidb")
-        .options(tidbOptions)
-        .option("database", databaseInSpark)
-        .option("table", testTable)
-        .mode("overwrite")
-        .save()
-    }
-
-    assert(
-      caught.getMessage
-        .equals("SaveMode: Overwrite is not supported. TiSpark only support SaveMode.Append.")
-    )
   }
 
   private def testSelect(dbtable: String, expectedAnswer: Seq[Row]): Unit = {

--- a/tikv-client/src/main/java/com/pingcap/tikv/codec/TableCodec.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/codec/TableCodec.java
@@ -12,6 +12,15 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class TableCodec {
+
+  /**
+   * Row layout: colID1, value1, colID2, value2, .....
+   * @param colTypes
+   * @param colIDs
+   * @param values
+   * @return
+   * @throws IllegalAccessException
+   */
   public static byte[] encodeRow(DataType[] colTypes, TLongArrayList colIDs, Object[] values)
       throws IllegalAccessException {
     if (colTypes.length != colIDs.size()) {
@@ -21,7 +30,6 @@ public class TableCodec {
               colTypes.length, colIDs.size()));
     }
 
-    // Row layout: colID1, value1, colID2, value2, .....
     CodecDataOutput cdo = new CodecDataOutput();
 
     for (int i = 0; i < colTypes.length; i++) {
@@ -34,9 +42,7 @@ public class TableCodec {
       return new byte[] {Codec.NULL_FLAG};
     }
 
-    byte[] res = cdo.toBytes();
-    cdo.reset();
-    return res;
+    return cdo.toBytes();
   }
 
   public static Object[] decodeRow(CodecDataInput cdi, DataType[] colTypes) {

--- a/tikv-client/src/main/java/com/pingcap/tikv/codec/TableCodec.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/codec/TableCodec.java
@@ -12,9 +12,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class TableCodec {
-  // Row layout: colID1, value1, colID2, value2, .....
-  private static final CodecDataOutput cdo = new CodecDataOutput();
-
   public static byte[] encodeRow(DataType[] colTypes, TLongArrayList colIDs, Object[] values)
       throws IllegalAccessException {
     if (colTypes.length != colIDs.size()) {
@@ -23,6 +20,9 @@ public class TableCodec {
               "encodeRow error: data and columnID count not " + "match %d vs %d",
               colTypes.length, colIDs.size()));
     }
+
+    // Row layout: colID1, value1, colID2, value2, .....
+    CodecDataOutput cdo = new CodecDataOutput();
 
     for (int i = 0; i < colTypes.length; i++) {
       IntegerCodec.writeLongFully(cdo, colIDs.get(i), false);


### PR DESCRIPTION
TiSpark only support `Append` SaveMode.

`Append` in TiSpark means `upsert`,
1. if primary key exists in db, data will be updated
2. if no same primary key exists, data will be inserted.

| SaveMode | Support | Semantics |
| -------- | ------- | --------- |
| Append | true | TiSpark's `Append` means upsert. If primary key is same, data will be updated; if no same primary key exists, data will be inserted.  |
| Overwrite | false |  - |
| ErrorIfExists | false | - |
| Ignore | false | - |

Currently TiSpark only support writing data to such tables:
1. the table does not contain a primary key
2. the table's primary key is `TINYINT`、`SMALLINT`、`MEDIUMINT` or `INTEGER`
3. the table's primary key is `auto increment`
