### PR TITLE
Trigger format on commit and forbid commit if unformatted

### DIFF
--- a/core/scripts/version.sh
+++ b/core/scripts/version.sh
@@ -14,7 +14,7 @@
 #   limitations under the License.
 #
 
-
+cd ..
 TiSparkReleaseVersion=2.1-SNAPSHOT
 TiSparkBuildTS=`date -u '+%Y-%m-%d %I:%M:%S'`
 TiSparkGitHash=`git rev-parse HEAD`
@@ -34,4 +34,4 @@ object TiSparkVersion {
   if (confStream != null) {
     prop.load(confStream)
   }
-  val version: String = "Release Version: '${TiSparkReleaseVersion}'\\nSupported Spark Version: " + prop.getProperty("spark.supported_version", "spark-2.3") + "\\nGit Commit Hash: '${TiSparkGitHash}'\\nGit Branch: '${TiSparkGitBranch}'\\nUTC Build Time: '${TiSparkBuildTS}'" }' > src/main/scala/com/pingcap/tispark/TiSparkVersion.scala
+  val version: String = "Release Version: '${TiSparkReleaseVersion}'\\nSupported Spark Version: " + prop.getProperty("spark.supported_version", "spark-2.3") + "\\nGit Commit Hash: '${TiSparkGitHash}'\\nGit Branch: '${TiSparkGitBranch}'\\nUTC Build Time: '${TiSparkBuildTS}'" }' > core/src/main/scala/com/pingcap/tispark/TiSparkVersion.scala

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -1,0 +1,16 @@
+## Guide to Use Git Pre-Commit Hook to format code
+
+Inspired by [this gist script](https://gist.github.com/alodavi/c42da82b888869bf935242b1160e05b7#file-pre-commit-hook-install-sh), we use maven plugin to do the work instead of `scalafmt`
+
+
+Run the following commands:
+```bash
+cd $ProjectRoot/hooks
+./pre-commit-hook-install.sh
+```
+
+The hook will be added to local `.git` directory, and will be performed each time pre-commit.
+
+Note that the if any changes are applied to `pre-commit-hook.sh`, the above instructions should be run again.
+
+This pre-commit hook will force format before commit, if un-staged changes exists, the commit will abort when code is not already formatted. It is due to possible merge conflicts of stashed un-staged changes and un-staged formatted changes.

--- a/hooks/pre-commit-hook-install.sh
+++ b/hooks/pre-commit-hook-install.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+touch ../.git/hooks/pre-commit #create the file if not exist
+rm ../.git/hooks/pre-commit #delete the file
+ln -s pre-commit-hook.sh ../.git/hooks/pre-commit #create a file link
+echo "$(tput setaf 3)* link to ../.git/hooks/pre-commit successfully created.$(tput sgr 0)"
+cp pre-commit-hook.sh ../.git/hooks/pre-commit-hook.sh
+echo "$(tput setaf 3)* pre-commit-hook successfully installed.$(tput sgr 0)"

--- a/hooks/pre-commit-hook.sh
+++ b/hooks/pre-commit-hook.sh
@@ -1,0 +1,73 @@
+#!/bin/sh
+
+# checks if locally staged changes are
+# formatted properly. Ignores non-staged
+# changes.
+# Intended as git pre-commit hook
+
+_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+DIR=$( echo ${_DIR} | sed 's/\/.git\/hooks$//' )
+
+#COLOR CODES:
+#tput setaf 3 = yellow -> Info
+#tput setaf 1 = red -> warning/not allowed commit
+#tput setaf 2 = green -> all good!/allowed commit
+
+echo ""
+echo "$(tput setaf 3)Running pre-commit hook ... (you can omit this with --no-verify, but don't)$(tput sgr 0)"
+git diff --quiet
+hadNoNonStagedChanges=$?
+
+if ! [[ ${hadNoNonStagedChanges} -eq 0 ]]
+then
+   echo "$(tput setaf 3)* Stashing non-staged changes$(tput sgr 0)"
+   git stash --keep-index -u > /dev/null
+fi
+
+echo "$(tput setaf 3)* Formatting staged changes... $(tput sgr 0)"
+(cd ${DIR}/; mvn initialize)
+git diff --quiet
+formatted=$?
+
+echo "$(tput setaf 3)* Properly formatted?$(tput sgr 0)"
+
+if [[ ${formatted} -eq 0 ]]
+then
+   echo "$(tput setaf 2)* Yes$(tput sgr 0)"
+else
+   echo "$(tput setaf 1)* No$(tput sgr 0)"
+    echo "$(tput setaf 1)The following files need formatting (in stage or commited):$(tput sgr 0)"
+    git diff --name-only
+    echo ""
+    echo "$(tput setaf 1)Files above will be formatted forcibly.$(tput sgr 0)"
+    echo ""
+fi
+
+if ! [[ ${hadNoNonStagedChanges} -eq 0 ]]
+then
+   echo "$(tput setaf 3)* Scheduling stash pop of previously stashed non-staged changes for 1 second after commit.$(tput sgr 0)"
+   if [[ ${formatted} -eq 0 ]]
+   then
+      sleep 1 && git stash pop --index > /dev/null & # sleep and & otherwise commit fails when this leads to a merge conflict
+   else
+      echo "$(tput setaf 3)* Undoing formatting$(tput sgr 0)"
+      git stash --keep-index > /dev/null
+      git stash drop > /dev/null
+      git stash pop --index > /dev/null &
+      echo "$(tput setaf 1)... done.$(tput sgr 0)"
+      echo "$(tput setaf 1)CANCELLING commit due to NON-FORMATTED CODE.$(tput sgr 0)"
+      echo "$(tput setaf 1)You probably need to stash your changes to avoid format conflicts.$(tput sgr 0)"
+      echo ""
+      exit 1
+   fi
+fi
+
+if ! [[ ${formatted} -eq 0 ]]
+then
+   echo "$(tput setaf 2)Add format result$(tput sgr 0)"
+   git add .
+fi
+
+echo "$(tput setaf 2)... done. Proceeding with commit.$(tput sgr 0)"
+echo ""
+echo 0

--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,24 @@
             </plugins>
         </pluginManagement>
         <plugins>
+            <plugin>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.0.0-M2</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireMavenVersion>
+                                    <version>[3.5,)</version>
+                                </requireMavenVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <!--GPG Signed Components-->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/tikv-client/pom.xml
+++ b/tikv-client/pom.xml
@@ -435,6 +435,7 @@
                 </configuration>
                 <executions>
                     <execution>
+                        <phase>validate</phase>
                         <goals>
                             <goal>format</goal>
                         </goals>


### PR DESCRIPTION
`git pre-commit hook` allows a formatter hook added when git performs commit. So formatting will be checked automatically when committing to git.  