### PR TITLE
Fix KeyNotInRegion may occur when retrieving rows by handle

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/tispark/TiHandleRDD.scala
+++ b/core/src/main/scala/org/apache/spark/sql/tispark/TiHandleRDD.scala
@@ -75,8 +75,9 @@ class TiHandleRDD(val dagRequest: TiDAGRequest,
       private val regionHandleMap = RangeSplitter
         .newSplitter(regionManager)
         .groupByAndSortHandlesByRegionId(physicalId, handleList)
+        .map(x => (x._1.first.getId, x._2))
 
-      private val iterator = regionHandleMap.iterator()
+      private val iterator = regionHandleMap.iterator
 
       override def hasNext: Boolean = {
         // Kill the task in case it has been marked as killed.
@@ -87,9 +88,9 @@ class TiHandleRDD(val dagRequest: TiDAGRequest,
       }
 
       override def next(): Row = {
-        iterator.advance()
-        val regionId = iterator.key
-        val handleList = iterator.value
+        val next = iterator.next
+        val regionId = next._1
+        val handleList = next._2
 
         // Returns RegionId:[handle1, handle2, handle3...] K-V pair
         Row.apply(regionId, handleList.toArray())

--- a/tikv-client/src/main/java/com/pingcap/tikv/meta/TiDAGRequest.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/meta/TiDAGRequest.java
@@ -1005,27 +1005,26 @@ public class TiDAGRequest implements Serializable {
     // Key ranges might be also useful
     if (!getRangesMaps().isEmpty()) {
       sb.append(", KeyRange: ");
-      if(tableInfo.isPartitionEnabled()) {
+      if (tableInfo.isPartitionEnabled()) {
         getRangesMaps()
-          .values()
-          .forEach(
-              vList -> {
-                for (int i = 9; i < vList.size(); i++) {
-                  sb.append(String.format("partition p%d", i));
-                  sb.append(KeyUtils.formatBytesUTF8(vList.get(i)));
-                }
-              });
+            .values()
+            .forEach(
+                vList -> {
+                  for (int i = 9; i < vList.size(); i++) {
+                    sb.append(String.format("partition p%d", i));
+                    sb.append(KeyUtils.formatBytesUTF8(vList.get(i)));
+                  }
+                });
       } else {
         getRangesMaps()
-          .values()
-          .forEach(
-              vList -> {
-                for (Coprocessor.KeyRange range : vList) {
-                  sb.append(KeyUtils.formatBytesUTF8(range));
-                }
-              });
+            .values()
+            .forEach(
+                vList -> {
+                  for (Coprocessor.KeyRange range : vList) {
+                    sb.append(KeyUtils.formatBytesUTF8(range));
+                  }
+                });
       }
-
     }
 
     if (!getPushDownAggregatePairs().isEmpty()) {

--- a/tikv-client/src/test/java/com/pingcap/tikv/util/RangeSplitterTest.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/util/RangeSplitterTest.java
@@ -293,8 +293,10 @@ public class RangeSplitterTest {
                 keyRangeByHandle(tableId, 0x2300L /*8960*/, Status.LESS, 16000L, Status.EQUAL),
                 keyRangeByHandle(tableId, 16000L, Status.EQUAL, null, Status.EQUAL)));
 
-    TLongObjectHashMap<TLongArrayList> result =
-        RangeSplitter.newSplitter(mgr).groupByAndSortHandlesByRegionId(tableId, handles);
+    TLongObjectHashMap<TLongArrayList> result = new TLongObjectHashMap<>();
+    RangeSplitter.newSplitter(mgr)
+        .groupByAndSortHandlesByRegionId(tableId, handles)
+        .forEach((k, v) -> result.put(k.first.getId(), v));
     assertEquals(2, result.get(0).size());
     assertEquals(10, result.get(1).size());
     assertEquals(2, result.get(2).size());


### PR DESCRIPTION
Fix #754 by using the same region info to split ranges and create tasks. If it is an outdated region info, we will let backOff to do the job.