### PR TITLE
extend joda's DateTime to support micro second in order to hold Timestamp

### DIFF
--- a/core/src/test/scala/com/pingcap/tispark/convert/ToDateTimeSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/convert/ToDateTimeSuite.scala
@@ -30,20 +30,20 @@ class ToDateTimeSuite extends BaseDataSourceTest("test_data_type_convert_to_date
 
     val readA: java.sql.Timestamp = java.sql.Timestamp.valueOf("2019-11-11 11:11:11")
     val readB: java.sql.Timestamp = java.sql.Timestamp.valueOf("1990-01-01 01:01:01.999")
-    val readC: java.sql.Timestamp = java.sql.Timestamp.valueOf("1995-05-01 21:21:21.6")
+    val readC: java.sql.Timestamp = java.sql.Timestamp.valueOf("1995-05-01 21:21:21.666666")
 
     readRow1 = Row(1, null, null, null)
     readRow2 = Row(2, readA, readB, readC)
   }
 
-  test("Test Convert from java.lang.Long to DATETIME") {
+  ignore("Test Convert from java.lang.Long to DATETIME") {
     // success
     // java.lang.Long -> DATETIME
     compareTiDBWriteWithJDBC {
       case (writeFunc, "tidbWrite") =>
         val a: java.lang.Long = java.sql.Timestamp.valueOf("2019-11-11 11:11:11").getTime
         val b: java.lang.Long = java.sql.Timestamp.valueOf("1990-01-01 01:01:01.999").getTime
-        val c: java.lang.Long = java.sql.Timestamp.valueOf("1995-05-01 21:21:21.6").getTime
+        val c: java.lang.Long = java.sql.Timestamp.valueOf("1995-05-01 21:21:21.666666").getTime
 
         val row1 = Row(1, null, null, null)
         val row2 = Row(2, a, b, c)
@@ -76,7 +76,7 @@ class ToDateTimeSuite extends BaseDataSourceTest("test_data_type_convert_to_date
       case (writeFunc, _) =>
         val row1 = Row(1, null, null, null)
         val row2 =
-          Row(2, "2019-11-11 11:11:11", "1990-01-01 01:01:01.999", "1995-05-01 21:21:21.6")
+          Row(2, "2019-11-11 11:11:11", "1990-01-01 01:01:01.999", "1995-05-01 21:21:21.666666")
 
         val schema = StructType(
           List(
@@ -133,7 +133,7 @@ class ToDateTimeSuite extends BaseDataSourceTest("test_data_type_convert_to_date
       case (writeFunc, _) =>
         val a: java.sql.Timestamp = java.sql.Timestamp.valueOf("2019-11-11 11:11:11")
         val b: java.sql.Timestamp = java.sql.Timestamp.valueOf("1990-01-01 01:01:01.999")
-        val c: java.sql.Timestamp = java.sql.Timestamp.valueOf("1995-05-01 21:21:21.6")
+        val c: java.sql.Timestamp = java.sql.Timestamp.valueOf("1995-05-01 21:21:21.666666")
 
         val row1 = Row(1, null, null, null)
         val row2 = Row(2, a, b, c)

--- a/core/src/test/scala/com/pingcap/tispark/convert/ToDateTimeSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/convert/ToDateTimeSuite.scala
@@ -36,39 +36,6 @@ class ToDateTimeSuite extends BaseDataSourceTest("test_data_type_convert_to_date
     readRow2 = Row(2, readA, readB, readC)
   }
 
-  ignore("Test Convert from java.lang.Long to DATETIME") {
-    // success
-    // java.lang.Long -> DATETIME
-    compareTiDBWriteWithJDBC {
-      case (writeFunc, "tidbWrite") =>
-        val a: java.lang.Long = java.sql.Timestamp.valueOf("2019-11-11 11:11:11").getTime
-        val b: java.lang.Long = java.sql.Timestamp.valueOf("1990-01-01 01:01:01.999").getTime
-        val c: java.lang.Long = java.sql.Timestamp.valueOf("1995-05-01 21:21:21.666666").getTime
-
-        val row1 = Row(1, null, null, null)
-        val row2 = Row(2, a, b, c)
-
-        val schema = StructType(
-          List(
-            StructField("i", IntegerType),
-            StructField("c1", LongType),
-            StructField("c2", LongType),
-            StructField("c3", LongType)
-          )
-        )
-
-        dropTable()
-        createTable()
-
-        // insert rows
-        writeFunc(List(row1, row2), schema, None)
-        compareTiDBSelectWithJDBC(Seq(readRow1, readRow2), readSchema)
-      case (writeFunc, "jdbcWrite") =>
-      // TODO: ignored, because of this error
-      //java.sql.BatchUpdateException: Data truncation: invalid time format: '34'
-    }
-  }
-
   test("Test Convert from String to DATETIME") {
     // success
     // String -> DATETIME
@@ -155,6 +122,9 @@ class ToDateTimeSuite extends BaseDataSourceTest("test_data_type_convert_to_date
         compareTiDBSelectWithJDBC(Seq(row1, row2), schema)
     }
   }
+
+  // mysql jdbc do not support following conversion
+  // java.lang.Long
 
   // TODO: test following types
   // java.math.BigDecimal

--- a/core/src/test/scala/com/pingcap/tispark/convert/ToTimestampSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/convert/ToTimestampSuite.scala
@@ -21,13 +21,13 @@ class ToTimestampSuite extends BaseDataSourceTest("test_data_type_convert_to_tim
   private def createTable(): Unit =
     jdbcUpdate(s"create table $dbtable(i INT, c1 TIMESTAMP, c2 TIMESTAMP(6))")
 
-  test("Test Convert from java.lang.Long to TIMESTAMP") {
+  ignore("Test Convert from java.lang.Long to TIMESTAMP") {
     // success
     // java.lang.Long -> TIMESTAMP
     compareTiDBWriteWithJDBC {
       case (writeFunc, "tidbWrite") =>
         val a: java.lang.Long = java.sql.Timestamp.valueOf("2019-11-11 11:11:11").getTime
-        val b: java.lang.Long = java.sql.Timestamp.valueOf("1990-01-01 01:01:01.999").getTime
+        val b: java.lang.Long = java.sql.Timestamp.valueOf("1990-01-01 01:01:01.999999").getTime
 
         val row1 = Row(1, null, null)
         val row2 = Row(2, a, b)
@@ -41,7 +41,7 @@ class ToTimestampSuite extends BaseDataSourceTest("test_data_type_convert_to_tim
         )
 
         val readA: java.sql.Timestamp = java.sql.Timestamp.valueOf("2019-11-11 11:11:11")
-        val readB: java.sql.Timestamp = java.sql.Timestamp.valueOf("1990-01-01 01:01:01.999")
+        val readB: java.sql.Timestamp = java.sql.Timestamp.valueOf("1990-01-01 01:01:01.999999")
 
         val readRow1 = Row(1, null, null)
         val readRow2 = Row(2, readA, readB)
@@ -64,7 +64,7 @@ class ToTimestampSuite extends BaseDataSourceTest("test_data_type_convert_to_tim
     compareTiDBWriteWithJDBC {
       case (writeFunc, "tidbWrite") =>
         val row1 = Row(1, null, null)
-        val row2 = Row(2, "2019-11-11 11:11:11", "1990-01-01 01:01:01.999")
+        val row2 = Row(2, "2019-11-11 11:11:11", "1990-01-01 01:01:01.999999")
 
         val schema = StructType(
           List(
@@ -75,7 +75,7 @@ class ToTimestampSuite extends BaseDataSourceTest("test_data_type_convert_to_tim
         )
 
         val readA: java.sql.Timestamp = java.sql.Timestamp.valueOf("2019-11-11 11:11:11")
-        val readB: java.sql.Timestamp = java.sql.Timestamp.valueOf("1990-01-01 01:01:01.999")
+        val readB: java.sql.Timestamp = java.sql.Timestamp.valueOf("1990-01-01 01:01:01.999999")
 
         val readRow1 = Row(1, null, null)
         val readRow2 = Row(2, readA, readB)
@@ -134,7 +134,7 @@ class ToTimestampSuite extends BaseDataSourceTest("test_data_type_convert_to_tim
     compareTiDBWriteWithJDBC {
       case (writeFunc, "tidbWrite") =>
         val a: java.sql.Timestamp = java.sql.Timestamp.valueOf("2019-11-11 11:11:11")
-        val b: java.sql.Timestamp = java.sql.Timestamp.valueOf("1990-01-01 01:01:01.999")
+        val b: java.sql.Timestamp = java.sql.Timestamp.valueOf("1990-01-01 01:01:01.999999")
 
         val row1 = Row(1, null, null)
         val row2 = Row(2, a, b)

--- a/docs/datasource_api_userguide.md
+++ b/docs/datasource_api_userguide.md
@@ -236,8 +236,8 @@ The full conversion metrics is as follows.
 | DOUBLE               | true        | true     | true      | true        | true     | true      | true       | true       | false       | true     | false         |
 | DECIMAL              | true        | true     | true      | true        | true     | true      | true       | true       | true        | false    | false         |
 | DATE                 | false       | false    | false     | false       | true     | true      | false      | false      | false       | true     | true          |
-| DATETIME             | false       | false    | false     | false       | true     | false     | false      | true       | false       | true     | true          |
-| TIMESTAMP            | false       | false    | false     | false       | true     | false     | false      | true       | false       | true     | true          |
+| DATETIME             | false       | false    | false     | false       | false    | false     | false      | true       | false       | true     | true          |
+| TIMESTAMP            | false       | false    | false     | false       | false    | false     | false      | true       | false       | true     | true          |
 | TIME                 | false       | false    | false     | false       | false    | false     | false      | false      | false       | false    | false         |
 | YEAR                 | false       | false    | false     | false       | false    | false     | false      | false      | false       | false    | false         |
 | CHAR                 | true        | true     | true      | true        | true     | false     | false      | true       | true        | true     | true          |

--- a/tikv-client/src/main/java/com/pingcap/tikv/ExtendedDateTime.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/ExtendedDateTime.java
@@ -1,0 +1,63 @@
+/*
+ *
+ * Copyright 2019 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.pingcap.tikv;
+
+import java.sql.Timestamp;
+import org.joda.time.DateTime;
+
+/** Extend joda DateTime to support micro second */
+public class ExtendedDateTime {
+
+  private DateTime dateTime;
+  private int microsOfMillis;
+
+  /**
+   * if timestamp = 2019-11-11 11:11:11 123456, then dateTime = 2019-11-11 11:11:11 123
+   * microInMillis = 456
+   *
+   * @param dateTime
+   * @param microsOfMillis
+   */
+  public ExtendedDateTime(DateTime dateTime, int microsOfMillis) {
+    this.dateTime = dateTime;
+    this.microsOfMillis = microsOfMillis;
+  }
+
+  public ExtendedDateTime(DateTime dateTime) {
+    this.dateTime = dateTime;
+    this.microsOfMillis = 0;
+  }
+
+  public DateTime getDateTime() {
+    return dateTime;
+  }
+
+  public int getMicrosOfSeconds() {
+    return dateTime.getMillisOfSecond() * 1000 + microsOfMillis;
+  }
+
+  public int getMicrosOfMillis() {
+    return microsOfMillis;
+  }
+
+  public Timestamp toTimeStamp() {
+    Timestamp timestamp = new Timestamp(dateTime.getMillis() / 1000 * 1000);
+    timestamp.setNanos(dateTime.getMillisOfSecond() * 1000000 + microsOfMillis * 1000);
+    return timestamp;
+  }
+}

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/AbstractDateTimeType.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/AbstractDateTimeType.java
@@ -1,6 +1,7 @@
 package com.pingcap.tikv.types;
 
 import com.pingcap.tidb.tipb.ExprType;
+import com.pingcap.tikv.ExtendedDateTime;
 import com.pingcap.tikv.codec.Codec;
 import com.pingcap.tikv.codec.Codec.DateCodec;
 import com.pingcap.tikv.codec.Codec.DateTimeCodec;
@@ -8,7 +9,6 @@ import com.pingcap.tikv.codec.CodecDataInput;
 import com.pingcap.tikv.codec.CodecDataOutput;
 import com.pingcap.tikv.exception.InvalidCodecFormatException;
 import com.pingcap.tikv.meta.TiColumnInfo.InternalTypeHolder;
-import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.LocalDate;
 
@@ -28,17 +28,17 @@ public abstract class AbstractDateTimeType extends DataType {
    * Decode DateTime from packed long value In TiDB / MySQL, timestamp type is converted to UTC and
    * stored
    */
-  DateTime decodeDateTime(int flag, CodecDataInput cdi) {
-    DateTime dateTime;
+  ExtendedDateTime decodeDateTime(int flag, CodecDataInput cdi) {
+    ExtendedDateTime extendedDateTime;
     if (flag == Codec.UVARINT_FLAG) {
-      dateTime = DateTimeCodec.readFromUVarInt(cdi, getTimezone());
+      extendedDateTime = DateTimeCodec.readFromUVarInt(cdi, getTimezone());
     } else if (flag == Codec.UINT_FLAG) {
-      dateTime = DateTimeCodec.readFromUInt(cdi, getTimezone());
+      extendedDateTime = DateTimeCodec.readFromUInt(cdi, getTimezone());
     } else {
       throw new InvalidCodecFormatException(
           "Invalid Flag type for " + getClass().getSimpleName() + ": " + flag);
     }
-    return dateTime;
+    return extendedDateTime;
   }
 
   /** Decode Date from packed long value */
@@ -58,8 +58,8 @@ public abstract class AbstractDateTimeType extends DataType {
   /** {@inheritDoc} */
   @Override
   protected void encodeKey(CodecDataOutput cdo, Object value) {
-    DateTime dt = Converter.convertToDateTime(value);
-    DateTimeCodec.writeDateTimeFully(cdo, dt, getTimezone());
+    ExtendedDateTime edt = Converter.convertToDateTime(value);
+    DateTimeCodec.writeDateTimeFully(cdo, edt, getTimezone());
   }
 
   /** {@inheritDoc} */
@@ -71,8 +71,8 @@ public abstract class AbstractDateTimeType extends DataType {
   /** {@inheritDoc} */
   @Override
   protected void encodeProto(CodecDataOutput cdo, Object value) {
-    DateTime dt = Converter.convertToDateTime(value);
-    DateTimeCodec.writeDateTimeProto(cdo, dt, getTimezone());
+    ExtendedDateTime edt = Converter.convertToDateTime(value);
+    DateTimeCodec.writeDateTimeProto(cdo, edt, getTimezone());
   }
 
   @Override

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/DateTimeType.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/DateTimeType.java
@@ -56,10 +56,7 @@ public class DateTimeType extends AbstractDateTimeType {
   private java.sql.Timestamp convertToMysqlDateTime(Object value)
       throws ConvertNotSupportException {
     java.sql.Timestamp result;
-    if (value instanceof Long) {
-      throw new ConvertNotSupportException(value.getClass().getName(), this.getClass().getName());
-      // result = new java.sql.Timestamp((Long) value);
-    } else if (value instanceof String) {
+    if (value instanceof String) {
       result = java.sql.Timestamp.valueOf((String) value);
     } else if (value instanceof java.sql.Date) {
       result = new java.sql.Timestamp(((java.sql.Date) value).getTime());

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/DateTimeType.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/DateTimeType.java
@@ -17,6 +17,7 @@
 
 package com.pingcap.tikv.types;
 
+import com.pingcap.tikv.ExtendedDateTime;
 import com.pingcap.tikv.codec.CodecDataInput;
 import com.pingcap.tikv.exception.ConvertNotSupportException;
 import com.pingcap.tikv.exception.ConvertOverflowException;
@@ -56,7 +57,8 @@ public class DateTimeType extends AbstractDateTimeType {
       throws ConvertNotSupportException {
     java.sql.Timestamp result;
     if (value instanceof Long) {
-      result = new java.sql.Timestamp((Long) value);
+      throw new ConvertNotSupportException(value.getClass().getName(), this.getClass().getName());
+      // result = new java.sql.Timestamp((Long) value);
     } else if (value instanceof String) {
       result = java.sql.Timestamp.valueOf((String) value);
     } else if (value instanceof java.sql.Date) {
@@ -75,17 +77,17 @@ public class DateTimeType extends AbstractDateTimeType {
    */
   @Override
   protected Timestamp decodeNotNull(int flag, CodecDataInput cdi) {
-    DateTime dateTime = decodeDateTime(flag, cdi);
+    ExtendedDateTime extendedDateTime = decodeDateTime(flag, cdi);
     // Even though null is filtered out but data like 0000-00-00 exists
     // according to MySQL JDBC behavior, it's converted to null
-    if (dateTime == null) {
+    if (extendedDateTime == null) {
       return null;
     }
-    return new Timestamp(dateTime.getMillis());
+    return extendedDateTime.toTimeStamp();
   }
 
   @Override
   public DateTime getOriginDefaultValueNonNull(String value, long version) {
-    return Converter.convertToDateTime(value);
+    return Converter.convertToDateTime(value).getDateTime();
   }
 }


### PR DESCRIPTION
let joda's DateTime hold micro second

close https://github.com/pingcap/tispark/issues/770