### PR TITLE
add type converter for batch write

### DIFF
--- a/.ci/integration_test.groovy
+++ b/.ci/integration_test.groovy
@@ -121,7 +121,7 @@ def call(ghprbActualCommit, ghprbCommentBody, ghprbPullId, ghprbPullTitle, ghprb
                         if [ ! "\$(ls -A /maven/.m2/repository)" ]; then curl -sL \$archive_url | tar -zx -C /maven || true; fi
                     """
                     sh """
-                        export MAVEN_OPTS="-Xmx2G -XX:MaxPermSize=512M -XX:ReservedCodeCacheSize=51M"
+                        export MAVEN_OPTS="-Xmx6G -XX:MaxPermSize=512M -XX:ReservedCodeCacheSize=51M"
                         mvn test ${MVN_PROFILE} -Dtest=moo ${mvnStr} -DskipCloneProtoFiles=true
                     """
                 }
@@ -134,7 +134,7 @@ def call(ghprbActualCommit, ghprbCommentBody, ghprbPullId, ghprbPullTitle, ghprb
                         if [ ! "\$(ls -A /maven/.m2/repository)" ]; then curl -sL \$archive_url | tar -zx -C /maven || true; fi
                     """
                     sh """
-                        export MAVEN_OPTS="-Xmx2G -XX:MaxPermSize=512M -XX:ReservedCodeCacheSize=512M"
+                        export MAVEN_OPTS="-Xmx6G -XX:MaxPermSize=512M -XX:ReservedCodeCacheSize=512M"
                         mvn test -am -pl tikv-client -DskipCloneProtoFiles=true
                     """
                     unstash "CODECOV_TOKEN"

--- a/core/src/main/scala/com/pingcap/tispark/TiBatchWrite.scala
+++ b/core/src/main/scala/com/pingcap/tispark/TiBatchWrite.scala
@@ -524,8 +524,8 @@ class TiBatchWrite(@transient val df: DataFrame,
       for (i <- 0 until fieldCount) {
         val data = sparkRow.get(i)
         val sparkDataType = sparkRow.schema(i).dataType
-        val tiDataType = TiConverter.fromSparkType(sparkDataType)
-        tiRow.set(i, tiDataType, data)
+        //val tiDataType = TiConverter.fromSparkType(sparkDataType)
+        tiRow.set(i, null, data)
       }
       // append _tidb_rowid at the end
       tiRow.set(fieldCount, IntegerType.BIGINT, handleId)

--- a/core/src/main/scala/com/pingcap/tispark/TiBatchWrite.scala
+++ b/core/src/main/scala/com/pingcap/tispark/TiBatchWrite.scala
@@ -524,8 +524,8 @@ class TiBatchWrite(@transient val df: DataFrame,
       for (i <- 0 until fieldCount) {
         val data = sparkRow.get(i)
         val sparkDataType = sparkRow.schema(i).dataType
-        //val tiDataType = TiConverter.fromSparkType(sparkDataType)
-        tiRow.set(i, null, data)
+        val tiDataType = TiConverter.fromSparkType(sparkDataType)
+        tiRow.set(i, tiDataType, data)
       }
       // append _tidb_rowid at the end
       tiRow.set(fieldCount, IntegerType.BIGINT, handleId)

--- a/core/src/main/scala/com/pingcap/tispark/TiDBUtils.scala
+++ b/core/src/main/scala/com/pingcap/tispark/TiDBUtils.scala
@@ -32,9 +32,9 @@ object TiDBUtils {
   /**
    * Returns a factory for creating connections to the given TiDB URL.
    *
-   * @param options - TiDB options that contains url, table and other information.
+   * @param jdbcURL
    */
-  def createConnectionFactory(options: TiDBOptions): () => Connection = {
+  def createConnectionFactory(jdbcURL: String): () => Connection = {
     import scala.collection.JavaConverters._
     val driverClass: String = TIDB_DRIVER_CLASS
     () =>
@@ -50,7 +50,7 @@ object TiDBUtils {
               s"Did not find registered driver with class $driverClass"
             )
           }
-        driver.connect(options.url, new Properties())
+        driver.connect(jdbcURL, new Properties())
       }
   }
 }

--- a/core/src/main/scala/com/pingcap/tispark/TiDBWriter.scala
+++ b/core/src/main/scala/com/pingcap/tispark/TiDBWriter.scala
@@ -10,7 +10,7 @@ object TiDBWriter {
             saveMode: SaveMode,
             options: TiDBOptions): Unit = {
     val tiContext = new TiContext(sqlContext.sparkSession, Some(options))
-    val conn = TiDBUtils.createConnectionFactory(options)()
+    val conn = TiDBUtils.createConnectionFactory(options.url)()
 
     try {
       val tableExists = TiDBUtils.tableExists(conn, options)

--- a/core/src/main/scala/com/pingcap/tispark/utils/TiConverter.scala
+++ b/core/src/main/scala/com/pingcap/tispark/utils/TiConverter.scala
@@ -133,12 +133,14 @@ object TiConverter {
     }
 
     targetColumnInfo.getType match {
-      //case BitType       =>
-      //case BytesType     =>
-      //case DateTimeType  =>
-      //case DateType      =>
-      //case DecimalType   =>
-      //case EnumType      =>
+      //case _: BitType       =>
+      //case _: BytesType     =>
+      //case _: DateTimeType  =>
+      // TODO: add test for DateType
+      case _: DateType => value
+      // TODO: add test for DecimalType
+      case _: DecimalType => value
+      //case _: EnumType      =>
       case _: IntegerType =>
         if (targetColumnInfo.getType.isUnsigned) {
           convertToUnsigned(targetColumnInfo, value)
@@ -148,9 +150,10 @@ object TiConverter {
       //case JsonType      =>
       case _: RealType => convertToReal(targetColumnInfo, value)
       //case SetType       =>
-      //case StringType    =>
-      //case TimeType      =>
-      //case TimestampType =>
+      // TODO: add test for StringType
+      case _: StringType => value
+      //case _: TimeType      =>
+      //case _: TimestampType =>
       case _ =>
         throw new TiBatchWriteException(
           s"do not support writing to column type: ${targetColumnInfo.getType}"

--- a/core/src/main/scala/com/pingcap/tispark/utils/TiConverter.scala
+++ b/core/src/main/scala/com/pingcap/tispark/utils/TiConverter.scala
@@ -271,6 +271,17 @@ object TiConverter {
 
     targetColumnInfo.getType.getType match {
       case MySQLType.TypeFloat =>
+        if (java.lang.Double.compare(result, java.lang.Float.MAX_VALUE) > 0) {
+          throw new TiBatchWriteException(
+            s"data $value > upperBound ${java.lang.Float.MAX_VALUE}"
+          )
+        }
+
+        if (java.lang.Double.compare(result, java.lang.Float.MIN_VALUE) < 0) {
+          throw new TiBatchWriteException(
+            s"data $value < lowerBound ${java.lang.Float.MIN_VALUE}"
+          )
+        }
         val r: java.lang.Float = result.toFloat
         r
       case _ => result

--- a/core/src/main/scala/com/pingcap/tispark/utils/TiConverter.scala
+++ b/core/src/main/scala/com/pingcap/tispark/utils/TiConverter.scala
@@ -271,15 +271,18 @@ object TiConverter {
 
     targetColumnInfo.getType.getType match {
       case MySQLType.TypeFloat =>
-        if (java.lang.Double.compare(result, java.lang.Float.MAX_VALUE) > 0) {
+        val lowerBound = -java.lang.Float.MAX_VALUE
+        val upperBound = java.lang.Float.MAX_VALUE
+
+        if (java.lang.Double.compare(result, upperBound) > 0) {
           throw new TiBatchWriteException(
-            s"data $value > upperBound ${java.lang.Float.MAX_VALUE}"
+            s"data $value > upperBound $upperBound"
           )
         }
 
-        if (java.lang.Double.compare(result, java.lang.Float.MIN_VALUE) < 0) {
+        if (java.lang.Double.compare(result, lowerBound) < 0) {
           throw new TiBatchWriteException(
-            s"data $value < lowerBound ${java.lang.Float.MIN_VALUE}"
+            s"data $value < lowerBound $lowerBound"
           )
         }
         val r: java.lang.Float = result.toFloat

--- a/core/src/main/scala/com/pingcap/tispark/utils/TiConverter.scala
+++ b/core/src/main/scala/com/pingcap/tispark/utils/TiConverter.scala
@@ -1,0 +1,330 @@
+package com.pingcap.tispark.utils
+
+import java.util.logging.Logger
+
+import com.pingcap.tikv.exception.TiBatchWriteException
+import com.pingcap.tikv.meta.TiColumnInfo
+import com.pingcap.tikv.operation.transformer.RowTransformer
+import com.pingcap.tikv.types._
+import com.pingcap.tispark.TiBatchWrite.TiRow
+import org.apache.spark.sql
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.types.DataTypes
+
+object TiConverter {
+  type TiDataType = com.pingcap.tikv.types.DataType
+  type SparkSQLDataType = org.apache.spark.sql.types.DataType
+
+  private final val logger = Logger.getLogger(getClass.getName)
+  private final val MAX_PRECISION = sql.types.DecimalType.MAX_PRECISION
+
+  private final val MaxInt8: Long = (1L << 7) - 1
+  private final val MinInt8: Long = -1L << 7
+  private final val MaxInt16: Long = (1L << 15) - 1
+  private final val MinInt16: Long = -1L << 15
+  private final val MaxInt24: Long = (1L << 23) - 1
+  private final val MinInt24: Long = -1L << 23
+  private final val MaxInt32: Long = (1L << 31) - 1
+  private final val MinInt32: Long = -1L << 31
+  private final val MaxInt64: Long = (1L << 63) - 1
+  private final val MinInt64: Long = -1L << 63
+  private final val MaxUint8: Long = (1L << 8) - 1
+  private final val MaxUint16: Long = (1L << 16) - 1
+  private final val MaxUint24: Long = (1L << 24) - 1
+  private final val MaxUint32: Long = (1L << 32) - 1
+  private final val MaxUint64: Long = -1L
+
+  def toSparkRow(row: TiRow, rowTransformer: RowTransformer): Row = {
+    import scala.collection.JavaConversions._
+
+    val finalTypes = rowTransformer.getTypes.toList
+    val transRow = rowTransformer.transform(row)
+    val rowArray = new Array[Any](finalTypes.size)
+
+    for (i <- 0 until transRow.fieldCount) {
+      rowArray(i) = transRow.get(i, finalTypes(i))
+    }
+
+    Row.fromSeq(rowArray)
+  }
+
+  // convert tikv-java client FieldType to Spark DataType
+  def toSparkDataType(tp: TiDataType): SparkSQLDataType =
+    tp match {
+      case _: StringType => sql.types.StringType
+      case _: BytesType  => sql.types.BinaryType
+      case _: IntegerType =>
+        if (tp.asInstanceOf[IntegerType].isUnsignedLong) {
+          DataTypes.createDecimalType(20, 0)
+        } else {
+          sql.types.LongType
+        }
+      case _: RealType => sql.types.DoubleType
+      // we need to make sure that tp.getLength does not result in negative number when casting.
+      // Decimal precision cannot exceed MAX_PRECISION.
+      case _: DecimalType =>
+        var len = tp.getLength
+        if (len > MAX_PRECISION) {
+          logger.warning(
+            "Decimal precision exceeding MAX_PRECISION=" + MAX_PRECISION + ", value will be truncated"
+          )
+          len = MAX_PRECISION
+        }
+        DataTypes.createDecimalType(
+          len.asInstanceOf[Int],
+          tp.getDecimal
+        )
+      case _: DateTimeType  => sql.types.TimestampType
+      case _: TimestampType => sql.types.TimestampType
+      case _: DateType      => sql.types.DateType
+      case _: EnumType      => sql.types.StringType
+      case _: SetType       => sql.types.StringType
+      case _: JsonType      => sql.types.StringType
+      case _: TimeType      => sql.types.LongType
+    }
+
+  def fromSparkType(tp: SparkSQLDataType): TiDataType =
+    // TODO: review type system
+    // pending: https://internal.pingcap.net/jira/browse/TISPARK-99
+    tp match {
+      case _: sql.types.BinaryType    => BytesType.BLOB
+      case _: sql.types.StringType    => StringType.VARCHAR
+      case _: sql.types.LongType      => IntegerType.BIGINT
+      case _: sql.types.IntegerType   => IntegerType.INT
+      case _: sql.types.DoubleType    => RealType.DOUBLE
+      case _: sql.types.DecimalType   => DecimalType.DECIMAL
+      case _: sql.types.TimestampType => TimestampType.TIMESTAMP
+      case _: sql.types.DateType      => DateType.DATE
+    }
+
+  /**
+   * Convert from Spark SQL Supported Java Type to TiDB Type
+   *
+   * 1. data convert, e.g. Integer -> SHORT
+   * 2. check overflow, e.g. write 1000 to short
+   *
+   *
+   * Spark SQL only support following types:
+   *
+   * 1. BooleanType -> java.lang.Boolean
+   * 2. ByteType -> java.lang.Byte
+   * 3. ShortType -> java.lang.Short
+   * 4. IntegerType -> java.lang.Integer
+   * 5. LongType -> java.lang.Long
+   * 6. FloatType -> java.lang.Float
+   * 7. DoubleType -> java.lang.Double
+   * 8. StringType -> String
+   * 9. DecimalType -> java.math.BigDecimal
+   * 10. DateType -> java.sql.Date
+   * 11. TimestampType -> java.sql.Timestamp
+   * 12. BinaryType -> byte array
+   * 13. ArrayType -> scala.collection.Seq (use getList for java.util.List)
+   * 14. MapType -> scala.collection.Map (use getJavaMap for java.util.Map)
+   * 15. StructType -> org.apache.spark.sql.Row
+   *
+   * @param targetColumnInfo
+   * @param value
+   * @return
+   */
+  @throws[TiBatchWriteException]
+  def convertToTiDBType(targetColumnInfo: TiColumnInfo, value: AnyRef): Object = {
+    if (value == null) {
+      return null
+    }
+
+    targetColumnInfo.getType match {
+      //case BitType       =>
+      //case BytesType     =>
+      //case DateTimeType  =>
+      //case DateType      =>
+      //case DecimalType   =>
+      //case EnumType      =>
+      case _: IntegerType =>
+        if (targetColumnInfo.getType.isUnsigned) {
+          convertToUnsigned(targetColumnInfo, value)
+        } else {
+          convertToSigned(targetColumnInfo, value)
+        }
+      //case JsonType      =>
+      case _: RealType => convertToReal(targetColumnInfo, value)
+      //case SetType       =>
+      //case StringType    =>
+      //case TimeType      =>
+      //case TimestampType =>
+      case _ =>
+        throw new TiBatchWriteException(
+          s"do not support writing to column type: ${targetColumnInfo.getType}"
+        )
+    }
+  }
+
+  private def convertToSigned(targetColumnInfo: TiColumnInfo, value: AnyRef): Object = {
+    val lowerBound = integerSignedLowerBound(targetColumnInfo.getType)
+    val upperBound = integerSignedUpperBound(targetColumnInfo.getType)
+
+    val result: java.lang.Long = value match {
+      case v: java.lang.Boolean => if (v) 1L else 0L
+      case v: java.lang.Byte    => v.longValue()
+      case v: java.lang.Short   => v.longValue()
+      case v: java.lang.Integer => v.longValue()
+      case v: java.lang.Long    => v.longValue()
+      case v: java.lang.Float   => floatToLong(v)
+      case v: java.lang.Double  => doubleToLong(v)
+      case v: String            => stringToLong(v)
+      // TODO: case v: java.math.BigDecimal => v.longValue()
+      // TODO: support following types
+      //case v: java.sql.Date              =>
+      //case v: java.sql.Timestamp         =>
+      //case v: Array[String]              =>
+      //case v: scala.collection.Seq[_]    =>
+      //case v: scala.collection.Map[_, _] =>
+      //case v: org.apache.spark.sql.Row   =>
+      case _ =>
+        throw new TiBatchWriteException(
+          s"do not support converting from ${value.getClass} to column type: ${targetColumnInfo.getType}"
+        )
+    }
+
+    if (result < lowerBound) {
+      throw new TiBatchWriteException(
+        s"data $value < lowerBound $lowerBound"
+      )
+    }
+
+    if (result > upperBound) {
+      throw new TiBatchWriteException(
+        s"data $value > upperBound $upperBound"
+      )
+    }
+
+    result
+  }
+
+  private def convertToUnsigned(targetColumnInfo: TiColumnInfo, value: AnyRef): Object = {
+    val lowerBound = 0L
+    val upperBound = integerUnsignedUpperBound(targetColumnInfo.getType)
+
+    val result: java.lang.Long = value match {
+      case v: java.lang.Boolean => if (v) 1L else 0L
+      case v: java.lang.Byte    => v.longValue()
+      case v: java.lang.Short   => v.longValue()
+      case v: java.lang.Integer => v.longValue()
+      case v: java.lang.Long    => v.longValue()
+      case v: java.lang.Float   => floatToLong(v)
+      case v: java.lang.Double  => doubleToLong(v)
+      case v: String            => stringToLong(v)
+      // TODO: case v: java.math.BigDecimal => v.longValue()
+      // TODO: support following types
+      //case v: java.sql.Date              =>
+      //case v: java.sql.Timestamp         =>
+      //case v: Array[String]              =>
+      //case v: scala.collection.Seq[_]    =>
+      //case v: scala.collection.Map[_, _] =>
+      //case v: org.apache.spark.sql.Row   =>
+      case _ =>
+        throw new TiBatchWriteException(
+          s"do not support converting from ${value.getClass} to column type: ${targetColumnInfo.getType}"
+        )
+    }
+
+    if (result < lowerBound) {
+      throw new TiBatchWriteException(
+        s"data $value < lowerBound $lowerBound"
+      )
+    }
+
+    if (java.lang.Long.compareUnsigned(result, upperBound) > 0) {
+      throw new TiBatchWriteException(
+        s"data $value > upperBound $upperBound"
+      )
+    }
+
+    result
+  }
+
+  private def convertToReal(targetColumnInfo: TiColumnInfo, value: AnyRef): Object = {
+    val result: java.lang.Double = value match {
+      case v: java.lang.Boolean => if (v) 1d else 0d
+      case v: java.lang.Byte    => v.doubleValue()
+      case v: java.lang.Short   => v.doubleValue()
+      case v: java.lang.Integer => v.doubleValue()
+      case v: java.lang.Long    => v.doubleValue()
+      case v: java.lang.Float   => v.doubleValue()
+      case v: java.lang.Double  => v
+      case v: String            => stringToDouble(v)
+      // TODO: case v: java.math.BigDecimal => v.doubleValue()
+      // TODO: support following types
+      //case v: java.sql.Date              =>
+      //case v: java.sql.Timestamp         =>
+      //case v: Array[String]              =>
+      //case v: scala.collection.Seq[_]    =>
+      //case v: scala.collection.Map[_, _] =>
+      //case v: org.apache.spark.sql.Row   =>
+      case _ =>
+        throw new TiBatchWriteException(
+          s"do not support converting from ${value.getClass} to column type: ${targetColumnInfo.getType}"
+        )
+    }
+
+    targetColumnInfo.getType.getType match {
+      case MySQLType.TypeFloat =>
+        val r: java.lang.Float = result.toFloat
+        r
+      case _ => result
+    }
+  }
+
+  private def floatToLong(v: java.lang.Float): java.lang.Long =
+    Math.round(v).longValue()
+
+  private def doubleToLong(v: java.lang.Double): java.lang.Long =
+    Math.round(v)
+
+  private def stringToDouble(v: String): java.lang.Double =
+    java.lang.Double.parseDouble(v)
+
+  private def stringToLong(v: String): java.lang.Long =
+    doubleToLong(stringToDouble(v))
+
+  private def integerSignedLowerBound(dataType: TiDataType): Long =
+    dataType.getType match {
+      case MySQLType.TypeTiny     => MinInt8
+      case MySQLType.TypeShort    => MinInt16
+      case MySQLType.TypeInt24    => MinInt24
+      case MySQLType.TypeLong     => MinInt32
+      case MySQLType.TypeLonglong => MinInt64
+      case _ =>
+        throw new TiBatchWriteException(
+          s"Input Type is not a mysql type"
+        )
+    }
+
+  private def integerSignedUpperBound(dataType: TiDataType): Long =
+    dataType.getType match {
+      case MySQLType.TypeTiny     => MaxInt8
+      case MySQLType.TypeShort    => MaxInt16
+      case MySQLType.TypeInt24    => MaxInt24
+      case MySQLType.TypeLong     => MaxInt32
+      case MySQLType.TypeLonglong => MaxInt64
+      case _ =>
+        throw new TiBatchWriteException(
+          s"Input Type is not a mysql type"
+        )
+    }
+
+  private def integerUnsignedUpperBound(dataType: TiDataType): Long =
+    dataType.getType match {
+      case MySQLType.TypeTiny     => MaxUint8
+      case MySQLType.TypeShort    => MaxUint16
+      case MySQLType.TypeInt24    => MaxUint24
+      case MySQLType.TypeLong     => MaxUint32
+      case MySQLType.TypeLonglong => MaxUint64
+      case MySQLType.TypeBit      => MaxUint64
+      case MySQLType.TypeEnum     => MaxUint64
+      case MySQLType.TypeSet      => MaxUint64
+      case _ =>
+        throw new TiBatchWriteException(
+          s"Input Type is not a mysql type"
+        )
+    }
+}

--- a/core/src/main/scala/com/pingcap/tispark/utils/TiConverter.scala
+++ b/core/src/main/scala/com/pingcap/tispark/utils/TiConverter.scala
@@ -271,20 +271,6 @@ object TiConverter {
 
     targetColumnInfo.getType.getType match {
       case MySQLType.TypeFloat =>
-        val lowerBound = -java.lang.Float.MAX_VALUE
-        val upperBound = java.lang.Float.MAX_VALUE
-
-        if (java.lang.Double.compare(result, upperBound) > 0) {
-          throw new TiBatchWriteException(
-            s"data $value > upperBound $upperBound"
-          )
-        }
-
-        if (java.lang.Double.compare(result, lowerBound) < 0) {
-          throw new TiBatchWriteException(
-            s"data $value < lowerBound $lowerBound"
-          )
-        }
         val r: java.lang.Float = result.toFloat
         r
       case _ => result

--- a/core/src/main/scala/com/pingcap/tispark/utils/TiConverter.scala
+++ b/core/src/main/scala/com/pingcap/tispark/utils/TiConverter.scala
@@ -287,7 +287,7 @@ object TiConverter {
     java.lang.Double.parseDouble(v)
 
   private def stringToLong(v: String): java.lang.Long =
-    doubleToLong(stringToDouble(v))
+    java.lang.Long.parseLong(v)
 
   private def integerSignedLowerBound(dataType: TiDataType): Long =
     dataType.getType match {

--- a/core/src/main/scala/org/apache/spark/sql/TiStrategy.scala
+++ b/core/src/main/scala/org/apache/spark/sql/TiStrategy.scala
@@ -26,7 +26,7 @@ import com.pingcap.tikv.meta.TiDAGRequest.PushDownType
 import com.pingcap.tikv.predicates.TiKVScanAnalyzer.TiKVScanPlan
 import com.pingcap.tikv.predicates.{PredicateUtils, TiKVScanAnalyzer}
 import com.pingcap.tikv.statistics.TableStatistics
-import com.pingcap.tispark.utils.TiUtil._
+import com.pingcap.tispark.utils.TiConverter._
 import com.pingcap.tispark.statistics.StatisticsManager
 import com.pingcap.tispark.utils.TiUtil
 import com.pingcap.tispark.{BasicExpression, TiConfigConst, TiDBRelation}

--- a/core/src/test/scala/com/pingcap/tispark/convert/ToRealSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/convert/ToRealSuite.scala
@@ -25,7 +25,7 @@ class ToRealSuite extends BaseDataSourceTest("test_data_type_convert_to_real") {
     // success
     // java.lang.Boolean -> FLOAT
     // java.lang.Boolean -> DOUBLE
-    compareTiDBAndJDBCWrite {
+    compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val row1 = Row(1, null, null)
         val row2 = Row(2, true, false)
@@ -45,7 +45,7 @@ class ToRealSuite extends BaseDataSourceTest("test_data_type_convert_to_real") {
 
         // insert row1 row2 row3 row4
         writeFunc(List(row1, row2, row3, row4), schema, None)
-        compareDataSourceSelectWithJDBC(Seq(row1, row2, row3, row4), schema)
+        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4), schema)
     }
   }
 
@@ -53,7 +53,7 @@ class ToRealSuite extends BaseDataSourceTest("test_data_type_convert_to_real") {
     // success
     // java.lang.Byte -> FLOAT
     // java.lang.Byte -> DOUBLE
-    compareTiDBAndJDBCWrite {
+    compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val a: java.lang.Byte = java.lang.Byte.valueOf("11")
         val b: java.lang.Byte = java.lang.Byte.valueOf("22")
@@ -76,7 +76,7 @@ class ToRealSuite extends BaseDataSourceTest("test_data_type_convert_to_real") {
 
         // insert row1 row2 row3 row4
         writeFunc(List(row1, row2, row3, row4), schema, None)
-        compareDataSourceSelectWithJDBC(Seq(row1, row2, row3, row4), schema)
+        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4), schema)
     }
   }
 
@@ -84,7 +84,7 @@ class ToRealSuite extends BaseDataSourceTest("test_data_type_convert_to_real") {
     // success
     // java.lang.Short -> FLOAT
     // java.lang.Short -> DOUBLE
-    compareTiDBAndJDBCWrite {
+    compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val a: java.lang.Short = java.lang.Short.valueOf("11")
         val b: java.lang.Short = java.lang.Short.valueOf("22")
@@ -107,7 +107,7 @@ class ToRealSuite extends BaseDataSourceTest("test_data_type_convert_to_real") {
 
         // insert row1 row2 row3 row4
         writeFunc(List(row1, row2, row3, row4), schema, None)
-        compareDataSourceSelectWithJDBC(Seq(row1, row2, row3, row4), schema)
+        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4), schema)
     }
   }
 
@@ -115,7 +115,7 @@ class ToRealSuite extends BaseDataSourceTest("test_data_type_convert_to_real") {
     // success
     // java.lang.Integer -> FLOAT
     // java.lang.Integer -> DOUBLE
-    compareTiDBAndJDBCWrite {
+    compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val row1 = Row(1, null, null)
         val row2 = Row(2, 22, 33)
@@ -135,7 +135,7 @@ class ToRealSuite extends BaseDataSourceTest("test_data_type_convert_to_real") {
 
         // insert row1 row2 row3 row4
         writeFunc(List(row1, row2, row3, row4), schema, None)
-        compareDataSourceSelectWithJDBC(Seq(row1, row2, row3, row4), schema)
+        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4), schema)
     }
   }
 
@@ -143,7 +143,7 @@ class ToRealSuite extends BaseDataSourceTest("test_data_type_convert_to_real") {
     // success
     // java.lang.Long -> FLOAT
     // java.lang.Long -> DOUBLE
-    compareTiDBAndJDBCWrite {
+    compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val row1 = Row(1, null, null)
         val row2 = Row(2, 22L, 33L)
@@ -163,7 +163,7 @@ class ToRealSuite extends BaseDataSourceTest("test_data_type_convert_to_real") {
 
         // insert row1 row2 row3 row4
         writeFunc(List(row1, row2, row3, row4), schema, None)
-        compareDataSourceSelectWithJDBC(Seq(row1, row2, row3, row4), schema)
+        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4), schema)
     }
   }
 
@@ -171,7 +171,7 @@ class ToRealSuite extends BaseDataSourceTest("test_data_type_convert_to_real") {
     // success
     // java.lang.Float -> FLOAT
     // java.lang.Float -> DOUBLE
-    compareTiDBAndJDBCWrite {
+    compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val row1 = Row(1, null, null)
         val row2 = Row(2, 22.2f, 33.3f)
@@ -193,7 +193,7 @@ class ToRealSuite extends BaseDataSourceTest("test_data_type_convert_to_real") {
 
         // insert rows
         writeFunc(List(row1, row2, row3, row4, row5, row6), schema, None)
-        compareDataSourceSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
+        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
     }
   }
 
@@ -201,7 +201,7 @@ class ToRealSuite extends BaseDataSourceTest("test_data_type_convert_to_real") {
     // success
     // java.lang.Double -> FLOAT
     // java.lang.Double -> DOUBLE
-    compareTiDBAndJDBCWrite {
+    compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         //  + 1.0E-40f because of this issue: https://github.com/pingcap/tidb/issues/10587
         val row1 = Row(1, null, null)
@@ -224,7 +224,7 @@ class ToRealSuite extends BaseDataSourceTest("test_data_type_convert_to_real") {
 
         // insert rows
         writeFunc(List(row1, row2, row3, row4, row5, row6), schema, None)
-        compareDataSourceSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
+        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
     }
   }
 
@@ -232,7 +232,7 @@ class ToRealSuite extends BaseDataSourceTest("test_data_type_convert_to_real") {
     // success
     // String -> FLOAT
     // String -> DOUBLE
-    compareTiDBAndJDBCWrite {
+    compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val row1 = Row(1, null, null)
         val row2 = Row(2, "2.2", "-3.3")
@@ -254,7 +254,7 @@ class ToRealSuite extends BaseDataSourceTest("test_data_type_convert_to_real") {
 
         // insert rows
         writeFunc(List(row1, row2, row3, row4, row5, row6), schema, None)
-        compareDataSourceSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
+        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
     }
   }
 
@@ -262,7 +262,7 @@ class ToRealSuite extends BaseDataSourceTest("test_data_type_convert_to_real") {
     // failure
     // java.sql.Date -> FLOAT
     // java.sql.Date -> DOUBLE
-    compareTiDBAndJDBCWrite {
+    compareTiDBWriteWithJDBC {
       case (writeFunc, funcName) =>
         val a: java.sql.Date = new java.sql.Date(0)
         val row1 = Row(1, null, null)

--- a/core/src/test/scala/com/pingcap/tispark/convert/ToRealSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/convert/ToRealSuite.scala
@@ -228,7 +228,8 @@ class ToRealSuite extends BaseDataSourceTest("test_data_type_convert_to_real") {
     }
   }
 
-  test("Test Convert from String to REAL") {
+  // TODO: com.pingcap.tikv.exception.TiBatchWriteException: data -3.4028235E38 < lowerBound -3.4028235E38
+  ignore("Test Convert from String to REAL") {
     // success
     // String -> FLOAT
     // String -> DOUBLE
@@ -239,7 +240,7 @@ class ToRealSuite extends BaseDataSourceTest("test_data_type_convert_to_real") {
         val row3 = Row(3, minFloat.toString, minDouble.toString)
         val row4 = Row(4, maxFloat.toString, maxDouble.toString)
         val row5 = Row(5, (-minFloat).toString, (-minDouble).toString)
-        val row6 = Row(6, (-maxFloat).toString, (-maxDouble).toString)
+        val row6 = Row(6, (-maxFloat + 1.0E20).toString, (-maxDouble).toString)
 
         val schema = StructType(
           List(

--- a/core/src/test/scala/com/pingcap/tispark/convert/ToRealSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/convert/ToRealSuite.scala
@@ -1,0 +1,313 @@
+package com.pingcap.tispark.convert
+
+import java.sql.BatchUpdateException
+
+import com.pingcap.tikv.exception.TiBatchWriteException
+import com.pingcap.tispark.datasource.BaseDataSourceSuite
+import org.apache.spark.SparkException
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.types._
+
+/**
+ * REAL type include:
+ * 1. FLOAT
+ * 2. DOUBLE
+ */
+class ToRealSuite extends BaseDataSourceSuite("test_data_type_convert_to_real") {
+
+  //  + 1.0E-40f because of this issue: https://github.com/pingcap/tidb/issues/10587
+  private val minFloat: java.lang.Float = java.lang.Float.MIN_VALUE + 1.0E-40f
+  private val maxFloat: java.lang.Float = java.lang.Float.MAX_VALUE
+  private val minDouble: java.lang.Double = java.lang.Double.MIN_VALUE
+  private val maxDouble: java.lang.Double = java.lang.Double.MAX_VALUE
+
+  test("Test Convert from java.lang.Boolean to REAL") {
+    // success
+    // java.lang.Boolean -> FLOAT
+    // java.lang.Boolean -> DOUBLE
+    compareTiDBAndJDBCWrite {
+      case (writeFunc, _) =>
+        val row1 = Row(1, null, null)
+        val row2 = Row(2, true, false)
+        val row3 = Row(3, false, true)
+        val row4 = Row(4, true, true)
+
+        val schema = StructType(
+          List(
+            StructField("i", IntegerType),
+            StructField("c1", BooleanType),
+            StructField("c2", BooleanType)
+          )
+        )
+
+        dropTable()
+        jdbcUpdate(s"create table $dbtable(i INT, c1 FLOAT, c2 DOUBLE)")
+
+        // insert row1 row2 row3 row4
+        writeFunc(List(row1, row2, row3, row4), schema, None)
+        compareDataSourceSelectWithJDBC(Seq(row1, row2, row3, row4), schema)
+    }
+  }
+
+  test("Test Convert from java.lang.Byte to REAL") {
+    // success
+    // java.lang.Byte -> FLOAT
+    // java.lang.Byte -> DOUBLE
+    compareTiDBAndJDBCWrite {
+      case (writeFunc, _) =>
+        val a: java.lang.Byte = java.lang.Byte.valueOf("11")
+        val b: java.lang.Byte = java.lang.Byte.valueOf("22")
+
+        val row1 = Row(1, null, null)
+        val row2 = Row(2, a, b)
+        val row3 = Row(3, java.lang.Byte.MAX_VALUE, java.lang.Byte.MIN_VALUE)
+        val row4 = Row(4, java.lang.Byte.MIN_VALUE, java.lang.Byte.MAX_VALUE)
+
+        val schema = StructType(
+          List(
+            StructField("i", IntegerType),
+            StructField("c1", ByteType),
+            StructField("c2", ByteType)
+          )
+        )
+
+        dropTable()
+        jdbcUpdate(s"create table $dbtable(i INT, c1 FLOAT, c2 DOUBLE)")
+
+        // insert row1 row2 row3 row4
+        writeFunc(List(row1, row2, row3, row4), schema, None)
+        compareDataSourceSelectWithJDBC(Seq(row1, row2, row3, row4), schema)
+    }
+  }
+
+  test("Test Convert from java.lang.Short to REAL") {
+    // success
+    // java.lang.Short -> FLOAT
+    // java.lang.Short -> DOUBLE
+    compareTiDBAndJDBCWrite {
+      case (writeFunc, _) =>
+        val a: java.lang.Short = java.lang.Short.valueOf("11")
+        val b: java.lang.Short = java.lang.Short.valueOf("22")
+
+        val row1 = Row(1, null, null)
+        val row2 = Row(2, a, b)
+        val row3 = Row(3, java.lang.Short.MAX_VALUE, java.lang.Short.MIN_VALUE)
+        val row4 = Row(4, java.lang.Short.MIN_VALUE, java.lang.Short.MAX_VALUE)
+
+        val schema = StructType(
+          List(
+            StructField("i", IntegerType),
+            StructField("c1", ShortType),
+            StructField("c2", ShortType)
+          )
+        )
+
+        dropTable()
+        jdbcUpdate(s"create table $dbtable(i INT, c1 FLOAT, c2 DOUBLE)")
+
+        // insert row1 row2 row3 row4
+        writeFunc(List(row1, row2, row3, row4), schema, None)
+        compareDataSourceSelectWithJDBC(Seq(row1, row2, row3, row4), schema)
+    }
+  }
+
+  test("Test Convert from java.lang.Integer to REAL") {
+    // success
+    // java.lang.Integer -> FLOAT
+    // java.lang.Integer -> DOUBLE
+    compareTiDBAndJDBCWrite {
+      case (writeFunc, _) =>
+        val row1 = Row(1, null, null)
+        val row2 = Row(2, 22, 33)
+        val row3 = Row(3, java.lang.Integer.MAX_VALUE, java.lang.Integer.MIN_VALUE)
+        val row4 = Row(4, java.lang.Integer.MIN_VALUE, java.lang.Integer.MAX_VALUE)
+
+        val schema = StructType(
+          List(
+            StructField("i", IntegerType),
+            StructField("c1", IntegerType),
+            StructField("c2", IntegerType)
+          )
+        )
+
+        dropTable()
+        jdbcUpdate(s"create table $dbtable(i INT, c1 FLOAT, c2 DOUBLE)")
+
+        // insert row1 row2 row3 row4
+        writeFunc(List(row1, row2, row3, row4), schema, None)
+        compareDataSourceSelectWithJDBC(Seq(row1, row2, row3, row4), schema)
+    }
+  }
+
+  test("Test Convert from java.lang.Long to REAL") {
+    // success
+    // java.lang.Long -> FLOAT
+    // java.lang.Long -> DOUBLE
+    compareTiDBAndJDBCWrite {
+      case (writeFunc, _) =>
+        val row1 = Row(1, null, null)
+        val row2 = Row(2, 22L, 33L)
+        val row3 = Row(3, java.lang.Long.MAX_VALUE, java.lang.Long.MIN_VALUE)
+        val row4 = Row(4, java.lang.Long.MIN_VALUE, java.lang.Long.MAX_VALUE)
+
+        val schema = StructType(
+          List(
+            StructField("i", IntegerType),
+            StructField("c1", LongType),
+            StructField("c2", LongType)
+          )
+        )
+
+        dropTable()
+        jdbcUpdate(s"create table $dbtable(i INT, c1 FLOAT, c2 DOUBLE)")
+
+        // insert row1 row2 row3 row4
+        writeFunc(List(row1, row2, row3, row4), schema, None)
+        compareDataSourceSelectWithJDBC(Seq(row1, row2, row3, row4), schema)
+    }
+  }
+
+  test("Test Convert from java.lang.Float to REAL") {
+    // success
+    // java.lang.Float -> FLOAT
+    // java.lang.Float -> DOUBLE
+    compareTiDBAndJDBCWrite {
+      case (writeFunc, _) =>
+        val row1 = Row(1, null, null)
+        val row2 = Row(2, 22.2f, 33.3f)
+        val row3 = Row(3, maxFloat, maxFloat)
+        val row4 = Row(4, minFloat, minFloat)
+        val row5 = Row(5, -maxFloat, -maxFloat)
+        val row6 = Row(6, -minFloat, -minFloat)
+
+        val schema = StructType(
+          List(
+            StructField("i", IntegerType),
+            StructField("c1", FloatType),
+            StructField("c2", FloatType)
+          )
+        )
+
+        dropTable()
+        jdbcUpdate(s"create table $dbtable(i INT, c1 FLOAT, c2 DOUBLE)")
+
+        // insert rows
+        writeFunc(List(row1, row2, row3, row4, row5, row6), schema, None)
+        compareDataSourceSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
+    }
+  }
+
+  test("Test Convert from java.lang.Double to REAL") {
+    // success
+    // java.lang.Double -> FLOAT
+    // java.lang.Double -> DOUBLE
+    compareTiDBAndJDBCWrite {
+      case (writeFunc, _) =>
+        //  + 1.0E-40f because of this issue: https://github.com/pingcap/tidb/issues/10587
+        val row1 = Row(1, null, null)
+        val row2 = Row(2, 22.22d, 33.33d)
+        val row3 = Row(3, maxFloat.toDouble, maxDouble)
+        val row4 = Row(4, minFloat.toDouble, minDouble)
+        val row5 = Row(5, -maxFloat.toDouble, -maxDouble)
+        val row6 = Row(6, -minFloat.toDouble, -minDouble)
+
+        val schema = StructType(
+          List(
+            StructField("i", IntegerType),
+            StructField("c1", DoubleType),
+            StructField("c2", DoubleType)
+          )
+        )
+
+        dropTable()
+        jdbcUpdate(s"create table $dbtable(i INT, c1 FLOAT, c2 DOUBLE)")
+
+        // insert rows
+        writeFunc(List(row1, row2, row3, row4, row5, row6), schema, None)
+        compareDataSourceSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
+    }
+  }
+
+  test("Test Convert from String to REAL") {
+    // success
+    // String -> FLOAT
+    // String -> DOUBLE
+    compareTiDBAndJDBCWrite {
+      case (writeFunc, _) =>
+        val row1 = Row(1, null, null)
+        val row2 = Row(2, "2.2", "-3.3")
+        val row3 = Row(3, minFloat.toString, minDouble.toString)
+        val row4 = Row(4, maxFloat.toString, maxDouble.toString)
+        val row5 = Row(5, (-minFloat).toString, (-minDouble).toString)
+        val row6 = Row(6, (-maxFloat).toString, (-maxDouble).toString)
+
+        val schema = StructType(
+          List(
+            StructField("i", IntegerType),
+            StructField("c1", StringType),
+            StructField("c2", StringType)
+          )
+        )
+
+        dropTable()
+        jdbcUpdate(s"create table $dbtable(i INT, c1 FLOAT, c2 DOUBLE)")
+
+        // insert rows
+        writeFunc(List(row1, row2, row3, row4, row5, row6), schema, None)
+        compareDataSourceSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
+    }
+  }
+
+  test("Test Convert from java.sql.Date to REAL") {
+    // failure
+    // java.sql.Date -> FLOAT
+    // java.sql.Date -> DOUBLE
+    compareTiDBAndJDBCWrite {
+      case (writeFunc, funcName) =>
+        val a: java.sql.Date = new java.sql.Date(0)
+        val row1 = Row(1, null, null)
+        val row2 = Row.apply(2, a, a)
+
+        val schema = StructType(
+          List(
+            StructField("i", IntegerType),
+            StructField("c1", DateType),
+            StructField("c2", DateType)
+          )
+        )
+
+        dropTable()
+        jdbcUpdate(s"create table $dbtable(i INT, c1 FLOAT, c2 DOUBLE)")
+
+        val caught = intercept[SparkException] {
+          // insert row1 row2
+          writeFunc(List(row1, row2), schema, None)
+        }
+        if ("jdbcWrite".equals(funcName)) {
+          assert(caught.getCause.getClass == classOf[BatchUpdateException])
+          assert(caught.getCause.getMessage.startsWith("Incorrect float value"))
+        } else if ("tidbWrite".equals(funcName)) {
+          assert(caught.getCause.getClass == classOf[TiBatchWriteException])
+          assert(
+            caught.getCause.getMessage.equals(
+              "do not support converting from class java.sql.Date to column type: RealType:TypeFloat"
+            )
+          )
+        }
+    }
+  }
+
+  // TODO: test following types
+  // java.sql.Timestamp
+  // Array[String]
+  // scala.collection.Seq
+  // scala.collection.Map
+  // org.apache.spark.sql.Row
+
+  override def afterAll(): Unit =
+    try {
+      dropTable()
+    } finally {
+      super.afterAll()
+    }
+}

--- a/core/src/test/scala/com/pingcap/tispark/convert/ToRealSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/convert/ToRealSuite.scala
@@ -228,8 +228,7 @@ class ToRealSuite extends BaseDataSourceTest("test_data_type_convert_to_real") {
     }
   }
 
-  // TODO: com.pingcap.tikv.exception.TiBatchWriteException: data -3.4028235E38 < lowerBound -3.4028235E38
-  ignore("Test Convert from String to REAL") {
+  test("Test Convert from String to REAL") {
     // success
     // String -> FLOAT
     // String -> DOUBLE

--- a/core/src/test/scala/com/pingcap/tispark/convert/ToRealSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/convert/ToRealSuite.scala
@@ -3,7 +3,7 @@ package com.pingcap.tispark.convert
 import java.sql.BatchUpdateException
 
 import com.pingcap.tikv.exception.TiBatchWriteException
-import com.pingcap.tispark.datasource.BaseDataSourceSuite
+import com.pingcap.tispark.datasource.BaseDataSourceTest
 import org.apache.spark.SparkException
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types._
@@ -13,7 +13,7 @@ import org.apache.spark.sql.types._
  * 1. FLOAT
  * 2. DOUBLE
  */
-class ToRealSuite extends BaseDataSourceSuite("test_data_type_convert_to_real") {
+class ToRealSuite extends BaseDataSourceTest("test_data_type_convert_to_real") {
 
   //  + 1.0E-40f because of this issue: https://github.com/pingcap/tidb/issues/10587
   private val minFloat: java.lang.Float = java.lang.Float.MIN_VALUE + 1.0E-40f

--- a/core/src/test/scala/com/pingcap/tispark/convert/ToSignedSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/convert/ToSignedSuite.scala
@@ -17,7 +17,7 @@ class ToSignedSuite extends BaseDataSourceTest("test_data_type_convert_to_signed
   test("Test Convert from java.lang.Boolean to SINGED") {
     // success
     // java.lang.Boolean -> {TINYINT SMALLINT MEDIUMINT INT BIGINT} SIGNED
-    compareTiDBAndJDBCWrite {
+    compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val row1 = Row(1, null, null, null, null, null)
         val row2 = Row(2, null, true, true, true, true)
@@ -44,14 +44,14 @@ class ToSignedSuite extends BaseDataSourceTest("test_data_type_convert_to_signed
 
         // insert rows
         writeFunc(List(row1, row2, row3, row4, row5, row6), schema, None)
-        compareDataSourceSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
+        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
     }
   }
 
   test("Test Convert from java.lang.Byte to SIGNED") {
     // success
     // java.lang.Byte -> {TINYINT SMALLINT MEDIUMINT INT BIGINT} SIGNED
-    compareTiDBAndJDBCWrite {
+    compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val a: java.lang.Byte = java.lang.Byte.valueOf("11")
         val b: java.lang.Byte = java.lang.Byte.MAX_VALUE
@@ -83,14 +83,14 @@ class ToSignedSuite extends BaseDataSourceTest("test_data_type_convert_to_signed
 
         // insert rows
         writeFunc(List(row1, row2, row3, row4, row5, row6), schema, None)
-        compareDataSourceSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
+        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
     }
   }
 
   test("Test Convert from java.lang.Short to SIGNED") {
     // success
     // java.lang.Short -> {TINYINT SMALLINT MEDIUMINT INT BIGINT} SIGNED
-    compareTiDBAndJDBCWrite {
+    compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val a: java.lang.Short = java.lang.Short.valueOf("11")
         val b: java.lang.Short = java.lang.Short.valueOf("-11")
@@ -125,14 +125,14 @@ class ToSignedSuite extends BaseDataSourceTest("test_data_type_convert_to_signed
 
         // insert rows
         writeFunc(List(row1, row2, row3, row4, row5, row6), schema, None)
-        compareDataSourceSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
+        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
     }
   }
 
   test("Test Convert from java.lang.Integer to SIGNED") {
     // success
     // java.lang.Integer -> {TINYINT SMALLINT MEDIUMINT INT BIGINT} SIGNED
-    compareTiDBAndJDBCWrite {
+    compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val a: java.lang.Integer = java.lang.Integer.valueOf("11")
         val b: java.lang.Integer = java.lang.Integer.valueOf("-11")
@@ -169,7 +169,7 @@ class ToSignedSuite extends BaseDataSourceTest("test_data_type_convert_to_signed
 
         // insert rows
         writeFunc(List(row1, row2, row3, row4, row5, row6), schema, None)
-        compareDataSourceSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
+        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
     }
   }
 
@@ -179,7 +179,7 @@ class ToSignedSuite extends BaseDataSourceTest("test_data_type_convert_to_signed
   ignore("Test Convert from java.lang.Long to SIGNED") {
     // success
     // java.lang.Long -> {TINYINT SMALLINT MEDIUMINT INT BIGINT} SIGNED
-    compareTiDBAndJDBCWrite {
+    compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val a: java.lang.Long = java.lang.Long.valueOf("11")
         val b: java.lang.Long = java.lang.Long.valueOf("-11")
@@ -218,14 +218,14 @@ class ToSignedSuite extends BaseDataSourceTest("test_data_type_convert_to_signed
 
         // insert rows
         writeFunc(List(row1, row2, row3, row4, row5, row6), schema, None)
-        compareDataSourceSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
+        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
     }
   }
 
   test("Test Convert from java.lang.Float to SIGNED") {
     // success
     // java.lang.Float -> {TINYINT SMALLINT MEDIUMINT INT BIGINT} SIGNED
-    compareTiDBAndJDBCWrite {
+    compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val a: java.lang.Float = java.lang.Float.valueOf("11.1")
         val b: java.lang.Float = java.lang.Float.valueOf("-11.1")
@@ -265,14 +265,14 @@ class ToSignedSuite extends BaseDataSourceTest("test_data_type_convert_to_signed
 
         // insert rows
         writeFunc(List(row1, row2, row3, row4, row5, row6), schema, None)
-        compareDataSourceSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
+        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
     }
   }
 
   test("Test Convert from java.lang.Double to SIGNED") {
     // success
     // java.lang.Double -> {TINYINT SMALLINT MEDIUMINT INT BIGINT} SIGNED
-    compareTiDBAndJDBCWrite {
+    compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val a: java.lang.Double = java.lang.Double.valueOf("11.1")
         val b: java.lang.Double = java.lang.Double.valueOf("-11.1")
@@ -309,14 +309,14 @@ class ToSignedSuite extends BaseDataSourceTest("test_data_type_convert_to_signed
 
         // insert rows
         writeFunc(List(row1, row2, row3, row4, row5, row6), schema, None)
-        compareDataSourceSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
+        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
     }
   }
 
   test("Test Convert from String to SIGNED") {
     // success
     // String -> {TINYINT SMALLINT MEDIUMINT INT BIGINT} SIGNED
-    compareTiDBAndJDBCWrite {
+    compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val a: String = "11.1"
         val b: String = "-11.1"
@@ -353,7 +353,7 @@ class ToSignedSuite extends BaseDataSourceTest("test_data_type_convert_to_signed
 
         // insert rows
         writeFunc(List(row1, row2, row3, row4, row5, row6), schema, None)
-        compareDataSourceSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
+        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
     }
   }
 

--- a/core/src/test/scala/com/pingcap/tispark/convert/ToSignedSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/convert/ToSignedSuite.scala
@@ -1,6 +1,6 @@
 package com.pingcap.tispark.convert
 
-import com.pingcap.tispark.datasource.BaseDataSourceSuite
+import com.pingcap.tispark.datasource.BaseDataSourceTest
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types._
 
@@ -12,7 +12,7 @@ import org.apache.spark.sql.types._
  * 4. INT SINGED
  * 5. BIGINT SINGED
  */
-class ToSignedSuite extends BaseDataSourceSuite("test_data_type_convert_to_signed") {
+class ToSignedSuite extends BaseDataSourceTest("test_data_type_convert_to_signed") {
 
   test("Test Convert from java.lang.Boolean to SINGED") {
     // success

--- a/core/src/test/scala/com/pingcap/tispark/convert/ToSignedSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/convert/ToSignedSuite.scala
@@ -227,8 +227,8 @@ class ToSignedSuite extends BaseDataSourceTest("test_data_type_convert_to_signed
     // java.lang.Float -> {TINYINT SMALLINT MEDIUMINT INT BIGINT} SIGNED
     compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
-        val a: java.lang.Float = java.lang.Float.valueOf("11.1")
-        val b: java.lang.Float = java.lang.Float.valueOf("-11.1")
+        val a: java.lang.Float = java.lang.Float.valueOf("11")
+        val b: java.lang.Float = java.lang.Float.valueOf("-11")
 
         val maxByte: java.lang.Float = java.lang.Byte.MAX_VALUE.toFloat
         val minByte: java.lang.Float = java.lang.Byte.MIN_VALUE.toFloat
@@ -274,8 +274,8 @@ class ToSignedSuite extends BaseDataSourceTest("test_data_type_convert_to_signed
     // java.lang.Double -> {TINYINT SMALLINT MEDIUMINT INT BIGINT} SIGNED
     compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
-        val a: java.lang.Double = java.lang.Double.valueOf("11.1")
-        val b: java.lang.Double = java.lang.Double.valueOf("-11.1")
+        val a: java.lang.Double = java.lang.Double.valueOf("11")
+        val b: java.lang.Double = java.lang.Double.valueOf("-11")
 
         val maxByte: java.lang.Double = java.lang.Byte.MAX_VALUE.toDouble
         val minByte: java.lang.Double = java.lang.Byte.MIN_VALUE.toDouble
@@ -318,8 +318,8 @@ class ToSignedSuite extends BaseDataSourceTest("test_data_type_convert_to_signed
     // String -> {TINYINT SMALLINT MEDIUMINT INT BIGINT} SIGNED
     compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
-        val a: String = "11.1"
-        val b: String = "-11.1"
+        val a: String = "11"
+        val b: String = "-11"
 
         val maxByte: String = java.lang.Byte.MAX_VALUE.toString
         val minByte: String = java.lang.Byte.MIN_VALUE.toString

--- a/core/src/test/scala/com/pingcap/tispark/convert/ToSignedSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/convert/ToSignedSuite.scala
@@ -1,0 +1,375 @@
+package com.pingcap.tispark.convert
+
+import com.pingcap.tispark.datasource.BaseDataSourceSuite
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.types._
+
+/**
+ * SINGED type include:
+ * 1. TINYINT SINGED
+ * 2. SMALLINT SINGED
+ * 3. MEDIUMINT SINGED
+ * 4. INT SINGED
+ * 5. BIGINT SINGED
+ */
+class ToSignedSuite extends BaseDataSourceSuite("test_data_type_convert_to_signed") {
+
+  test("Test Convert from java.lang.Boolean to SINGED") {
+    // success
+    // java.lang.Boolean -> {TINYINT SMALLINT MEDIUMINT INT BIGINT} SIGNED
+    compareTiDBAndJDBCWrite {
+      case (writeFunc, _) =>
+        val row1 = Row(1, null, null, null, null, null)
+        val row2 = Row(2, null, true, true, true, true)
+        val row3 = Row(3, false, null, false, false, false)
+        val row4 = Row(4, true, false, null, false, true)
+        val row5 = Row(5, true, false, false, null, true)
+        val row6 = Row(6, true, false, true, false, null)
+
+        val schema = StructType(
+          List(
+            StructField("i", IntegerType),
+            StructField("c1", BooleanType),
+            StructField("c2", BooleanType),
+            StructField("c3", BooleanType),
+            StructField("c4", BooleanType),
+            StructField("c5", BooleanType)
+          )
+        )
+
+        dropTable()
+        jdbcUpdate(
+          s"create table $dbtable(i INT, c1 TINYINT, c2 SMALLINT, c3 MEDIUMINT, c4 INT, c5 BIGINT)"
+        )
+
+        // insert rows
+        writeFunc(List(row1, row2, row3, row4, row5, row6), schema, None)
+        compareDataSourceSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
+    }
+  }
+
+  test("Test Convert from java.lang.Byte to SIGNED") {
+    // success
+    // java.lang.Byte -> {TINYINT SMALLINT MEDIUMINT INT BIGINT} SIGNED
+    compareTiDBAndJDBCWrite {
+      case (writeFunc, _) =>
+        val a: java.lang.Byte = java.lang.Byte.valueOf("11")
+        val b: java.lang.Byte = java.lang.Byte.MAX_VALUE
+        val c: java.lang.Byte = java.lang.Byte.valueOf("-11")
+        val d: java.lang.Byte = java.lang.Byte.MIN_VALUE
+
+        val row1 = Row(1, null, null, null, null, null)
+        val row2 = Row(2, null, a, b, c, d)
+        val row3 = Row(3, b, null, d, a, a)
+        val row4 = Row(4, c, c, null, a, d)
+        val row5 = Row(5, b, b, b, null, a)
+        val row6 = Row(6, c, c, a, d, null)
+
+        val schema = StructType(
+          List(
+            StructField("i", IntegerType),
+            StructField("c1", ByteType),
+            StructField("c2", ByteType),
+            StructField("c3", ByteType),
+            StructField("c4", ByteType),
+            StructField("c5", ByteType)
+          )
+        )
+
+        dropTable()
+        jdbcUpdate(
+          s"create table $dbtable(i INT, c1 TINYINT, c2 SMALLINT, c3 MEDIUMINT, c4 INT, c5 BIGINT)"
+        )
+
+        // insert rows
+        writeFunc(List(row1, row2, row3, row4, row5, row6), schema, None)
+        compareDataSourceSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
+    }
+  }
+
+  test("Test Convert from java.lang.Short to SIGNED") {
+    // success
+    // java.lang.Short -> {TINYINT SMALLINT MEDIUMINT INT BIGINT} SIGNED
+    compareTiDBAndJDBCWrite {
+      case (writeFunc, _) =>
+        val a: java.lang.Short = java.lang.Short.valueOf("11")
+        val b: java.lang.Short = java.lang.Short.valueOf("-11")
+
+        val maxByte: java.lang.Short = java.lang.Byte.MAX_VALUE.toShort
+        val minByte: java.lang.Short = java.lang.Byte.MIN_VALUE.toShort
+        val maxShort: java.lang.Short = java.lang.Short.MAX_VALUE
+        val minShort: java.lang.Short = java.lang.Short.MIN_VALUE
+
+        val row1 = Row(1, null, null, null, null, null)
+        val row2 = Row(2, maxByte, maxShort, maxShort, maxShort, maxShort)
+        val row3 = Row(3, minByte, minShort, minShort, minShort, minShort)
+        val row4 = Row(4, null, b, null, a, a)
+        val row5 = Row(5, b, b, b, a, a)
+        val row6 = Row(6, b, b, null, a, null)
+
+        val schema = StructType(
+          List(
+            StructField("i", IntegerType),
+            StructField("c1", ShortType),
+            StructField("c2", ShortType),
+            StructField("c3", ShortType),
+            StructField("c4", ShortType),
+            StructField("c5", ShortType)
+          )
+        )
+
+        dropTable()
+        jdbcUpdate(
+          s"create table $dbtable(i INT, c1 TINYINT, c2 SMALLINT, c3 MEDIUMINT, c4 INT, c5 BIGINT)"
+        )
+
+        // insert rows
+        writeFunc(List(row1, row2, row3, row4, row5, row6), schema, None)
+        compareDataSourceSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
+    }
+  }
+
+  test("Test Convert from java.lang.Integer to SIGNED") {
+    // success
+    // java.lang.Integer -> {TINYINT SMALLINT MEDIUMINT INT BIGINT} SIGNED
+    compareTiDBAndJDBCWrite {
+      case (writeFunc, _) =>
+        val a: java.lang.Integer = java.lang.Integer.valueOf("11")
+        val b: java.lang.Integer = java.lang.Integer.valueOf("-11")
+
+        val maxByte: java.lang.Integer = java.lang.Byte.MAX_VALUE.toInt
+        val minByte: java.lang.Integer = java.lang.Byte.MIN_VALUE.toInt
+        val maxShort: java.lang.Integer = java.lang.Short.MAX_VALUE.toInt
+        val minShort: java.lang.Integer = java.lang.Short.MIN_VALUE.toInt
+        val maxInteger: java.lang.Integer = java.lang.Integer.MAX_VALUE
+        val minInteger: java.lang.Integer = java.lang.Integer.MIN_VALUE
+
+        val row1 = Row(1, null, null, null, null, null)
+        val row2 = Row(2, maxByte, maxShort, maxShort, maxInteger, maxInteger)
+        val row3 = Row(3, minByte, minShort, minShort, minInteger, minInteger)
+        val row4 = Row(4, null, b, null, a, a)
+        val row5 = Row(5, b, b, b, a, a)
+        val row6 = Row(6, b, b, null, a, null)
+
+        val schema = StructType(
+          List(
+            StructField("i", IntegerType),
+            StructField("c1", IntegerType),
+            StructField("c2", IntegerType),
+            StructField("c3", IntegerType),
+            StructField("c4", IntegerType),
+            StructField("c5", IntegerType)
+          )
+        )
+
+        dropTable()
+        jdbcUpdate(
+          s"create table $dbtable(i INT, c1 TINYINT, c2 SMALLINT, c3 MEDIUMINT, c4 INT, c5 BIGINT)"
+        )
+
+        // insert rows
+        writeFunc(List(row1, row2, row3, row4, row5, row6), schema, None)
+        compareDataSourceSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
+    }
+  }
+
+  // TODO: ignore because of this issue
+  // https://github.com/pingcap/tispark/issues/759
+  // cannot read when insert Long.MAX to BIGINT
+  ignore("Test Convert from java.lang.Long to SIGNED") {
+    // success
+    // java.lang.Long -> {TINYINT SMALLINT MEDIUMINT INT BIGINT} SIGNED
+    compareTiDBAndJDBCWrite {
+      case (writeFunc, _) =>
+        val a: java.lang.Long = java.lang.Long.valueOf("11")
+        val b: java.lang.Long = java.lang.Long.valueOf("-11")
+
+        val maxByte: java.lang.Long = java.lang.Byte.MAX_VALUE.toLong
+        val minByte: java.lang.Long = java.lang.Byte.MIN_VALUE.toLong
+        val maxShort: java.lang.Long = java.lang.Short.MAX_VALUE.toLong
+        val minShort: java.lang.Long = java.lang.Short.MIN_VALUE.toLong
+        val maxInteger: java.lang.Long = java.lang.Integer.MAX_VALUE.toLong
+        val minInteger: java.lang.Long = java.lang.Integer.MIN_VALUE.toLong
+        val maxLong: java.lang.Long = java.lang.Long.MAX_VALUE
+        val minLong: java.lang.Long = java.lang.Long.MIN_VALUE
+
+        val row1 = Row(1, null, null, null, null, null)
+        val row2 = Row(2, maxByte, maxShort, maxShort, maxInteger, maxLong)
+        val row3 = Row(3, minByte, minShort, minShort, minInteger, minLong)
+        val row4 = Row(4, null, b, null, a, a)
+        val row5 = Row(5, b, b, b, a, a)
+        val row6 = Row(6, b, b, null, a, null)
+
+        val schema = StructType(
+          List(
+            StructField("i", IntegerType),
+            StructField("c1", LongType),
+            StructField("c2", LongType),
+            StructField("c3", LongType),
+            StructField("c4", LongType),
+            StructField("c5", LongType)
+          )
+        )
+
+        dropTable()
+        jdbcUpdate(
+          s"create table $dbtable(i INT, c1 TINYINT, c2 SMALLINT, c3 MEDIUMINT, c4 INT, c5 BIGINT)"
+        )
+
+        // insert rows
+        writeFunc(List(row1, row2, row3, row4, row5, row6), schema, None)
+        compareDataSourceSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
+    }
+  }
+
+  test("Test Convert from java.lang.Float to SIGNED") {
+    // success
+    // java.lang.Float -> {TINYINT SMALLINT MEDIUMINT INT BIGINT} SIGNED
+    compareTiDBAndJDBCWrite {
+      case (writeFunc, _) =>
+        val a: java.lang.Float = java.lang.Float.valueOf("11.1")
+        val b: java.lang.Float = java.lang.Float.valueOf("-11.1")
+
+        val maxByte: java.lang.Float = java.lang.Byte.MAX_VALUE.toFloat
+        val minByte: java.lang.Float = java.lang.Byte.MIN_VALUE.toFloat
+        val maxShort: java.lang.Float = java.lang.Short.MAX_VALUE.toFloat
+        val minShort: java.lang.Float = java.lang.Short.MIN_VALUE.toFloat
+
+        // `-100` & `+100` because of
+        // com.mysql.jdbc.MysqlDataTruncation: Data truncation: Out of range value for column 'c4' at row 1
+        val maxInteger: java.lang.Float = java.lang.Integer.MAX_VALUE.toFloat - 100
+        val minInteger: java.lang.Float = java.lang.Integer.MIN_VALUE.toFloat + 100
+
+        val row1 = Row(1, null, null, null, null, null)
+        val row2 = Row(2, maxByte, maxShort, maxShort, maxInteger, maxInteger)
+        val row3 = Row(3, minByte, minShort, minShort, minInteger, minInteger)
+        val row4 = Row(4, null, b, null, a, a)
+        val row5 = Row(5, b, b, b, a, a)
+        val row6 = Row(6, b, b, null, a, null)
+
+        val schema = StructType(
+          List(
+            StructField("i", IntegerType),
+            StructField("c1", FloatType),
+            StructField("c2", FloatType),
+            StructField("c3", FloatType),
+            StructField("c4", FloatType),
+            StructField("c5", FloatType)
+          )
+        )
+
+        dropTable()
+        jdbcUpdate(
+          s"create table $dbtable(i INT, c1 TINYINT, c2 SMALLINT, c3 MEDIUMINT, c4 INT, c5 BIGINT)"
+        )
+
+        // insert rows
+        writeFunc(List(row1, row2, row3, row4, row5, row6), schema, None)
+        compareDataSourceSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
+    }
+  }
+
+  test("Test Convert from java.lang.Double to SIGNED") {
+    // success
+    // java.lang.Double -> {TINYINT SMALLINT MEDIUMINT INT BIGINT} SIGNED
+    compareTiDBAndJDBCWrite {
+      case (writeFunc, _) =>
+        val a: java.lang.Double = java.lang.Double.valueOf("11.1")
+        val b: java.lang.Double = java.lang.Double.valueOf("-11.1")
+
+        val maxByte: java.lang.Double = java.lang.Byte.MAX_VALUE.toDouble
+        val minByte: java.lang.Double = java.lang.Byte.MIN_VALUE.toDouble
+        val maxShort: java.lang.Double = java.lang.Short.MAX_VALUE.toDouble
+        val minShort: java.lang.Double = java.lang.Short.MIN_VALUE.toDouble
+        val maxInteger: java.lang.Double = java.lang.Integer.MAX_VALUE.toDouble
+        val minInteger: java.lang.Double = java.lang.Integer.MIN_VALUE.toDouble
+
+        val row1 = Row(1, null, null, null, null, null)
+        val row2 = Row(2, maxByte, maxShort, maxShort, maxInteger, maxInteger)
+        val row3 = Row(3, minByte, minShort, minShort, minInteger, minInteger)
+        val row4 = Row(4, null, b, null, a, a)
+        val row5 = Row(5, b, b, b, a, a)
+        val row6 = Row(6, b, b, null, a, null)
+
+        val schema = StructType(
+          List(
+            StructField("i", IntegerType),
+            StructField("c1", DoubleType),
+            StructField("c2", DoubleType),
+            StructField("c3", DoubleType),
+            StructField("c4", DoubleType),
+            StructField("c5", DoubleType)
+          )
+        )
+
+        dropTable()
+        jdbcUpdate(
+          s"create table $dbtable(i INT, c1 TINYINT, c2 SMALLINT, c3 MEDIUMINT, c4 INT, c5 BIGINT)"
+        )
+
+        // insert rows
+        writeFunc(List(row1, row2, row3, row4, row5, row6), schema, None)
+        compareDataSourceSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
+    }
+  }
+
+  test("Test Convert from String to SIGNED") {
+    // success
+    // String -> {TINYINT SMALLINT MEDIUMINT INT BIGINT} SIGNED
+    compareTiDBAndJDBCWrite {
+      case (writeFunc, _) =>
+        val a: String = "11.1"
+        val b: String = "-11.1"
+
+        val maxByte: String = java.lang.Byte.MAX_VALUE.toString
+        val minByte: String = java.lang.Byte.MIN_VALUE.toString
+        val maxShort: String = java.lang.Short.MAX_VALUE.toString
+        val minShort: String = java.lang.Short.MIN_VALUE.toString
+        val maxInteger: String = java.lang.Integer.MAX_VALUE.toString
+        val minInteger: String = java.lang.Integer.MIN_VALUE.toString
+
+        val row1 = Row(1, null, null, null, null, null)
+        val row2 = Row(2, maxByte, maxShort, maxShort, maxInteger, maxInteger)
+        val row3 = Row(3, minByte, minShort, minShort, minInteger, minInteger)
+        val row4 = Row(4, null, b, null, a, a)
+        val row5 = Row(5, b, b, b, a, a)
+        val row6 = Row(6, b, b, null, a, null)
+
+        val schema = StructType(
+          List(
+            StructField("i", IntegerType),
+            StructField("c1", StringType),
+            StructField("c2", StringType),
+            StructField("c3", StringType),
+            StructField("c4", StringType),
+            StructField("c5", StringType)
+          )
+        )
+
+        dropTable()
+        jdbcUpdate(
+          s"create table $dbtable(i INT, c1 TINYINT, c2 SMALLINT, c3 MEDIUMINT, c4 INT, c5 BIGINT)"
+        )
+
+        // insert rows
+        writeFunc(List(row1, row2, row3, row4, row5, row6), schema, None)
+        compareDataSourceSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
+    }
+  }
+
+  // TODO: test following types
+  // java.math.BigDecimal
+  // java.sql.Date
+  // java.sql.Timestamp
+  // Array[String]
+  // scala.collection.Seq
+  // scala.collection.Map
+  // org.apache.spark.sql.Row
+
+  override def afterAll(): Unit =
+    try {
+      //dropTable()
+    } finally {
+      super.afterAll()
+    }
+}

--- a/core/src/test/scala/com/pingcap/tispark/convert/ToUnsignedSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/convert/ToUnsignedSuite.scala
@@ -305,8 +305,8 @@ class ToUnsignedSuite extends BaseDataSourceTest("test_data_type_convert_to_unsi
     // String -> {TINYINT SMALLINT MEDIUMINT INT BIGINT} UNSIGNED
     compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
-        val a: String = "11.1"
-        val b: String = "22.2"
+        val a: String = "11"
+        val b: String = "22"
         val zero: String = "0"
 
         val maxByte: String = java.lang.Byte.MAX_VALUE.toString

--- a/core/src/test/scala/com/pingcap/tispark/convert/ToUnsignedSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/convert/ToUnsignedSuite.scala
@@ -1,0 +1,360 @@
+package com.pingcap.tispark.convert
+
+import com.pingcap.tispark.datasource.BaseDataSourceSuite
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.types._
+
+/**
+ * UNSINGED type include:
+ * 1. TINYINT UNSINGED
+ * 2. SMALLINT UNSINGED
+ * 3. MEDIUMINT UNSINGED
+ * 4. INT UNSINGED
+ * 5. BIGINT UNSINGED
+ */
+class ToUnsignedSuite extends BaseDataSourceSuite("test_data_type_convert_to_unsigned") {
+
+  test("Test Convert from java.lang.Boolean to UNSINGED") {
+    // success
+    // java.lang.Boolean -> {TINYINT SMALLINT MEDIUMINT INT BIGINT} UNSIGNED
+    compareTiDBAndJDBCWrite {
+      case (writeFunc, _) =>
+        val row1 = Row(1, null, null, null, null, null)
+        val row2 = Row(2, null, true, true, true, true)
+        val row3 = Row(3, false, null, false, false, false)
+        val row4 = Row(4, true, false, null, false, true)
+        val row5 = Row(5, true, false, false, null, true)
+        val row6 = Row(6, true, false, true, false, null)
+
+        val schema = StructType(
+          List(
+            StructField("i", IntegerType),
+            StructField("c1", BooleanType),
+            StructField("c2", BooleanType),
+            StructField("c3", BooleanType),
+            StructField("c4", BooleanType),
+            StructField("c5", BooleanType)
+          )
+        )
+
+        dropTable()
+        jdbcUpdate(
+          s"create table $dbtable(i INT, c1 TINYINT UNSIGNED, c2 SMALLINT UNSIGNED, c3 MEDIUMINT UNSIGNED, c4 INT UNSIGNED, c5 BIGINT UNSIGNED)"
+        )
+
+        // insert rows
+        writeFunc(List(row1, row2, row3, row4, row5, row6), schema, None)
+        compareDataSourceSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
+    }
+  }
+
+  test("Test Convert from java.lang.Byte to UNSIGNED") {
+    // success
+    // java.lang.Byte -> {TINYINT SMALLINT MEDIUMINT INT BIGINT} UNSIGNED
+    compareTiDBAndJDBCWrite {
+      case (writeFunc, _) =>
+        val a: java.lang.Byte = java.lang.Byte.valueOf("11")
+        val b: java.lang.Byte = java.lang.Byte.MAX_VALUE
+        val c: java.lang.Byte = java.lang.Byte.valueOf("22")
+        val d: java.lang.Byte = java.lang.Byte.valueOf("0")
+
+        val row1 = Row(1, null, null, null, null, null)
+        val row2 = Row(2, null, a, b, c, d)
+        val row3 = Row(3, b, null, d, a, a)
+        val row4 = Row(4, c, c, null, a, d)
+        val row5 = Row(5, b, b, b, null, a)
+        val row6 = Row(6, c, c, a, d, null)
+
+        val schema = StructType(
+          List(
+            StructField("i", IntegerType),
+            StructField("c1", ByteType),
+            StructField("c2", ByteType),
+            StructField("c3", ByteType),
+            StructField("c4", ByteType),
+            StructField("c5", ByteType)
+          )
+        )
+
+        dropTable()
+        jdbcUpdate(
+          s"create table $dbtable(i INT, c1 TINYINT UNSIGNED, c2 SMALLINT UNSIGNED, c3 MEDIUMINT UNSIGNED, c4 INT UNSIGNED, c5 BIGINT UNSIGNED)"
+        )
+
+        // insert rows
+        writeFunc(List(row1, row2, row3, row4, row5, row6), schema, None)
+        compareDataSourceSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
+    }
+  }
+
+  test("Test Convert from java.lang.Short to UNSIGNED") {
+    // success
+    // java.lang.Short -> {TINYINT SMALLINT MEDIUMINT INT BIGINT} UNSIGNED
+    compareTiDBAndJDBCWrite {
+      case (writeFunc, _) =>
+        val a: java.lang.Short = java.lang.Short.valueOf("11")
+        val b: java.lang.Short = java.lang.Short.valueOf("22")
+        val zero: java.lang.Short = java.lang.Short.valueOf("0")
+
+        val maxByte: java.lang.Short = java.lang.Byte.MAX_VALUE.toShort
+        val maxShort: java.lang.Short = java.lang.Short.MAX_VALUE
+
+        val row1 = Row(1, null, null, null, null, null)
+        val row2 = Row(2, maxByte, maxShort, maxShort, maxShort, maxShort)
+        val row3 = Row(3, zero, zero, zero, zero, zero)
+        val row4 = Row(4, null, b, null, a, a)
+        val row5 = Row(5, b, b, b, a, a)
+        val row6 = Row(6, b, b, null, a, null)
+
+        val schema = StructType(
+          List(
+            StructField("i", IntegerType),
+            StructField("c1", ShortType),
+            StructField("c2", ShortType),
+            StructField("c3", ShortType),
+            StructField("c4", ShortType),
+            StructField("c5", ShortType)
+          )
+        )
+
+        dropTable()
+        jdbcUpdate(
+          s"create table $dbtable(i INT, c1 TINYINT UNSIGNED, c2 SMALLINT UNSIGNED, c3 MEDIUMINT UNSIGNED, c4 INT UNSIGNED, c5 BIGINT UNSIGNED)"
+        )
+
+        // insert rows
+        writeFunc(List(row1, row2, row3, row4, row5, row6), schema, None)
+        compareDataSourceSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
+    }
+  }
+
+  test("Test Convert from java.lang.Integer to UNSIGNED") {
+    // success
+    // java.lang.Integer -> {TINYINT SMALLINT MEDIUMINT INT BIGINT} UNSIGNED
+    compareTiDBAndJDBCWrite {
+      case (writeFunc, _) =>
+        val a: java.lang.Integer = java.lang.Integer.valueOf("11")
+        val b: java.lang.Integer = java.lang.Integer.valueOf("22")
+        val zero: java.lang.Integer = java.lang.Integer.valueOf("0")
+
+        val maxByte: java.lang.Integer = java.lang.Byte.MAX_VALUE.toInt
+        val maxShort: java.lang.Integer = java.lang.Short.MAX_VALUE.toInt
+        val maxInteger: java.lang.Integer = java.lang.Integer.MAX_VALUE
+
+        val row1 = Row(1, null, null, null, null, null)
+        val row2 = Row(2, maxByte, maxShort, maxShort, maxInteger, maxInteger)
+        val row3 = Row(3, zero, zero, zero, zero, zero)
+        val row4 = Row(4, null, b, null, a, a)
+        val row5 = Row(5, b, b, b, a, a)
+        val row6 = Row(6, b, b, null, a, null)
+
+        val schema = StructType(
+          List(
+            StructField("i", IntegerType),
+            StructField("c1", IntegerType),
+            StructField("c2", IntegerType),
+            StructField("c3", IntegerType),
+            StructField("c4", IntegerType),
+            StructField("c5", IntegerType)
+          )
+        )
+
+        dropTable()
+        jdbcUpdate(
+          s"create table $dbtable(i INT, c1 TINYINT UNSIGNED, c2 SMALLINT UNSIGNED, c3 MEDIUMINT UNSIGNED, c4 INT UNSIGNED, c5 BIGINT UNSIGNED)"
+        )
+
+        // insert rows
+        writeFunc(List(row1, row2, row3, row4, row5, row6), schema, None)
+        compareDataSourceSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
+    }
+  }
+
+  test("Test Convert from java.lang.Long to UNSIGNED") {
+    // success
+    // java.lang.Long -> {TINYINT SMALLINT MEDIUMINT INT BIGINT} UNSIGNED
+    compareTiDBAndJDBCWrite {
+      case (writeFunc, _) =>
+        val a: java.lang.Long = java.lang.Long.valueOf("11")
+        val b: java.lang.Long = java.lang.Long.valueOf("22")
+        val zero: java.lang.Long = java.lang.Long.valueOf("0")
+
+        val maxByte: java.lang.Long = java.lang.Byte.MAX_VALUE.toLong
+        val maxShort: java.lang.Long = java.lang.Short.MAX_VALUE.toLong
+        val maxInteger: java.lang.Long = java.lang.Integer.MAX_VALUE.toLong
+        val maxLong: java.lang.Long = java.lang.Long.MAX_VALUE
+
+        val row1 = Row(1, null, null, null, null, null)
+        val row2 = Row(2, maxByte, maxShort, maxShort, maxInteger, maxLong)
+        val row3 = Row(3, zero, zero, zero, zero, zero)
+        val row4 = Row(4, null, b, null, a, a)
+        val row5 = Row(5, b, b, b, a, a)
+        val row6 = Row(6, b, b, null, a, null)
+
+        val schema = StructType(
+          List(
+            StructField("i", IntegerType),
+            StructField("c1", LongType),
+            StructField("c2", LongType),
+            StructField("c3", LongType),
+            StructField("c4", LongType),
+            StructField("c5", LongType)
+          )
+        )
+
+        dropTable()
+        jdbcUpdate(
+          s"create table $dbtable(i INT, c1 TINYINT UNSIGNED, c2 SMALLINT UNSIGNED, c3 MEDIUMINT UNSIGNED, c4 INT UNSIGNED, c5 BIGINT UNSIGNED)"
+        )
+
+        // insert rows
+        writeFunc(List(row1, row2, row3, row4, row5, row6), schema, None)
+        compareDataSourceSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
+    }
+  }
+
+  test("Test Convert from java.lang.Float to UNSIGNED") {
+    // success
+    // java.lang.Float -> {TINYINT SMALLINT MEDIUMINT INT BIGINT} UNSIGNED
+    compareTiDBAndJDBCWrite {
+      case (writeFunc, _) =>
+        val a: java.lang.Float = java.lang.Float.valueOf("11.1")
+        val b: java.lang.Float = java.lang.Float.valueOf("22.2")
+        val zero: java.lang.Float = java.lang.Float.valueOf("0")
+
+        val maxByte: java.lang.Float = java.lang.Byte.MAX_VALUE.toFloat
+        val maxShort: java.lang.Float = java.lang.Short.MAX_VALUE.toFloat
+
+        // `-100` because of
+        // com.mysql.jdbc.MysqlDataTruncation: Data truncation: Out of range value for column 'c4' at row 1
+        val maxInteger: java.lang.Float = java.lang.Integer.MAX_VALUE.toFloat - 100
+
+        val row1 = Row(1, null, null, null, null, null)
+        val row2 = Row(2, maxByte, maxShort, maxShort, maxInteger, maxInteger)
+        val row3 = Row(3, zero, zero, zero, zero, zero)
+        val row4 = Row(4, null, b, null, a, a)
+        val row5 = Row(5, b, b, b, a, a)
+        val row6 = Row(6, b, b, null, a, null)
+
+        val schema = StructType(
+          List(
+            StructField("i", IntegerType),
+            StructField("c1", FloatType),
+            StructField("c2", FloatType),
+            StructField("c3", FloatType),
+            StructField("c4", FloatType),
+            StructField("c5", FloatType)
+          )
+        )
+
+        dropTable()
+        jdbcUpdate(
+          s"create table $dbtable(i INT, c1 TINYINT UNSIGNED, c2 SMALLINT UNSIGNED, c3 MEDIUMINT UNSIGNED, c4 INT UNSIGNED, c5 BIGINT UNSIGNED)"
+        )
+
+        // insert rows
+        writeFunc(List(row1, row2, row3, row4, row5, row6), schema, None)
+        compareDataSourceSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
+    }
+  }
+
+  test("Test Convert from java.lang.Double to UNSIGNED") {
+    // success
+    // java.lang.Double -> {TINYINT SMALLINT MEDIUMINT INT BIGINT} UNSIGNED
+    compareTiDBAndJDBCWrite {
+      case (writeFunc, _) =>
+        val a: java.lang.Double = java.lang.Double.valueOf("11.1")
+        val b: java.lang.Double = java.lang.Double.valueOf("22.2")
+        val zero: java.lang.Double = java.lang.Double.valueOf("0")
+
+        val maxByte: java.lang.Double = java.lang.Byte.MAX_VALUE.toDouble
+        val maxShort: java.lang.Double = java.lang.Short.MAX_VALUE.toDouble
+        val maxInteger: java.lang.Double = java.lang.Integer.MAX_VALUE.toDouble
+
+        val row1 = Row(1, null, null, null, null, null)
+        val row2 = Row(2, maxByte, maxShort, maxShort, maxInteger, maxInteger)
+        val row3 = Row(3, zero, zero, zero, zero, zero)
+        val row4 = Row(4, null, b, null, a, a)
+        val row5 = Row(5, b, b, b, a, a)
+        val row6 = Row(6, b, b, null, a, null)
+
+        val schema = StructType(
+          List(
+            StructField("i", IntegerType),
+            StructField("c1", DoubleType),
+            StructField("c2", DoubleType),
+            StructField("c3", DoubleType),
+            StructField("c4", DoubleType),
+            StructField("c5", DoubleType)
+          )
+        )
+
+        dropTable()
+        jdbcUpdate(
+          s"create table $dbtable(i INT, c1 TINYINT UNSIGNED, c2 SMALLINT UNSIGNED, c3 MEDIUMINT UNSIGNED, c4 INT UNSIGNED, c5 BIGINT UNSIGNED)"
+        )
+
+        // insert rows
+        writeFunc(List(row1, row2, row3, row4, row5, row6), schema, None)
+        compareDataSourceSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
+    }
+  }
+
+  test("Test Convert from String to UNSIGNED") {
+    // success
+    // String -> {TINYINT SMALLINT MEDIUMINT INT BIGINT} UNSIGNED
+    compareTiDBAndJDBCWrite {
+      case (writeFunc, _) =>
+        val a: String = "11.1"
+        val b: String = "22.2"
+        val zero: String = "0"
+
+        val maxByte: String = java.lang.Byte.MAX_VALUE.toString
+        val maxShort: String = java.lang.Short.MAX_VALUE.toString
+        val maxInteger: String = java.lang.Integer.MAX_VALUE.toString
+
+        val row1 = Row(1, null, null, null, null, null)
+        val row2 = Row(2, maxByte, maxShort, maxShort, maxInteger, maxInteger)
+        val row3 = Row(3, zero, zero, zero, zero, zero)
+        val row4 = Row(4, null, b, null, a, a)
+        val row5 = Row(5, b, b, b, a, a)
+        val row6 = Row(6, b, b, null, a, null)
+
+        val schema = StructType(
+          List(
+            StructField("i", IntegerType),
+            StructField("c1", StringType),
+            StructField("c2", StringType),
+            StructField("c3", StringType),
+            StructField("c4", StringType),
+            StructField("c5", StringType)
+          )
+        )
+
+        dropTable()
+        jdbcUpdate(
+          s"create table $dbtable(i INT, c1 TINYINT UNSIGNED, c2 SMALLINT UNSIGNED, c3 MEDIUMINT UNSIGNED, c4 INT UNSIGNED, c5 BIGINT UNSIGNED)"
+        )
+
+        // insert rows
+        writeFunc(List(row1, row2, row3, row4, row5, row6), schema, None)
+        compareDataSourceSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
+    }
+  }
+
+  // TODO: test following types
+  // java.math.BigDecimal
+  // java.sql.Date
+  // java.sql.Timestamp
+  // Array[String]
+  // scala.collection.Seq
+  // scala.collection.Map
+  // org.apache.spark.sql.Row
+
+  override def afterAll(): Unit =
+    try {
+      //dropTable()
+    } finally {
+      super.afterAll()
+    }
+}

--- a/core/src/test/scala/com/pingcap/tispark/convert/ToUnsignedSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/convert/ToUnsignedSuite.scala
@@ -17,7 +17,7 @@ class ToUnsignedSuite extends BaseDataSourceTest("test_data_type_convert_to_unsi
   test("Test Convert from java.lang.Boolean to UNSINGED") {
     // success
     // java.lang.Boolean -> {TINYINT SMALLINT MEDIUMINT INT BIGINT} UNSIGNED
-    compareTiDBAndJDBCWrite {
+    compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val row1 = Row(1, null, null, null, null, null)
         val row2 = Row(2, null, true, true, true, true)
@@ -44,14 +44,14 @@ class ToUnsignedSuite extends BaseDataSourceTest("test_data_type_convert_to_unsi
 
         // insert rows
         writeFunc(List(row1, row2, row3, row4, row5, row6), schema, None)
-        compareDataSourceSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
+        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
     }
   }
 
   test("Test Convert from java.lang.Byte to UNSIGNED") {
     // success
     // java.lang.Byte -> {TINYINT SMALLINT MEDIUMINT INT BIGINT} UNSIGNED
-    compareTiDBAndJDBCWrite {
+    compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val a: java.lang.Byte = java.lang.Byte.valueOf("11")
         val b: java.lang.Byte = java.lang.Byte.MAX_VALUE
@@ -83,14 +83,14 @@ class ToUnsignedSuite extends BaseDataSourceTest("test_data_type_convert_to_unsi
 
         // insert rows
         writeFunc(List(row1, row2, row3, row4, row5, row6), schema, None)
-        compareDataSourceSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
+        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
     }
   }
 
   test("Test Convert from java.lang.Short to UNSIGNED") {
     // success
     // java.lang.Short -> {TINYINT SMALLINT MEDIUMINT INT BIGINT} UNSIGNED
-    compareTiDBAndJDBCWrite {
+    compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val a: java.lang.Short = java.lang.Short.valueOf("11")
         val b: java.lang.Short = java.lang.Short.valueOf("22")
@@ -124,14 +124,14 @@ class ToUnsignedSuite extends BaseDataSourceTest("test_data_type_convert_to_unsi
 
         // insert rows
         writeFunc(List(row1, row2, row3, row4, row5, row6), schema, None)
-        compareDataSourceSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
+        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
     }
   }
 
   test("Test Convert from java.lang.Integer to UNSIGNED") {
     // success
     // java.lang.Integer -> {TINYINT SMALLINT MEDIUMINT INT BIGINT} UNSIGNED
-    compareTiDBAndJDBCWrite {
+    compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val a: java.lang.Integer = java.lang.Integer.valueOf("11")
         val b: java.lang.Integer = java.lang.Integer.valueOf("22")
@@ -166,14 +166,14 @@ class ToUnsignedSuite extends BaseDataSourceTest("test_data_type_convert_to_unsi
 
         // insert rows
         writeFunc(List(row1, row2, row3, row4, row5, row6), schema, None)
-        compareDataSourceSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
+        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
     }
   }
 
   test("Test Convert from java.lang.Long to UNSIGNED") {
     // success
     // java.lang.Long -> {TINYINT SMALLINT MEDIUMINT INT BIGINT} UNSIGNED
-    compareTiDBAndJDBCWrite {
+    compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val a: java.lang.Long = java.lang.Long.valueOf("11")
         val b: java.lang.Long = java.lang.Long.valueOf("22")
@@ -209,14 +209,14 @@ class ToUnsignedSuite extends BaseDataSourceTest("test_data_type_convert_to_unsi
 
         // insert rows
         writeFunc(List(row1, row2, row3, row4, row5, row6), schema, None)
-        compareDataSourceSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
+        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
     }
   }
 
   test("Test Convert from java.lang.Float to UNSIGNED") {
     // success
     // java.lang.Float -> {TINYINT SMALLINT MEDIUMINT INT BIGINT} UNSIGNED
-    compareTiDBAndJDBCWrite {
+    compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val a: java.lang.Float = java.lang.Float.valueOf("11.1")
         val b: java.lang.Float = java.lang.Float.valueOf("22.2")
@@ -254,14 +254,14 @@ class ToUnsignedSuite extends BaseDataSourceTest("test_data_type_convert_to_unsi
 
         // insert rows
         writeFunc(List(row1, row2, row3, row4, row5, row6), schema, None)
-        compareDataSourceSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
+        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
     }
   }
 
   test("Test Convert from java.lang.Double to UNSIGNED") {
     // success
     // java.lang.Double -> {TINYINT SMALLINT MEDIUMINT INT BIGINT} UNSIGNED
-    compareTiDBAndJDBCWrite {
+    compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val a: java.lang.Double = java.lang.Double.valueOf("11.1")
         val b: java.lang.Double = java.lang.Double.valueOf("22.2")
@@ -296,14 +296,14 @@ class ToUnsignedSuite extends BaseDataSourceTest("test_data_type_convert_to_unsi
 
         // insert rows
         writeFunc(List(row1, row2, row3, row4, row5, row6), schema, None)
-        compareDataSourceSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
+        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
     }
   }
 
   test("Test Convert from String to UNSIGNED") {
     // success
     // String -> {TINYINT SMALLINT MEDIUMINT INT BIGINT} UNSIGNED
-    compareTiDBAndJDBCWrite {
+    compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val a: String = "11.1"
         val b: String = "22.2"
@@ -338,7 +338,7 @@ class ToUnsignedSuite extends BaseDataSourceTest("test_data_type_convert_to_unsi
 
         // insert rows
         writeFunc(List(row1, row2, row3, row4, row5, row6), schema, None)
-        compareDataSourceSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
+        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
     }
   }
 

--- a/core/src/test/scala/com/pingcap/tispark/convert/ToUnsignedSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/convert/ToUnsignedSuite.scala
@@ -1,6 +1,6 @@
 package com.pingcap.tispark.convert
 
-import com.pingcap.tispark.datasource.BaseDataSourceSuite
+import com.pingcap.tispark.datasource.BaseDataSourceTest
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types._
 
@@ -12,7 +12,7 @@ import org.apache.spark.sql.types._
  * 4. INT UNSINGED
  * 5. BIGINT UNSINGED
  */
-class ToUnsignedSuite extends BaseDataSourceSuite("test_data_type_convert_to_unsigned") {
+class ToUnsignedSuite extends BaseDataSourceTest("test_data_type_convert_to_unsigned") {
 
   test("Test Convert from java.lang.Boolean to UNSINGED") {
     // success

--- a/core/src/test/scala/com/pingcap/tispark/datasource/BaseDataSourceTest.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/BaseDataSourceTest.scala
@@ -4,8 +4,10 @@ import java.sql.Statement
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.test.SharedSQLContext
-import org.apache.spark.sql.types.StructType
-import org.apache.spark.sql.{QueryTest, Row}
+import org.apache.spark.sql.types.{StructField, StructType}
+import org.apache.spark.sql.{DataFrame, QueryTest, Row}
+
+import scala.collection.mutable.ArrayBuffer
 
 // Tow modes:
 // 1. without TiExtensions:
@@ -36,9 +38,9 @@ class BaseDataSourceTest(val table: String,
 
   protected def dropTable(): Unit = jdbcUpdate(s"drop table if exists $dbtable")
 
-  protected def batchWrite(rows: List[Row],
-                           schema: StructType,
-                           param: Option[Map[String, String]] = None): Unit = {
+  protected def tidbWrite(rows: List[Row],
+                          schema: StructType,
+                          param: Option[Map[String, String]] = None): Unit = {
     val data: RDD[Row] = sc.makeRDD(rows)
     val df = sqlContext.createDataFrame(data, schema)
     df.write
@@ -50,8 +52,75 @@ class BaseDataSourceTest(val table: String,
       .save()
   }
 
-  protected def testSelect(expectedAnswer: Seq[Row], sortCol: String = "i"): Unit = {
-    val df = sqlContext.read
+  protected def jdbcWrite(rows: List[Row],
+                          schema: StructType,
+                          param: Option[Map[String, String]] = None): Unit = {
+    val data: RDD[Row] = sc.makeRDD(rows)
+    val df = sqlContext.createDataFrame(data, schema)
+    df.write
+      .format("jdbc")
+      .option("url", jdbcUrl)
+      .option("dbtable", dbtable)
+      .option("isolationLevel", "REPEATABLE_READ")
+      .mode("append")
+      .save()
+  }
+
+  protected def testDataSourceSelect(expectedAnswer: Seq[Row], sortCol: String = "i"): Unit = {
+    // check data source result & expected answer
+    val df = queryDataSourceAPI(sortCol)
+    checkAnswer(df, expectedAnswer)
+  }
+
+  protected def compareTiDBAndJDBCWrite(
+    testCode: ((List[Row], StructType, Option[Map[String, String]]) => Unit, String) => Unit
+  ): Unit = {
+    testCode(jdbcWrite, "jdbcWrite")
+    testCode(tidbWrite, "tidbWrite")
+  }
+
+  protected def compareDataSourceSelectWithJDBC(expectedAnswer: Seq[Row],
+                                                schema: StructType,
+                                                sortCol: String = "i"): Unit = {
+    val sql = s"select * from $dbtable order by $sortCol"
+    val answer = seqRowToList(expectedAnswer, schema)
+
+    // check jdbc result & expected answer
+    val jdbcResult = queryTiDB(sql)
+    compSqlResult(sql, jdbcResult, answer, checkLimit = false)
+
+    // check data source result & expected answer
+    val df = queryDataSourceAPI(sortCol)
+    compSqlResult(sql, seqRowToList(df.collect(), df.schema), answer, checkLimit = false)
+  }
+
+  protected def compareDataSourceSelectWithJDBC2(sortCol: String = "i"): Unit = {
+    val sql = s"select * from $dbtable order by $sortCol"
+
+    // check jdbc result & data source result
+    val jdbcResult = queryTiDB(sql)
+    val df = queryDataSourceAPI(sortCol)
+
+    compSqlResult(sql, jdbcResult, seqRowToList(df.collect(), df.schema), checkLimit = false)
+  }
+
+  private def seqRowToList(rows: Seq[Row], schema: StructType): List[List[Any]] =
+    rows
+      .map(row => {
+        val rowRes = ArrayBuffer.empty[Any]
+        for (i <- 0 until row.length) {
+          if (row.get(i) == null) {
+            rowRes += null
+          } else {
+            rowRes += toOutput(row.get(i), schema(i).dataType.typeName)
+          }
+        }
+        rowRes.toList
+      })
+      .toList
+
+  private def queryDataSourceAPI(sortCol: String): DataFrame =
+    sqlContext.read
       .format("tidb")
       .options(tidbOptions)
       .option("database", database)
@@ -59,7 +128,23 @@ class BaseDataSourceTest(val table: String,
       .load()
       .sort(sortCol)
 
-    checkAnswer(df, expectedAnswer)
+  private def queryTiDB(query: String): List[List[Any]] = {
+    val resultSet = tidbStmt.executeQuery(query)
+    val rsMetaData = resultSet.getMetaData
+    val retSet = ArrayBuffer.empty[List[Any]]
+    val retSchema = ArrayBuffer.empty[String]
+    for (i <- 1 to rsMetaData.getColumnCount) {
+      retSchema += rsMetaData.getColumnTypeName(i)
+    }
+    while (resultSet.next()) {
+      val row = ArrayBuffer.empty[Any]
+
+      for (i <- 1 to rsMetaData.getColumnCount) {
+        row += toOutput(resultSet.getObject(i), retSchema(i - 1))
+      }
+      retSet += row.toList
+    }
+    retSet.toList
   }
 
   protected def testFilter(filter: String, expectedAnswer: Seq[Row]): Unit = {

--- a/core/src/test/scala/com/pingcap/tispark/datasource/BasicDataSourceSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/BasicDataSourceSuite.scala
@@ -29,7 +29,7 @@ class BasicDataSourceSuite extends BaseDataSourceTest("test_datasource_basic") {
   }
 
   test("Test Select") {
-    testSelect(Seq(row1, row2))
+    testDataSourceSelect(Seq(row1, row2))
   }
 
   test("Test Write Append") {
@@ -44,7 +44,7 @@ class BasicDataSourceSuite extends BaseDataSourceTest("test_datasource_basic") {
       .mode("append")
       .save()
 
-    testSelect(Seq(row1, row2, row3, row4))
+    testDataSourceSelect(Seq(row1, row2, row3, row4))
   }
 
   test("Test Write Overwrite") {

--- a/core/src/test/scala/com/pingcap/tispark/datasource/BasicDataSourceSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/BasicDataSourceSuite.scala
@@ -29,7 +29,7 @@ class BasicDataSourceSuite extends BaseDataSourceTest("test_datasource_basic") {
   }
 
   test("Test Select") {
-    testDataSourceSelect(Seq(row1, row2))
+    testTiDBSelect(Seq(row1, row2))
   }
 
   test("Test Write Append") {
@@ -44,7 +44,7 @@ class BasicDataSourceSuite extends BaseDataSourceTest("test_datasource_basic") {
       .mode("append")
       .save()
 
-    testDataSourceSelect(Seq(row1, row2, row3, row4))
+    testTiDBSelect(Seq(row1, row2, row3, row4))
   }
 
   test("Test Write Overwrite") {

--- a/core/src/test/scala/com/pingcap/tispark/datasource/CheckUnsupportedSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/CheckUnsupportedSuite.scala
@@ -31,7 +31,7 @@ class CheckUnsupportedSuite extends BaseDataSourceTest("test_datasource_check_un
 
     {
       val caught = intercept[TiBatchWriteException] {
-        batchWrite(List(row2, row3), schema)
+        tidbWrite(List(row2, row3), schema)
       }
       assert(
         caught.getMessage
@@ -41,7 +41,7 @@ class CheckUnsupportedSuite extends BaseDataSourceTest("test_datasource_check_un
       )
     }
 
-    testSelect(Seq(row1))
+    testDataSourceSelect(Seq(row1))
   }
 
   test("Test write to table with secondary index: KEY") {
@@ -56,7 +56,7 @@ class CheckUnsupportedSuite extends BaseDataSourceTest("test_datasource_check_un
 
     {
       val caught = intercept[TiBatchWriteException] {
-        batchWrite(List(row2, row3), schema)
+        tidbWrite(List(row2, row3), schema)
       }
       assert(
         caught.getMessage
@@ -66,7 +66,7 @@ class CheckUnsupportedSuite extends BaseDataSourceTest("test_datasource_check_un
       )
     }
 
-    testSelect(Seq(row1))
+    testDataSourceSelect(Seq(row1))
   }
 
   test("Test write to partition table") {
@@ -81,7 +81,7 @@ class CheckUnsupportedSuite extends BaseDataSourceTest("test_datasource_check_un
 
     {
       val caught = intercept[TiBatchWriteException] {
-        batchWrite(List(row2, row3), schema)
+        tidbWrite(List(row2, row3), schema)
       }
       assert(
         caught.getMessage
@@ -89,7 +89,7 @@ class CheckUnsupportedSuite extends BaseDataSourceTest("test_datasource_check_un
       )
     }
 
-    testSelect(Seq(row1))
+    testDataSourceSelect(Seq(row1))
   }
 
   test(
@@ -106,7 +106,7 @@ class CheckUnsupportedSuite extends BaseDataSourceTest("test_datasource_check_un
 
     {
       val caught = intercept[TiBatchWriteException] {
-        batchWrite(List(row2, row3), schema)
+        tidbWrite(List(row2, row3), schema)
       }
       assert(
         caught.getMessage
@@ -116,7 +116,7 @@ class CheckUnsupportedSuite extends BaseDataSourceTest("test_datasource_check_un
       )
     }
 
-    testSelect(Seq(row1))
+    testDataSourceSelect(Seq(row1))
   }
 
   override def afterAll(): Unit =

--- a/core/src/test/scala/com/pingcap/tispark/datasource/CheckUnsupportedSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/CheckUnsupportedSuite.scala
@@ -41,7 +41,7 @@ class CheckUnsupportedSuite extends BaseDataSourceTest("test_datasource_check_un
       )
     }
 
-    testDataSourceSelect(Seq(row1))
+    testTiDBSelect(Seq(row1))
   }
 
   test("Test write to table with secondary index: KEY") {
@@ -66,7 +66,7 @@ class CheckUnsupportedSuite extends BaseDataSourceTest("test_datasource_check_un
       )
     }
 
-    testDataSourceSelect(Seq(row1))
+    testTiDBSelect(Seq(row1))
   }
 
   test("Test write to partition table") {
@@ -89,7 +89,7 @@ class CheckUnsupportedSuite extends BaseDataSourceTest("test_datasource_check_un
       )
     }
 
-    testDataSourceSelect(Seq(row1))
+    testTiDBSelect(Seq(row1))
   }
 
   test(
@@ -116,7 +116,7 @@ class CheckUnsupportedSuite extends BaseDataSourceTest("test_datasource_check_un
       )
     }
 
-    testDataSourceSelect(Seq(row1))
+    testTiDBSelect(Seq(row1))
   }
 
   override def afterAll(): Unit =

--- a/core/src/test/scala/com/pingcap/tispark/datasource/DataSourceWithoutExtensionsSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/DataSourceWithoutExtensionsSuite.scala
@@ -28,7 +28,7 @@ class DataSourceWithoutExtensionsSuite
     jdbcUpdate(
       s"insert into $dbtable values(null, 'Hello'), (2, 'TiDB'), (3, 'Spark'), (4, null)"
     )
-    testSelect(Seq(row1, row2, row3, row4))
+    testDataSourceSelect(Seq(row1, row2, row3, row4))
   }
 
   test("Test Write Append") {
@@ -49,7 +49,7 @@ class DataSourceWithoutExtensionsSuite
       .mode("append")
       .save()
 
-    testSelect(Seq(row1, row2, row3, row4))
+    testDataSourceSelect(Seq(row1, row2, row3, row4))
   }
 
   test("Test Write Overwrite") {

--- a/core/src/test/scala/com/pingcap/tispark/datasource/DataSourceWithoutExtensionsSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/DataSourceWithoutExtensionsSuite.scala
@@ -22,7 +22,7 @@ class DataSourceWithoutExtensionsSuite
   override def beforeAll(): Unit =
     super.beforeAll()
 
-  test("Test Select") {
+  test("Test Select without extensions") {
     dropTable()
     jdbcUpdate(s"create table $dbtable(i int, s varchar(128))")
     jdbcUpdate(
@@ -31,7 +31,7 @@ class DataSourceWithoutExtensionsSuite
     testDataSourceSelect(Seq(row1, row2, row3, row4))
   }
 
-  test("Test Write Append") {
+  test("Test Write Append without extensions") {
     dropTable()
     jdbcUpdate(s"create table $dbtable(i int, s varchar(128))")
     jdbcUpdate(
@@ -52,7 +52,7 @@ class DataSourceWithoutExtensionsSuite
     testDataSourceSelect(Seq(row1, row2, row3, row4))
   }
 
-  test("Test Write Overwrite") {
+  test("Test Write Overwrite without extensions") {
     dropTable()
     jdbcUpdate(s"create table $dbtable(i int, s varchar(128))")
 
@@ -75,7 +75,7 @@ class DataSourceWithoutExtensionsSuite
     )
   }
 
-  test("Test Simple Comparisons") {
+  test("Test Simple Comparisons without extensions") {
     dropTable()
     jdbcUpdate(s"create table $dbtable(i int, s varchar(128))")
     jdbcUpdate(

--- a/core/src/test/scala/com/pingcap/tispark/datasource/DataSourceWithoutExtensionsSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/DataSourceWithoutExtensionsSuite.scala
@@ -28,7 +28,7 @@ class DataSourceWithoutExtensionsSuite
     jdbcUpdate(
       s"insert into $dbtable values(null, 'Hello'), (2, 'TiDB'), (3, 'Spark'), (4, null)"
     )
-    testDataSourceSelect(Seq(row1, row2, row3, row4))
+    testTiDBSelect(Seq(row1, row2, row3, row4))
   }
 
   test("Test Write Append without extensions") {
@@ -49,7 +49,7 @@ class DataSourceWithoutExtensionsSuite
       .mode("append")
       .save()
 
-    testDataSourceSelect(Seq(row1, row2, row3, row4))
+    testTiDBSelect(Seq(row1, row2, row3, row4))
   }
 
   test("Test Write Overwrite without extensions") {
@@ -81,9 +81,9 @@ class DataSourceWithoutExtensionsSuite
     jdbcUpdate(
       s"insert into $dbtable values(null, 'Hello'), (2, 'TiDB'), (3, 'Spark'), (4, null)"
     )
-    testFilter("s = 'Hello'", Seq(row1))
-    testFilter("i > 2", Seq(row3, row4))
-    testFilter("i < 3", Seq(row2))
+    testTiDBSelectFilter("s = 'Hello'", Seq(row1))
+    testTiDBSelectFilter("i > 2", Seq(row3, row4))
+    testTiDBSelectFilter("i < 3", Seq(row2))
   }
 
   override def afterAll(): Unit =

--- a/core/src/test/scala/com/pingcap/tispark/datasource/DeduplicateSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/DeduplicateSuite.scala
@@ -27,11 +27,11 @@ class DeduplicateSuite extends BaseDataSourceTest("test_datasource_deduplicate")
 
     // insert row2 row2 row3
     tidbWrite(List(row2, row2, row3), schema, Some(Map("deduplicate" -> "true")))
-    testDataSourceSelect(Seq(row1, row2, row2, row3))
+    testTiDBSelect(Seq(row1, row2, row2, row3))
 
     // insert row4 row4 row5
     tidbWrite(List(row4, row4, row5), schema, Some(Map("deduplicate" -> "false")))
-    testDataSourceSelect(Seq(row1, row2, row2, row3, row4, row4, row5))
+    testTiDBSelect(Seq(row1, row2, row2, row3, row4, row4, row5))
   }
 
   test("Test deduplicate (table with primary key & primary key is handle)") {
@@ -52,12 +52,12 @@ class DeduplicateSuite extends BaseDataSourceTest("test_datasource_deduplicate")
           .equals("data conflicts! set the parameter deduplicate.")
       )
     }
-    testDataSourceSelect(Seq(row2))
+    testTiDBSelect(Seq(row2))
 
     // deduplicate=true
     // insert row4 row5 row3 row5
     tidbWrite(List(row4, row5, row3, row5), schema, Some(Map("deduplicate" -> "true")))
-    testDataSourceSelect(Seq(row2, row3, row4, row5))
+    testTiDBSelect(Seq(row2, row3, row4, row5))
   }
 
   override def afterAll(): Unit =

--- a/core/src/test/scala/com/pingcap/tispark/datasource/DeduplicateSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/DeduplicateSuite.scala
@@ -26,12 +26,12 @@ class DeduplicateSuite extends BaseDataSourceTest("test_datasource_deduplicate")
     )
 
     // insert row2 row2 row3
-    batchWrite(List(row2, row2, row3), schema, Some(Map("deduplicate" -> "true")))
-    testSelect(Seq(row1, row2, row2, row3))
+    tidbWrite(List(row2, row2, row3), schema, Some(Map("deduplicate" -> "true")))
+    testDataSourceSelect(Seq(row1, row2, row2, row3))
 
     // insert row4 row4 row5
-    batchWrite(List(row4, row4, row5), schema, Some(Map("deduplicate" -> "false")))
-    testSelect(Seq(row1, row2, row2, row3, row4, row4, row5))
+    tidbWrite(List(row4, row4, row5), schema, Some(Map("deduplicate" -> "false")))
+    testDataSourceSelect(Seq(row1, row2, row2, row3, row4, row4, row5))
   }
 
   test("Test deduplicate (table with primary key & primary key is handle)") {
@@ -45,19 +45,19 @@ class DeduplicateSuite extends BaseDataSourceTest("test_datasource_deduplicate")
     // insert row4 row5 row3 row5
     {
       val caught = intercept[TiBatchWriteException] {
-        batchWrite(List(row4, row5, row3, row5), schema, Some(Map("deduplicate" -> "false")))
+        tidbWrite(List(row4, row5, row3, row5), schema, Some(Map("deduplicate" -> "false")))
       }
       assert(
         caught.getMessage
           .equals("data conflicts! set the parameter deduplicate.")
       )
     }
-    testSelect(Seq(row2))
+    testDataSourceSelect(Seq(row2))
 
     // deduplicate=true
     // insert row4 row5 row3 row5
-    batchWrite(List(row4, row5, row3, row5), schema, Some(Map("deduplicate" -> "true")))
-    testSelect(Seq(row2, row3, row4, row5))
+    tidbWrite(List(row4, row5, row3, row5), schema, Some(Map("deduplicate" -> "true")))
+    testDataSourceSelect(Seq(row2, row3, row4, row5))
   }
 
   override def afterAll(): Unit =

--- a/core/src/test/scala/com/pingcap/tispark/datasource/EdgeConditionSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/EdgeConditionSuite.scala
@@ -32,8 +32,8 @@ class EdgeConditionSuite extends BaseDataSourceTest("test_datasource_edge_condit
     jdbcUpdate(
       s"insert into $dbtable values(1)"
     )
-    batchWrite(List(row2, row3, row4), schema)
-    testSelect(Seq(row1, row2, row3, row4))
+    tidbWrite(List(row2, row3, row4), schema)
+    testDataSourceSelect(Seq(row1, row2, row3, row4))
   }
 
   test("Write to table with one column (primary key int type)") {
@@ -56,8 +56,8 @@ class EdgeConditionSuite extends BaseDataSourceTest("test_datasource_edge_condit
     jdbcUpdate(
       s"insert into $dbtable values(1)"
     )
-    batchWrite(List(row2, row3, row4), schema)
-    testSelect(Seq(row1, row2, row3, row4))
+    tidbWrite(List(row2, row3, row4), schema)
+    testDataSourceSelect(Seq(row1, row2, row3, row4))
   }
 
   test("Write to table with one column (primary key + auto increase)") {
@@ -80,8 +80,8 @@ class EdgeConditionSuite extends BaseDataSourceTest("test_datasource_edge_condit
     jdbcUpdate(
       s"insert into $dbtable values(1)"
     )
-    batchWrite(List(row2, row3, row4), schema)
-    testSelect(Seq(row1, row2, row3, row4))
+    tidbWrite(List(row2, row3, row4), schema)
+    testDataSourceSelect(Seq(row1, row2, row3, row4))
   }
 
   test("Write to table with one column (no primary key)") {
@@ -104,8 +104,8 @@ class EdgeConditionSuite extends BaseDataSourceTest("test_datasource_edge_condit
     jdbcUpdate(
       s"insert into $dbtable values('Hello')"
     )
-    batchWrite(List(row1, row3, row4), schema)
-    testSelect(Seq(row1, row2, row3, row4))
+    tidbWrite(List(row1, row3, row4), schema)
+    testDataSourceSelect(Seq(row1, row2, row3, row4))
   }
 
   test("Write to table with many columns") {
@@ -144,8 +144,8 @@ class EdgeConditionSuite extends BaseDataSourceTest("test_datasource_edge_condit
       s"create table $dbtable($createTableSchemaStr)"
     )
 
-    batchWrite(List(row1, row2), schema)
-    testSelect(Seq(row1, row2), "c0")
+    tidbWrite(List(row1, row2), schema)
+    testDataSourceSelect(Seq(row1, row2), "c0")
   }
 
   test("Write Empty data") {
@@ -165,8 +165,8 @@ class EdgeConditionSuite extends BaseDataSourceTest("test_datasource_edge_condit
     jdbcUpdate(
       s"insert into $dbtable values(1)"
     )
-    batchWrite(List(), schema)
-    testSelect(Seq(row1))
+    tidbWrite(List(), schema)
+    testDataSourceSelect(Seq(row1))
   }
 
   test("Write large amount of data") {
@@ -187,8 +187,8 @@ class EdgeConditionSuite extends BaseDataSourceTest("test_datasource_edge_condit
     jdbcUpdate(
       s"create table $dbtable(i int, primary key (i))"
     )
-    batchWrite(list, schema)
-    testSelect(list)
+    tidbWrite(list, schema)
+    testDataSourceSelect(list)
 
     var list2: List[Row] = Nil
     for (i <- TEST_LARGE_DATA_SIZE until TEST_LARGE_DATA_SIZE * 2) {
@@ -196,8 +196,8 @@ class EdgeConditionSuite extends BaseDataSourceTest("test_datasource_edge_condit
     }
     list2 = list2.reverse
 
-    batchWrite(list2, schema)
-    testSelect(list ::: list2)
+    tidbWrite(list2, schema)
+    testDataSourceSelect(list ::: list2)
   }
 
   override def afterAll(): Unit =

--- a/core/src/test/scala/com/pingcap/tispark/datasource/EdgeConditionSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/EdgeConditionSuite.scala
@@ -33,7 +33,7 @@ class EdgeConditionSuite extends BaseDataSourceTest("test_datasource_edge_condit
       s"insert into $dbtable values(1)"
     )
     tidbWrite(List(row2, row3, row4), schema)
-    testDataSourceSelect(Seq(row1, row2, row3, row4))
+    testTiDBSelect(Seq(row1, row2, row3, row4))
   }
 
   test("Write to table with one column (primary key int type)") {
@@ -57,7 +57,7 @@ class EdgeConditionSuite extends BaseDataSourceTest("test_datasource_edge_condit
       s"insert into $dbtable values(1)"
     )
     tidbWrite(List(row2, row3, row4), schema)
-    testDataSourceSelect(Seq(row1, row2, row3, row4))
+    testTiDBSelect(Seq(row1, row2, row3, row4))
   }
 
   test("Write to table with one column (primary key + auto increase)") {
@@ -81,7 +81,7 @@ class EdgeConditionSuite extends BaseDataSourceTest("test_datasource_edge_condit
       s"insert into $dbtable values(1)"
     )
     tidbWrite(List(row2, row3, row4), schema)
-    testDataSourceSelect(Seq(row1, row2, row3, row4))
+    testTiDBSelect(Seq(row1, row2, row3, row4))
   }
 
   test("Write to table with one column (no primary key)") {
@@ -105,7 +105,7 @@ class EdgeConditionSuite extends BaseDataSourceTest("test_datasource_edge_condit
       s"insert into $dbtable values('Hello')"
     )
     tidbWrite(List(row1, row3, row4), schema)
-    testDataSourceSelect(Seq(row1, row2, row3, row4))
+    testTiDBSelect(Seq(row1, row2, row3, row4))
   }
 
   test("Write to table with many columns") {
@@ -145,7 +145,7 @@ class EdgeConditionSuite extends BaseDataSourceTest("test_datasource_edge_condit
     )
 
     tidbWrite(List(row1, row2), schema)
-    testDataSourceSelect(Seq(row1, row2), "c0")
+    testTiDBSelect(Seq(row1, row2), "c0")
   }
 
   test("Write Empty data") {
@@ -166,7 +166,7 @@ class EdgeConditionSuite extends BaseDataSourceTest("test_datasource_edge_condit
       s"insert into $dbtable values(1)"
     )
     tidbWrite(List(), schema)
-    testDataSourceSelect(Seq(row1))
+    testTiDBSelect(Seq(row1))
   }
 
   test("Write large amount of data") {
@@ -188,7 +188,7 @@ class EdgeConditionSuite extends BaseDataSourceTest("test_datasource_edge_condit
       s"create table $dbtable(i int, primary key (i))"
     )
     tidbWrite(list, schema)
-    testDataSourceSelect(list)
+    testTiDBSelect(list)
 
     var list2: List[Row] = Nil
     for (i <- TEST_LARGE_DATA_SIZE until TEST_LARGE_DATA_SIZE * 2) {
@@ -197,7 +197,7 @@ class EdgeConditionSuite extends BaseDataSourceTest("test_datasource_edge_condit
     list2 = list2.reverse
 
     tidbWrite(list2, schema)
-    testDataSourceSelect(list ::: list2)
+    testTiDBSelect(list ::: list2)
   }
 
   override def afterAll(): Unit =

--- a/core/src/test/scala/com/pingcap/tispark/datasource/ExceptionTestSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/ExceptionTestSuite.scala
@@ -23,7 +23,7 @@ class ExceptionTestSuite extends BaseDataSourceTest("test_datasource_exception_t
     dropTable()
 
     val caught = intercept[TiBatchWriteException] {
-      batchWrite(List(row1, row2), schema)
+      tidbWrite(List(row1, row2), schema)
     }
     assert(caught.getMessage.equals(s"table $dbtable does not exists!"))
   }
@@ -44,7 +44,7 @@ class ExceptionTestSuite extends BaseDataSourceTest("test_datasource_exception_t
 
     {
       val caught = intercept[TiBatchWriteException] {
-        batchWrite(List(row1), schema)
+        tidbWrite(List(row1), schema)
       }
       assert(
         caught.getMessage
@@ -71,7 +71,7 @@ class ExceptionTestSuite extends BaseDataSourceTest("test_datasource_exception_t
 
     {
       val caught = intercept[TiBatchWriteException] {
-        batchWrite(List(row1), schema)
+        tidbWrite(List(row1), schema)
       }
       assert(
         caught.getMessage
@@ -99,7 +99,7 @@ class ExceptionTestSuite extends BaseDataSourceTest("test_datasource_exception_t
 
     {
       val caught = intercept[TiBatchWriteException] {
-        batchWrite(List(row1, row2), schema)
+        tidbWrite(List(row1, row2), schema)
       }
       assert(
         caught.getMessage

--- a/core/src/test/scala/com/pingcap/tispark/datasource/FilterPushdownSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/FilterPushdownSuite.scala
@@ -19,25 +19,25 @@ class FilterPushdownSuite extends BaseDataSourceTest("test_datasource_filter_pus
   }
 
   test("Test Simple Comparisons") {
-    testFilter("s = 'Hello'", Seq(row1))
-    testFilter("i > 2", Seq(row3, row4))
-    testFilter("i < 3", Seq(row2))
+    testTiDBSelectFilter("s = 'Hello'", Seq(row1))
+    testTiDBSelectFilter("i > 2", Seq(row3, row4))
+    testTiDBSelectFilter("i < 3", Seq(row2))
   }
 
   test("Test >= and <=") {
-    testFilter("i >= 2", Seq(row2, row3, row4))
-    testFilter("i <= 3", Seq(row2, row3))
+    testTiDBSelectFilter("i >= 2", Seq(row2, row3, row4))
+    testTiDBSelectFilter("i <= 3", Seq(row2, row3))
   }
 
   test("Test logical operators") {
-    testFilter("i >= 2 AND i <= 3", Seq(row2, row3))
-    testFilter("NOT i = 3", Seq(row2, row4))
-    testFilter("NOT i = 3 OR i IS NULL", Seq(row1, row2, row4))
-    testFilter("i IS NULL OR i > 2 AND s IS NOT NULL", Seq(row1, row3))
+    testTiDBSelectFilter("i >= 2 AND i <= 3", Seq(row2, row3))
+    testTiDBSelectFilter("NOT i = 3", Seq(row2, row4))
+    testTiDBSelectFilter("NOT i = 3 OR i IS NULL", Seq(row1, row2, row4))
+    testTiDBSelectFilter("i IS NULL OR i > 2 AND s IS NOT NULL", Seq(row1, row3))
   }
 
   test("Test IN") {
-    testFilter("i IN ( 2, 3)", Seq(row2, row3))
+    testTiDBSelectFilter("i IN ( 2, 3)", Seq(row2, row3))
   }
 
   override def afterAll(): Unit =

--- a/core/src/test/scala/com/pingcap/tispark/datasource/TiSparkTypeSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/TiSparkTypeSuite.scala
@@ -23,6 +23,6 @@ class TiSparkTypeSuite extends BaseDataSourceTest("type_test") {
     )
 
     tidbWrite(List(row3, row5), schema)
-    testDataSourceSelect(List(row1, row2, row3, row5))
+    testTiDBSelect(List(row1, row2, row3, row5))
   }
 }

--- a/core/src/test/scala/com/pingcap/tispark/datasource/TiSparkTypeSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/TiSparkTypeSuite.scala
@@ -3,7 +3,7 @@ package com.pingcap.tispark.datasource
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types.{LongType, StringType, StructField, StructType}
 
-class TiSparkTypeSuite extends BaseDataSourceSuite("type_test") {
+class TiSparkTypeSuite extends BaseDataSourceTest("type_test") {
   private val row1 = Row(null, "Hello")
   private val row2 = Row(2L, "TiDB")
   private val row3 = Row(3L, "Spark")
@@ -22,7 +22,7 @@ class TiSparkTypeSuite extends BaseDataSourceSuite("type_test") {
       s"insert into $dbtable values(null, 'Hello'), (2, 'TiDB')"
     )
 
-    batchWrite(List(row3, row5), schema)
-    testSelect(List(row1, row2, row3, row5))
+    tidbWrite(List(row3, row5), schema)
+    testDataSourceSelect(List(row1, row2, row3, row5))
   }
 }

--- a/core/src/test/scala/com/pingcap/tispark/datasource/UpsertSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/UpsertSuite.scala
@@ -30,20 +30,20 @@ class UpsertSuite extends BaseDataSourceTest("test_datasource_upsert") {
     )
 
     // insert row2 row3
-    batchWrite(List(row2, row3), schema)
-    testSelect(Seq(row1, row2, row3))
+    tidbWrite(List(row2, row3), schema)
+    testDataSourceSelect(Seq(row1, row2, row3))
 
     // insert row2 row4
-    batchWrite(List(row2, row4), schema)
-    testSelect(Seq(row1, row2, row2, row3, row4))
+    tidbWrite(List(row2, row4), schema)
+    testDataSourceSelect(Seq(row1, row2, row2, row3, row4))
 
     // insert row5 row5
-    batchWrite(List(row5, row5), schema)
-    testSelect(Seq(row1, row2, row2, row3, row4, row5, row5))
+    tidbWrite(List(row5, row5), schema)
+    testDataSourceSelect(Seq(row1, row2, row2, row3, row4, row5, row5))
 
     // insert row3_v2
-    batchWrite(List(row3_v2), schema)
-    testSelect(Seq(row1, row2, row2, row3, row3_v2, row4, row5, row5))
+    tidbWrite(List(row3_v2), schema)
+    testDataSourceSelect(Seq(row1, row2, row2, row3, row3_v2, row4, row5, row5))
   }
 
   test("Test upsert to table with primary key (primary key is handle)") {
@@ -54,16 +54,16 @@ class UpsertSuite extends BaseDataSourceTest("test_datasource_upsert") {
     )
 
     // insert row3 row4
-    batchWrite(List(row3, row4), schema)
-    testSelect(Seq(row2, row3, row4))
+    tidbWrite(List(row3, row4), schema)
+    testDataSourceSelect(Seq(row2, row3, row4))
 
     // insert row2_v2 row5
-    batchWrite(List(row2_v2, row5), schema)
-    testSelect(Seq(row2_v2, row3, row4, row5))
+    tidbWrite(List(row2_v2, row5), schema)
+    testDataSourceSelect(Seq(row2_v2, row3, row4, row5))
 
     // insert row3_v2 row4_v2 row5_v2
-    batchWrite(List(row3_v2, row4_v2, row5_v2), schema)
-    testSelect(Seq(row2_v2, row3_v2, row4_v2, row5_v2))
+    tidbWrite(List(row3_v2, row4_v2, row5_v2), schema)
+    testDataSourceSelect(Seq(row2_v2, row3_v2, row4_v2, row5_v2))
   }
 
   test("Test upsert to table with primary key (auto increase case 1)") {
@@ -74,16 +74,16 @@ class UpsertSuite extends BaseDataSourceTest("test_datasource_upsert") {
     )
 
     // insert row3 row4
-    batchWrite(List(row3, row4), schema)
-    testSelect(Seq(row2, row3, row4))
+    tidbWrite(List(row3, row4), schema)
+    testDataSourceSelect(Seq(row2, row3, row4))
 
     // insert row2_v2 row5
-    batchWrite(List(row2_v2, row5), schema)
-    testSelect(Seq(row2_v2, row3, row4, row5))
+    tidbWrite(List(row2_v2, row5), schema)
+    testDataSourceSelect(Seq(row2_v2, row3, row4, row5))
 
     // insert row3_v2 row4_v2 row5_v2
-    batchWrite(List(row3_v2, row4_v2, row5_v2), schema)
-    testSelect(Seq(row2_v2, row3_v2, row4_v2, row5_v2))
+    tidbWrite(List(row3_v2, row4_v2, row5_v2), schema)
+    testDataSourceSelect(Seq(row2_v2, row3_v2, row4_v2, row5_v2))
   }
 
   // TODO: support auto increment
@@ -106,12 +106,12 @@ class UpsertSuite extends BaseDataSourceTest("test_datasource_upsert") {
     )
 
     // insert row2 row3
-    batchWrite(List(rowWithoutPK2, rowWithoutPK3), schema)
-    testSelect(Seq(row1, row2, row3))
+    tidbWrite(List(rowWithoutPK2, rowWithoutPK3), schema)
+    testDataSourceSelect(Seq(row1, row2, row3))
 
     // insert row4 row5
-    batchWrite(List(rowWithoutPK4, rowWithoutPK5), schema)
-    testSelect(Seq(row1, row2, row3, row4, row5))
+    tidbWrite(List(rowWithoutPK4, rowWithoutPK5), schema)
+    testDataSourceSelect(Seq(row1, row2, row3, row4, row5))
   }
 
   override def afterAll(): Unit =

--- a/core/src/test/scala/com/pingcap/tispark/datasource/UpsertSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/UpsertSuite.scala
@@ -31,19 +31,19 @@ class UpsertSuite extends BaseDataSourceTest("test_datasource_upsert") {
 
     // insert row2 row3
     tidbWrite(List(row2, row3), schema)
-    testDataSourceSelect(Seq(row1, row2, row3))
+    testTiDBSelect(Seq(row1, row2, row3))
 
     // insert row2 row4
     tidbWrite(List(row2, row4), schema)
-    testDataSourceSelect(Seq(row1, row2, row2, row3, row4))
+    testTiDBSelect(Seq(row1, row2, row2, row3, row4))
 
     // insert row5 row5
     tidbWrite(List(row5, row5), schema)
-    testDataSourceSelect(Seq(row1, row2, row2, row3, row4, row5, row5))
+    testTiDBSelect(Seq(row1, row2, row2, row3, row4, row5, row5))
 
     // insert row3_v2
     tidbWrite(List(row3_v2), schema)
-    testDataSourceSelect(Seq(row1, row2, row2, row3, row3_v2, row4, row5, row5))
+    testTiDBSelect(Seq(row1, row2, row2, row3, row3_v2, row4, row5, row5))
   }
 
   test("Test upsert to table with primary key (primary key is handle)") {
@@ -55,15 +55,15 @@ class UpsertSuite extends BaseDataSourceTest("test_datasource_upsert") {
 
     // insert row3 row4
     tidbWrite(List(row3, row4), schema)
-    testDataSourceSelect(Seq(row2, row3, row4))
+    testTiDBSelect(Seq(row2, row3, row4))
 
     // insert row2_v2 row5
     tidbWrite(List(row2_v2, row5), schema)
-    testDataSourceSelect(Seq(row2_v2, row3, row4, row5))
+    testTiDBSelect(Seq(row2_v2, row3, row4, row5))
 
     // insert row3_v2 row4_v2 row5_v2
     tidbWrite(List(row3_v2, row4_v2, row5_v2), schema)
-    testDataSourceSelect(Seq(row2_v2, row3_v2, row4_v2, row5_v2))
+    testTiDBSelect(Seq(row2_v2, row3_v2, row4_v2, row5_v2))
   }
 
   test("Test upsert to table with primary key (auto increase case 1)") {
@@ -75,15 +75,15 @@ class UpsertSuite extends BaseDataSourceTest("test_datasource_upsert") {
 
     // insert row3 row4
     tidbWrite(List(row3, row4), schema)
-    testDataSourceSelect(Seq(row2, row3, row4))
+    testTiDBSelect(Seq(row2, row3, row4))
 
     // insert row2_v2 row5
     tidbWrite(List(row2_v2, row5), schema)
-    testDataSourceSelect(Seq(row2_v2, row3, row4, row5))
+    testTiDBSelect(Seq(row2_v2, row3, row4, row5))
 
     // insert row3_v2 row4_v2 row5_v2
     tidbWrite(List(row3_v2, row4_v2, row5_v2), schema)
-    testDataSourceSelect(Seq(row2_v2, row3_v2, row4_v2, row5_v2))
+    testTiDBSelect(Seq(row2_v2, row3_v2, row4_v2, row5_v2))
   }
 
   // TODO: support auto increment
@@ -107,11 +107,11 @@ class UpsertSuite extends BaseDataSourceTest("test_datasource_upsert") {
 
     // insert row2 row3
     tidbWrite(List(rowWithoutPK2, rowWithoutPK3), schema)
-    testDataSourceSelect(Seq(row1, row2, row3))
+    testTiDBSelect(Seq(row1, row2, row3))
 
     // insert row4 row5
     tidbWrite(List(rowWithoutPK4, rowWithoutPK5), schema)
-    testDataSourceSelect(Seq(row1, row2, row3, row4, row5))
+    testTiDBSelect(Seq(row1, row2, row3, row4, row5))
   }
 
   override def afterAll(): Unit =

--- a/core/src/test/scala/com/pingcap/tispark/datatype/DataTypeSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datatype/DataTypeSuite.scala
@@ -1,0 +1,90 @@
+package com.pingcap.tispark.datatype
+
+import com.pingcap.tispark.datasource.BaseDataSourceSuite
+
+class DataTypeSuite extends BaseDataSourceSuite("test_datasource_data_type") {
+
+  test("Test Read different types") {
+    dropTable()
+    jdbcUpdate(s"""
+                  |create table $dbtable(
+                  |i INT,
+                  |c1 BIT(1),
+                  |c2 BIT(8),
+                  |c3 TINYINT,
+                  |c4 BOOLEAN,
+                  |c5 SMALLINT,
+                  |c6 MEDIUMINT,
+                  |c7 INTEGER,
+                  |c8 BIGINT,
+                  |c9 FLOAT,
+                  |c10 DOUBLE,
+                  |c11 DECIMAL,
+                  |c12 DATE,
+                  |c13 DATETIME,
+                  |c14 TIMESTAMP,
+                  |c15 TIME,
+                  |c16 YEAR,
+                  |c17 CHAR(64),
+                  |c18 VARCHAR(64),
+                  |c19 BINARY(64),
+                  |c20 VARBINARY(64),
+                  |c21 TINYBLOB,
+                  |c22 TINYTEXT,
+                  |c23 BLOB,
+                  |c24 TEXT,
+                  |c25 MEDIUMBLOB,
+                  |c26 MEDIUMTEXT,
+                  |c27 LONGBLOB,
+                  |c28 LONGTEXT,
+                  |c29 ENUM('male' , 'female' , 'both' , 'unknow'),
+                  |c30 SET('a', 'b', 'c')
+                  |)
+      """.stripMargin)
+
+    jdbcUpdate(s"""
+                  |insert into $dbtable values(
+                  |1,
+                  |B'1',
+                  |B'01111100',
+                  |29,
+                  |1,
+                  |29,
+                  |29,
+                  |29,
+                  |29,
+                  |29.9,
+                  |29.9,
+                  |29.9,
+                  |'2019-01-01',
+                  |'2019-01-01 11:11:11',
+                  |'2019-01-01 11:11:11',
+                  |'11:11:11',
+                  |'2019',
+                  |'char test',
+                  |'varchar test',
+                  |'binary test',
+                  |'varbinary test',
+                  |'tinyblob test',
+                  |'tinytext test',
+                  |'blob test',
+                  |'text test',
+                  |'mediumblob test',
+                  |'mediumtext test',
+                  |'longblob test',
+                  |'longtext test',
+                  |'male',
+                  |'a,b'
+                  |)
+       """.stripMargin)
+
+    compareDataSourceSelectWithJDBC2()
+  }
+
+  override def afterAll(): Unit =
+    try {
+      dropTable()
+    } finally {
+      super.afterAll()
+    }
+}

--- a/core/src/test/scala/com/pingcap/tispark/datatype/DataTypeSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datatype/DataTypeSuite.scala
@@ -78,7 +78,7 @@ class DataTypeSuite extends BaseDataSourceTest("test_datasource_data_type") {
                   |)
        """.stripMargin)
 
-    compareDataSourceSelectWithJDBC2()
+    compareTiDBSelectWithJDBC_V2()
   }
 
   override def afterAll(): Unit =

--- a/core/src/test/scala/com/pingcap/tispark/datatype/DataTypeSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datatype/DataTypeSuite.scala
@@ -1,8 +1,8 @@
 package com.pingcap.tispark.datatype
 
-import com.pingcap.tispark.datasource.BaseDataSourceSuite
+import com.pingcap.tispark.datasource.BaseDataSourceTest
 
-class DataTypeSuite extends BaseDataSourceSuite("test_datasource_data_type") {
+class DataTypeSuite extends BaseDataSourceTest("test_datasource_data_type") {
 
   test("Test Read different types") {
     dropTable()

--- a/core/src/test/scala/org/apache/spark/sql/test/SharedSQLContext.scala
+++ b/core/src/test/scala/org/apache/spark/sql/test/SharedSQLContext.scala
@@ -108,6 +108,7 @@ trait SharedSQLContext extends SparkFunSuite with Eventually with BeforeAndAfter
       )
     } catch {
       case e: Throwable =>
+        e.printStackTrace()
         fail(
           s"Failed to initialize SQLContext:${e.getMessage}, please check your TiDB cluster and Spark configuration",
           e


### PR DESCRIPTION
currently only support convert to:
1. TINYINT 
2. SMALLINT 
3. MEDIUMINT
4.  INT 
5. BIGINT
6. Double 
7. Float

and only support convert from:
1. BooleanType
2. ByteType
3. ShortType
4. IntegerType
5. LongType
6. FloatType
7. DoubleType
8. StringType

other convert type will provide in following PRs