### PR TITLE
fix count error, if advanceNextResponse is empty, we should read next region

### DIFF
--- a/tikv-client/src/main/java/com/pingcap/tikv/operation/iterator/DAGIterator.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/operation/iterator/DAGIterator.java
@@ -131,14 +131,16 @@ public abstract class DAGIterator<T> extends CoprocessIterator<T> {
    * @return
    */
   private boolean readNextRegionChunks() {
-    while (true) {
-      if (eof || regionTasks == null || taskIndex >= regionTasks.size()) {
-        return false;
-      }
+    while (hasNextRegionTask()) {
       if (doReadNextRegionChunks()) {
         return true;
       }
     }
+    return false;
+  }
+
+  private boolean hasNextRegionTask() {
+    return !(eof || regionTasks == null || taskIndex >= regionTasks.size());
   }
 
   private boolean doReadNextRegionChunks() {

--- a/tikv-client/src/main/java/com/pingcap/tikv/operation/iterator/DAGIterator.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/operation/iterator/DAGIterator.java
@@ -133,16 +133,12 @@ public abstract class DAGIterator<T> extends CoprocessIterator<T> {
       } // else {
       // if doReadNextRegionChunks returns false
       // readNextRegionChunks should not just return false
-      // readNextRegionChunks should read next region chunks
+      // readNextRegionChunks should continue read next region chunks
       // }
     }
   }
 
   private boolean doReadNextRegionChunks() {
-    if (eof || regionTasks == null || taskIndex >= regionTasks.size()) {
-      return false;
-    }
-
     try {
       switch (pushDownType) {
         case STREAMING:

--- a/tikv-client/src/main/java/com/pingcap/tikv/operation/iterator/DAGIterator.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/operation/iterator/DAGIterator.java
@@ -124,6 +124,21 @@ public abstract class DAGIterator<T> extends CoprocessIterator<T> {
   }
 
   private boolean readNextRegionChunks() {
+    while (true) {
+      if (eof || regionTasks == null || taskIndex >= regionTasks.size()) {
+        return false;
+      }
+      if (doReadNextRegionChunks()) {
+        return true;
+      } // else {
+      // if doReadNextRegionChunks returns false
+      // readNextRegionChunks should not just return false
+      // readNextRegionChunks should read next region chunks
+      // }
+    }
+  }
+
+  private boolean doReadNextRegionChunks() {
     if (eof || regionTasks == null || taskIndex >= regionTasks.size()) {
       return false;
     }
@@ -143,11 +158,7 @@ public abstract class DAGIterator<T> extends CoprocessIterator<T> {
     }
 
     taskIndex++;
-    if (advanceNextResponse()) {
-      return true;
-    } else {
-      return readNextRegionChunks();
-    }
+    return advanceNextResponse();
   }
 
   private SelectResponse process(RangeSplitter.RegionTask regionTask) {

--- a/tikv-client/src/main/java/com/pingcap/tikv/operation/iterator/DAGIterator.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/operation/iterator/DAGIterator.java
@@ -123,6 +123,13 @@ public abstract class DAGIterator<T> extends CoprocessIterator<T> {
     return true;
   }
 
+  /**
+   * chunk maybe empty while there is still data transmitting from TiKV. In this case, {@code
+   * readNextRegionChunks} cannot just returns false because the iterator thinks there is no data to
+   * process. This while loop ensures we can drain all possible data transmitting from TiKV.
+   *
+   * @return
+   */
   private boolean readNextRegionChunks() {
     while (true) {
       if (eof || regionTasks == null || taskIndex >= regionTasks.size()) {
@@ -130,11 +137,7 @@ public abstract class DAGIterator<T> extends CoprocessIterator<T> {
       }
       if (doReadNextRegionChunks()) {
         return true;
-      } // else {
-      // if doReadNextRegionChunks returns false
-      // readNextRegionChunks should not just return false
-      // readNextRegionChunks should continue read next region chunks
-      // }
+      }
     }
   }
 

--- a/tikv-client/src/main/java/com/pingcap/tikv/operation/iterator/DAGIterator.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/operation/iterator/DAGIterator.java
@@ -143,7 +143,11 @@ public abstract class DAGIterator<T> extends CoprocessIterator<T> {
     }
 
     taskIndex++;
-    return advanceNextResponse();
+    if (advanceNextResponse()) {
+      return true;
+    } else {
+      return readNextRegionChunks();
+    }
   }
 
   private SelectResponse process(RangeSplitter.RegionTask regionTask) {


### PR DESCRIPTION
closing https://github.com/pingcap/tispark/issues/877

In DATIterator, if advanceNextResponse is empty, we should read next region instead of just return false.