### PR TITLE
Remove option timestamp in TiDBRelation

### DIFF
--- a/core/src/main/scala/com/pingcap/tispark/TiDBRelation.scala
+++ b/core/src/main/scala/com/pingcap/tispark/TiDBRelation.scala
@@ -30,7 +30,7 @@ import org.apache.spark.sql.types.StructType
 case class TiDBRelation(session: TiSession,
                         tableRef: TiTableReference,
                         meta: MetaManager,
-                        var ts: Option[TiTimestamp] = None)(
+                        var ts: TiTimestamp = null)(
   @transient val sqlContext: SQLContext
 ) extends BaseRelation {
   val table: TiTableInfo = meta

--- a/core/src/main/scala/org/apache/spark/sql/TiContext.scala
+++ b/core/src/main/scala/org/apache/spark/sql/TiContext.scala
@@ -157,7 +157,7 @@ class TiContext(val sparkSession: SparkSession) extends Serializable with Loggin
       tiSession,
       TiTableReference(dbName, tableName),
       meta,
-      Some(tiSession.getTimestamp)
+      tiSession.getTimestamp
     )(sqlContext)
     sqlContext.baseRelationToDataFrame(tiRelation)
   }
@@ -203,7 +203,7 @@ class TiContext(val sparkSession: SparkSession) extends Serializable with Loggin
           tiSession,
           TiTableReference(dbName, tableName, sizeInBytes),
           meta,
-          Some(tiSession.getTimestamp)
+          tiSession.getTimestamp
         )(sqlContext)
 
         val viewName = getViewName(dbName, tableName, dbNameAsPrefix)

--- a/core/src/main/scala/org/apache/spark/sql/TiStrategy.scala
+++ b/core/src/main/scala/org/apache/spark/sql/TiStrategy.scala
@@ -100,8 +100,8 @@ case class TiStrategy(getOrCreateTiContext: SparkSession => TiContext)(sparkSess
   // apply StartTs to every logical plan in Spark Planning stage
   protected def applyStartTs(ts: TiTimestamp): PartialFunction[LogicalPlan, Unit] = {
     case LogicalRelation(r @ TiDBRelation(_, _, _, timestamp), _, _, _) =>
-      if (timestamp.isEmpty) {
-        r.ts = Some(ts)
+      if (timestamp == null) {
+        r.ts = ts
       }
     case logicalPlan =>
       logicalPlan transformExpressionsUp {
@@ -129,7 +129,7 @@ case class TiStrategy(getOrCreateTiContext: SparkSession => TiContext)(sparkSess
     dagRequest: TiDAGRequest
   ): SparkPlan = {
     dagRequest.setTableInfo(source.table)
-    dagRequest.setStartTs(source.ts.get)
+    dagRequest.setStartTs(source.ts)
     dagRequest.resolve()
 
     val notAllowPushDown = dagRequest.getFields.asScala
@@ -277,7 +277,7 @@ case class TiStrategy(getOrCreateTiContext: SparkSession => TiContext)(sparkSess
     }
 
     dagRequest.setTableInfo(source.table)
-    dagRequest.setStartTs(source.ts.get)
+    dagRequest.setStartTs(source.ts)
     dagRequest.setEstimatedCount(scanPlan.getEstimatedRowCount)
     dagRequest
   }


### PR DESCRIPTION
Option is no longer useful because we indicate that Timestamp is needed when executing relation plan