### PR TITLE
support table region split 

### DIFF
--- a/core/src/main/scala/com/pingcap/tispark/TiBatchWrite.scala
+++ b/core/src/main/scala/com/pingcap/tispark/TiBatchWrite.scala
@@ -696,7 +696,8 @@ class TiBatchWrite(@transient val df: DataFrame,
         )
     }
 
-    // this is only used for test
+    // when data to be inserted is too small to do region split, we check is user set region split num.
+    // If so, we do region split as user's intention. This is also useful for writing test case.
     if (options.enableRegionSplit && options.regionSplitNum != 0) {
       tiDBJDBCClient
         .splitTableRegion(

--- a/core/src/main/scala/com/pingcap/tispark/TiBatchWrite.scala
+++ b/core/src/main/scala/com/pingcap/tispark/TiBatchWrite.scala
@@ -694,6 +694,7 @@ class TiBatchWrite(@transient val df: DataFrame,
             options.regionSplitNum
           )
       } else {
+        //TODO refine this https://github.com/pingcap/tispark/issues/891
         val rowSize = tiTableInfo.getEstimatedRowSizeInByte
         //TODO: replace 96 with actual value read from pd https://github.com/pingcap/tispark/issues/890
         val regionSplitNum = (wrappedRowRdd.count() * rowSize) / (96 * 1024 * 1024)

--- a/core/src/main/scala/com/pingcap/tispark/TiBatchWrite.scala
+++ b/core/src/main/scala/com/pingcap/tispark/TiBatchWrite.scala
@@ -146,8 +146,8 @@ class TiBatchWrite(@transient val df: DataFrame,
 
     // lock table
     tiDBJDBCClient = new TiDBJDBCClient(TiDBUtils.createConnectionFactory(options.url)())
-    isEnableTableLock = tiDBJDBCClient.isEnableTableLock
-    isEnableSplitRegion = tiDBJDBCClient.isEnableSplitTable
+    isEnableTableLock = TiDBJDBCClient.isEnableTableLock
+    isEnableSplitRegion = TiDBJDBCClient.isEnableSplitTable
     lockTable()
 
     // check schema

--- a/core/src/main/scala/com/pingcap/tispark/TiBatchWrite.scala
+++ b/core/src/main/scala/com/pingcap/tispark/TiBatchWrite.scala
@@ -220,8 +220,6 @@ class TiBatchWrite(@transient val df: DataFrame,
     // currently we only support replace and insert.
     val constraintCheckIsNeeded = handleCol != null || uniqueIndices.nonEmpty
 
-    // TODO: region pre split is time consuming we can async execute region pre split operation
-    // and generate key-value pairs.  Once the split is successful, we can continue insertion.
     val encodedTiRowRDD = if (constraintCheckIsNeeded) {
       val wrappedRowRdd = if (tiTableInfo.isPkHandle) {
         tiRowRdd.map { row =>

--- a/core/src/main/scala/com/pingcap/tispark/TiBatchWrite.scala
+++ b/core/src/main/scala/com/pingcap/tispark/TiBatchWrite.scala
@@ -47,19 +47,13 @@ object TiBatchWrite {
 
   @throws(classOf[NoSuchTableException])
   @throws(classOf[TiBatchWriteException])
-  def writeToTiDB(df: DataFrame,
-                  tiContext: TiContext,
-                  options: TiDBOptions,
-                  regionSplitNumber: Option[Int] = None,
-                  enableRegionPreSplit: Boolean = false): Unit =
-    new TiBatchWrite(df, tiContext, options, regionSplitNumber, enableRegionPreSplit).write()
+  def writeToTiDB(df: DataFrame, tiContext: TiContext, options: TiDBOptions): Unit =
+    new TiBatchWrite(df, tiContext, options).write()
 }
 
 class TiBatchWrite(@transient val df: DataFrame,
                    @transient val tiContext: TiContext,
-                   options: TiDBOptions,
-                   regionSplitNumber: Option[Int],
-                   enableRegionPreSplit: Boolean)
+                   options: TiDBOptions)
     extends Serializable {
   private final val logger = LoggerFactory.getLogger(getClass.getName)
 
@@ -690,16 +684,16 @@ class TiBatchWrite(@transient val df: DataFrame,
 
   private def preSplitTableRegion(minHandle: Long, maxHandle: Long) = {
     // region pre-split
-    if (enableRegionPreSplit && handleCol != null) {
+    if (options.enableRegionPreSplit) {
       logger.info("region pre split is enabled.")
       val regions = getRegions
       if (regions.size < 5) {
         tiDBJDBCClient
           .splitTableRegion(
-            tiDBInfo.getName,
-            tiTableInfo.getName,
-            minHandle,
-            maxHandle,
+            options.database,
+            options.table,
+            0,
+            Int.MaxValue,
             options.regionSplitNum
           )
       }

--- a/core/src/main/scala/com/pingcap/tispark/TiBatchWrite.scala
+++ b/core/src/main/scala/com/pingcap/tispark/TiBatchWrite.scala
@@ -703,7 +703,7 @@ class TiBatchWrite(@transient val df: DataFrame,
         // region split
         if (regionSplitNum > 1) {
           logger.info("region split is enabled.")
-          logger.info("regionSplitNum="+ regionSplitNum)
+          logger.info("regionSplitNum=" + regionSplitNum)
           tiDBJDBCClient
             .splitTableRegion(
               options.database,

--- a/core/src/main/scala/com/pingcap/tispark/TiBatchWrite.scala
+++ b/core/src/main/scala/com/pingcap/tispark/TiBatchWrite.scala
@@ -146,8 +146,8 @@ class TiBatchWrite(@transient val df: DataFrame,
 
     // lock table
     tiDBJDBCClient = new TiDBJDBCClient(TiDBUtils.createConnectionFactory(options.url)())
-    isEnableTableLock = TiDBJDBCClient.isEnableTableLock
-    isEnableSplitRegion = TiDBJDBCClient.isEnableSplitTable
+    isEnableTableLock = tiDBJDBCClient.isEnableTableLock
+    isEnableSplitRegion = tiDBJDBCClient.isEnableSplitTable
     lockTable()
 
     // check schema
@@ -695,6 +695,7 @@ class TiBatchWrite(@transient val df: DataFrame,
           )
       } else {
         val rowSize = tiTableInfo.getEstimatedRowSizeInByte
+        //TODO: replace 96 with actual value read from pd https://github.com/pingcap/tispark/issues/890
         val regionSplitNum = (wrappedRowRdd.count() * rowSize) / (96 * 1024 * 1024)
         val minHandle = wrappedRowRdd.min().handle
         val maxHandle = wrappedRowRdd.max().handle

--- a/core/src/main/scala/com/pingcap/tispark/TiBatchWrite.scala
+++ b/core/src/main/scala/com/pingcap/tispark/TiBatchWrite.scala
@@ -683,8 +683,8 @@ class TiBatchWrite(@transient val df: DataFrame,
   private def splitTableRegion(wrappedRowRdd: RDD[WrappedRow]) = {
     // when data to be inserted is too small to do region split, we check is user set region split num.
     // If so, we do region split as user's intention. This is also useful for writing test case.
-    if (options.enableRegionSplit) {
-      if (options.regionSplitNum != 0 && isEnableSplitRegion) {
+    if (options.enableRegionSplit && isEnableSplitRegion) {
+      if (options.regionSplitNum != 0) {
         tiDBJDBCClient
           .splitTableRegion(
             options.database,
@@ -700,8 +700,9 @@ class TiBatchWrite(@transient val df: DataFrame,
         val minHandle = wrappedRowRdd.min().handle
         val maxHandle = wrappedRowRdd.max().handle
         // region split
-        if (regionSplitNum > 1 && isEnableSplitRegion) {
+        if (regionSplitNum > 1) {
           logger.info("region split is enabled.")
+          logger.info("regionSplitNum="+ regionSplitNum)
           tiDBJDBCClient
             .splitTableRegion(
               options.database,

--- a/core/src/main/scala/com/pingcap/tispark/TiConfigConst.scala
+++ b/core/src/main/scala/com/pingcap/tispark/TiConfigConst.scala
@@ -39,7 +39,6 @@ object TiConfigConst {
   val DB_PREFIX: String = "spark.tispark.db_prefix"
   val WRITE_ALLOW_SPARK_SQL: String = "spark.tispark.write.allow_spark_sql"
   val WRITE_ENABLE: String = "spark.tispark.write.enable"
-
   val SNAPSHOT_ISOLATION_LEVEL: String = "SI"
   val READ_COMMITTED_ISOLATION_LEVEL: String = "RC"
 }

--- a/core/src/main/scala/com/pingcap/tispark/TiConfigConst.scala
+++ b/core/src/main/scala/com/pingcap/tispark/TiConfigConst.scala
@@ -39,6 +39,7 @@ object TiConfigConst {
   val DB_PREFIX: String = "spark.tispark.db_prefix"
   val WRITE_ALLOW_SPARK_SQL: String = "spark.tispark.write.allow_spark_sql"
   val WRITE_ENABLE: String = "spark.tispark.write.enable"
+
   val SNAPSHOT_ISOLATION_LEVEL: String = "SI"
   val READ_COMMITTED_ISOLATION_LEVEL: String = "RC"
 }

--- a/core/src/main/scala/com/pingcap/tispark/TiDBOptions.scala
+++ b/core/src/main/scala/com/pingcap/tispark/TiDBOptions.scala
@@ -67,6 +67,9 @@ class TiDBOptions(@transient val parameters: CaseInsensitiveMap[String]) extends
 
   val regionSplitNum: Int = parameters.getOrElse(TIDB_REGION_SPLIT_NUM, "3").toInt
 
+  val enableRegionPreSplit: Boolean =
+    parameters.getOrElse(TIDB_ENABLE_REGION_PRE_SPLIT, "false").toBoolean
+
   // ------------------------------------------------------------
   // Calculated parameters
   // ------------------------------------------------------------
@@ -108,4 +111,5 @@ object TiDBOptions {
   val TIDB_REPLACE: String = newOption("replace")
   val TIDB_SKIP_COMMIT_SECONDARY_KEY: String = newOption("skipCommitSecondaryKey")
   val TIDB_REGION_SPLIT_NUM: String = newOption("regionSplitNum")
+  val TIDB_ENABLE_REGION_PRE_SPLIT: String = newOption("enableRegionPreSplit")
 }

--- a/core/src/main/scala/com/pingcap/tispark/TiDBOptions.scala
+++ b/core/src/main/scala/com/pingcap/tispark/TiDBOptions.scala
@@ -65,7 +65,7 @@ class TiDBOptions(@transient val parameters: CaseInsensitiveMap[String]) extends
   val skipCommitSecondaryKey: Boolean =
     parameters.getOrElse(TIDB_SKIP_COMMIT_SECONDARY_KEY, "true").toBoolean
 
-  val regionSplitNum: Int = parameters.getOrElse(TIDB_REGION_SPLIT_NUM, "3").toInt
+  val regionSplitNum: Int = parameters.getOrElse(TIDB_REGION_SPLIT_NUM, "0").toInt
 
   val enableRegionSplit: Boolean =
     parameters.getOrElse(TIDB_ENABLE_REGION_SPLIT, "true").toBoolean

--- a/core/src/main/scala/com/pingcap/tispark/TiDBOptions.scala
+++ b/core/src/main/scala/com/pingcap/tispark/TiDBOptions.scala
@@ -65,7 +65,7 @@ class TiDBOptions(@transient val parameters: CaseInsensitiveMap[String]) extends
   val skipCommitSecondaryKey: Boolean =
     parameters.getOrElse(TIDB_SKIP_COMMIT_SECONDARY_KEY, "true").toBoolean
 
-  val sampleFraction: Double = parameters.getOrElse(TIDB_SAMPLE_FRACTION, "0.01").toDouble
+  val regionSplitNum: Int = parameters.getOrElse(TIDB_REGION_SPLIT_NUM, "3").toInt
 
   // ------------------------------------------------------------
   // Calculated parameters
@@ -106,6 +106,6 @@ object TiDBOptions {
   val TIDB_DATABASE: String = newOption("database")
   val TIDB_TABLE: String = newOption("table")
   val TIDB_REPLACE: String = newOption("replace")
-  val TIDB_SKIP_COMMIT_SECONDARY_KEY = newOption("skipCommitSecondaryKey")
-  val TIDB_SAMPLE_FRACTION = newOption("sampleFraction")
+  val TIDB_SKIP_COMMIT_SECONDARY_KEY: String = newOption("skipCommitSecondaryKey")
+  val TIDB_REGION_SPLIT_NUM: String = newOption("regionSplitNum")
 }

--- a/core/src/main/scala/com/pingcap/tispark/TiDBOptions.scala
+++ b/core/src/main/scala/com/pingcap/tispark/TiDBOptions.scala
@@ -70,6 +70,8 @@ class TiDBOptions(@transient val parameters: CaseInsensitiveMap[String]) extends
   val enableRegionSplit: Boolean =
     parameters.getOrElse(TIDB_ENABLE_REGION_SPLIT, "false").toBoolean
 
+  val regionSize: Int = parameters.getOrElse(TIDB_REGION_SIZE, "96").toInt
+
   // ------------------------------------------------------------
   // Calculated parameters
   // ------------------------------------------------------------
@@ -112,4 +114,5 @@ object TiDBOptions {
   val TIDB_SKIP_COMMIT_SECONDARY_KEY: String = newOption("skipCommitSecondaryKey")
   val TIDB_REGION_SPLIT_NUM: String = newOption("regionSplitNum")
   val TIDB_ENABLE_REGION_SPLIT: String = newOption("enableRegionPreSplit")
+  val TIDB_REGION_SIZE: String = newOption("regionSize")
 }

--- a/core/src/main/scala/com/pingcap/tispark/TiDBOptions.scala
+++ b/core/src/main/scala/com/pingcap/tispark/TiDBOptions.scala
@@ -67,8 +67,8 @@ class TiDBOptions(@transient val parameters: CaseInsensitiveMap[String]) extends
 
   val regionSplitNum: Int = parameters.getOrElse(TIDB_REGION_SPLIT_NUM, "3").toInt
 
-  val enableRegionPreSplit: Boolean =
-    parameters.getOrElse(TIDB_ENABLE_REGION_PRE_SPLIT, "false").toBoolean
+  val enableRegionSplit: Boolean =
+    parameters.getOrElse(TIDB_ENABLE_REGION_SPLIT, "false").toBoolean
 
   // ------------------------------------------------------------
   // Calculated parameters
@@ -111,5 +111,5 @@ object TiDBOptions {
   val TIDB_REPLACE: String = newOption("replace")
   val TIDB_SKIP_COMMIT_SECONDARY_KEY: String = newOption("skipCommitSecondaryKey")
   val TIDB_REGION_SPLIT_NUM: String = newOption("regionSplitNum")
-  val TIDB_ENABLE_REGION_PRE_SPLIT: String = newOption("enableRegionPreSplit")
+  val TIDB_ENABLE_REGION_SPLIT: String = newOption("enableRegionPreSplit")
 }

--- a/core/src/main/scala/com/pingcap/tispark/TiDBOptions.scala
+++ b/core/src/main/scala/com/pingcap/tispark/TiDBOptions.scala
@@ -68,9 +68,7 @@ class TiDBOptions(@transient val parameters: CaseInsensitiveMap[String]) extends
   val regionSplitNum: Int = parameters.getOrElse(TIDB_REGION_SPLIT_NUM, "3").toInt
 
   val enableRegionSplit: Boolean =
-    parameters.getOrElse(TIDB_ENABLE_REGION_SPLIT, "false").toBoolean
-
-  val regionSize: Int = parameters.getOrElse(TIDB_REGION_SIZE, "96").toInt
+    parameters.getOrElse(TIDB_ENABLE_REGION_SPLIT, "true").toBoolean
 
   // ------------------------------------------------------------
   // Calculated parameters
@@ -113,6 +111,5 @@ object TiDBOptions {
   val TIDB_REPLACE: String = newOption("replace")
   val TIDB_SKIP_COMMIT_SECONDARY_KEY: String = newOption("skipCommitSecondaryKey")
   val TIDB_REGION_SPLIT_NUM: String = newOption("regionSplitNum")
-  val TIDB_ENABLE_REGION_SPLIT: String = newOption("enableRegionPreSplit")
-  val TIDB_REGION_SIZE: String = newOption("regionSize")
+  val TIDB_ENABLE_REGION_SPLIT: String = newOption("enableRegionSplit")
 }

--- a/core/src/main/scala/com/pingcap/tispark/examples/TiBatchWritePressureTest.scala
+++ b/core/src/main/scala/com/pingcap/tispark/examples/TiBatchWritePressureTest.scala
@@ -32,9 +32,6 @@ object TiBatchWritePressureTest {
     val outputDatabase = args(2)
     val outputTable = args(3)
 
-    val regionSplitNumber = if (args.length >= 5) Some(args(4).toInt) else None
-    val enableRegionPreSplit = if (args.length >= 6) args(5).toBoolean else false
-
     // init
     val start = System.currentTimeMillis()
     val sparkConf = new SparkConf()
@@ -60,7 +57,7 @@ object TiBatchWritePressureTest {
     val options = new TiDBOptions(
       sparkConf.getAll.toMap ++ Map("database" -> outputDatabase, "table" -> outputTable)
     )
-    TiBatchWrite.writeToTiDB(df, ti, options, regionSplitNumber, enableRegionPreSplit)
+    TiBatchWrite.writeToTiDB(df, ti, options)
 
     // time
     val end = System.currentTimeMillis()

--- a/core/src/main/scala/com/pingcap/tispark/examples/TiBatchWriteRandomDataTest.scala
+++ b/core/src/main/scala/com/pingcap/tispark/examples/TiBatchWriteRandomDataTest.scala
@@ -32,9 +32,6 @@ object TiBatchWriteRandomDataTest {
     val outputTable = args(1)
     val size = args(2).toInt
 
-    val enableRegionPreSplit = false
-    val regionSplitNumber = None
-
     // init
     val start = System.currentTimeMillis()
     val sparkConf = new SparkConf()
@@ -80,9 +77,7 @@ object TiBatchWriteRandomDataTest {
     TiBatchWrite.writeToTiDB(
       df,
       ti,
-      options,
-      regionSplitNumber,
-      enableRegionPreSplit
+      options
     )
 
     // time

--- a/core/src/test/scala/com/pingcap/tispark/datasource/RegionSplitSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/RegionSplitSuite.scala
@@ -12,7 +12,7 @@ class RegionSplitSuite extends BaseDataSourceTest("region_split_test") {
     )
   )
 
-  test("region pre split test") {
+  test("region split test") {
     // do not test this case on tidb which does not support split region
     if (!isEnableSplitRegion) {
       cancel

--- a/core/src/test/scala/com/pingcap/tispark/datasource/RegionSplitSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/RegionSplitSuite.scala
@@ -4,7 +4,7 @@ import com.pingcap.tikv.TiBatchWriteUtils
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types.{IntegerType, StructField, StructType}
 
-class RegionSplitSuite extends BaseDataSourceTest("region_pre_split_test") {
+class RegionSplitSuite extends BaseDataSourceTest("region_split_test") {
   private val row1 = Row(1)
   private val schema = StructType(
     List(

--- a/core/src/test/scala/com/pingcap/tispark/datasource/RegionSplitSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/RegionSplitSuite.scala
@@ -13,6 +13,11 @@ class RegionSplitSuite extends BaseDataSourceTest("region_pre_split_test") {
   )
 
   test("region pre split test") {
+    // do test this case on tidb which does not support split region
+    if (!isEnableSplitRegion) {
+      cancel
+    }
+
     dropTable()
     jdbcUpdate(
       s"CREATE TABLE  $dbtable ( `a` int(11) DEFAULT NULL) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin"

--- a/core/src/test/scala/com/pingcap/tispark/datasource/RegionSplitSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/RegionSplitSuite.scala
@@ -13,7 +13,7 @@ class RegionSplitSuite extends BaseDataSourceTest("region_pre_split_test") {
   )
 
   test("region pre split test") {
-    // do test this case on tidb which does not support split region
+    // do not test this case on tidb which does not support split region
     if (!isEnableSplitRegion) {
       cancel
     }

--- a/core/src/test/scala/com/pingcap/tispark/datasource/RegionSplitSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/RegionSplitSuite.scala
@@ -14,7 +14,9 @@ class RegionSplitSuite extends BaseDataSourceTest("region_pre_split_test") {
 
   test("region pre split test") {
     dropTable()
-    jdbcUpdate(s"CREATE TABLE  $dbtable ( `a` int(11) DEFAULT NULL) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin")
+    jdbcUpdate(
+      s"CREATE TABLE  $dbtable ( `a` int(11) DEFAULT NULL) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin"
+    )
 
     val dbName = "tidb_tispark_test"
     val tableName = "region_pre_split_test"

--- a/core/src/test/scala/com/pingcap/tispark/datasource/RegionSplitSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/RegionSplitSuite.scala
@@ -1,0 +1,28 @@
+package com.pingcap.tispark.datasource
+
+import com.pingcap.tikv.TiBatchWriteUtils
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.types.{IntegerType, StructField, StructType}
+
+class RegionSplitSuite extends BaseDataSourceTest("region_pre_split_test") {
+  private val row1 = Row(1)
+  private val schema = StructType(
+    List(
+      StructField("a", IntegerType)
+    )
+  )
+
+  test("region pre split test") {
+    dropTable()
+    jdbcUpdate(s"CREATE TABLE  $dbtable ( `a` int(11) DEFAULT NULL) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin")
+
+    val dbName = "tidb_tispark_test"
+    val tableName = "region_pre_split_test"
+    val options = Some(Map("enableRegionPreSplit" -> "true"))
+    tidbWrite(List(row1), schema, options)
+    val tiTableInfo =
+      ti.tiSession.getCatalog.getTable(dbName, tableName)
+    val regionsNum = TiBatchWriteUtils.getRegionsByTable(ti.tiSession, tiTableInfo).size()
+    assert(regionsNum == 3)
+  }
+}

--- a/core/src/test/scala/com/pingcap/tispark/datasource/RegionSplitSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/RegionSplitSuite.scala
@@ -23,12 +23,12 @@ class RegionSplitSuite extends BaseDataSourceTest("region_pre_split_test") {
       s"CREATE TABLE  $dbtable ( `a` int(11) DEFAULT NULL) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin"
     )
 
-    val dbName = "tidb_tispark_test"
-    val tableName = "region_pre_split_test"
     val options = Some(Map("enableRegionSplit" -> "true", "regionSplitNum" -> "3"))
+
     tidbWrite(List(row1), schema, options)
+
     val tiTableInfo =
-      ti.tiSession.getCatalog.getTable(dbName, tableName)
+      ti.tiSession.getCatalog.getTable(dbPrefix + database, table)
     val regionsNum = TiBatchWriteUtils.getRegionsByTable(ti.tiSession, tiTableInfo).size()
     assert(regionsNum == 3)
   }

--- a/core/src/test/scala/com/pingcap/tispark/datasource/RegionSplitSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/RegionSplitSuite.scala
@@ -20,7 +20,7 @@ class RegionSplitSuite extends BaseDataSourceTest("region_pre_split_test") {
 
     val dbName = "tidb_tispark_test"
     val tableName = "region_pre_split_test"
-    val options = Some(Map("enableRegionPreSplit" -> "true"))
+    val options = Some(Map("enableRegionSplit" -> "true", "regionSplitNum" -> "3"))
     tidbWrite(List(row1), schema, options)
     val tiTableInfo =
       ti.tiSession.getCatalog.getTable(dbName, tableName)

--- a/core/src/test/scala/com/pingcap/tispark/datasource/RowIDAllocatorSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/RowIDAllocatorSuite.scala
@@ -10,7 +10,7 @@ class RowIDAllocatorSuite extends BaseTiSparkTest {
                        |  `a` int(11) DEFAULT NULL
                        |) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin
       """.stripMargin)
-    refreshConnections()
+
     val dbName = "tidb_tispark_test"
     val tableName = "rowid_allocator"
     val tiDBInfo = ti.tiSession.getCatalog.getDatabase(dbName)
@@ -28,7 +28,7 @@ class RowIDAllocatorSuite extends BaseTiSparkTest {
                        |  `a` int(11) DEFAULT NULL
                        |) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin
       """.stripMargin)
-    refreshConnections()
+
     val dbName = "tidb_tispark_test"
     val tableName = "t"
     val tiDBInfo = ti.tiSession.getCatalog.getDatabase(dbName)

--- a/core/src/test/scala/org/apache/spark/sql/BaseTiSparkTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/BaseTiSparkTest.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql
 import java.sql.Statement
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.pingcap.tikv.TiDBJDBCClient
 import org.apache.spark.sql.catalyst.analysis.NoSuchDatabaseException
 import org.apache.spark.sql.catalyst.catalog.TiSessionCatalog
 import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions
@@ -37,13 +38,9 @@ class BaseTiSparkTest extends QueryTest with SharedSQLContext {
 
   private def tiCatalog = ti.tiCatalog
 
-  protected def isEnableTableLock: Boolean = {
-    val configJSON = queryTiDBViaJDBC("select @@tidb_config;").head.head.toString
-    val objectMapper = new ObjectMapper
-    val configMap = objectMapper.readValue(configJSON, classOf[java.util.HashMap[String, Object]])
-    val enableTableLock = configMap.getOrDefault("enable-table-lock", Boolean.box(false))
-    enableTableLock.asInstanceOf[Boolean]
-  }
+  protected def isEnableTableLock: Boolean = TiDBJDBCClient.isEnableTableLock
+
+  protected def isEnableSplitRegion: Boolean = TiDBJDBCClient.isEnableSplitTable
 
   protected def queryViaTiSpark(query: String): List[List[Any]] = {
     val df = sql(query)

--- a/core/src/test/scala/org/apache/spark/sql/BaseTiSparkTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/BaseTiSparkTest.scala
@@ -21,6 +21,7 @@ import java.sql.Statement
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.pingcap.tikv.TiDBJDBCClient
+import com.pingcap.tispark.TiDBUtils
 import org.apache.spark.sql.catalyst.analysis.NoSuchDatabaseException
 import org.apache.spark.sql.catalyst.catalog.TiSessionCatalog
 import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions
@@ -38,9 +39,17 @@ class BaseTiSparkTest extends QueryTest with SharedSQLContext {
 
   private def tiCatalog = ti.tiCatalog
 
-  protected def isEnableTableLock: Boolean = TiDBJDBCClient.isEnableTableLock
+  protected def isEnableTableLock: Boolean = {
+    val conn = TiDBUtils.createConnectionFactory(jdbcUrl)()
+    val tiDBJDBCClient = new TiDBJDBCClient(conn)
+    tiDBJDBCClient.isEnableTableLock
+  }
 
-  protected def isEnableSplitRegion: Boolean = TiDBJDBCClient.isEnableSplitTable
+  protected def isEnableSplitRegion: Boolean = {
+    val conn = TiDBUtils.createConnectionFactory(jdbcUrl)()
+    val tiDBJDBCClient = new TiDBJDBCClient(conn)
+    tiDBJDBCClient.isEnableTableLock
+  }
 
   protected def queryViaTiSpark(query: String): List[List[Any]] = {
     val df = sql(query)

--- a/docs/datasource_api_userguide.md
+++ b/docs/datasource_api_userguide.md
@@ -214,9 +214,9 @@ The following is TiDB-specific options, which can be passed in through `TiDBOpti
 | spark.tispark.tidb.password | tidb.password | true | TiDB Password | - |
 | database | - | true | TiDB Database | - |
 | table | - | true | TiDB Table | - |
-| deduplicate | - | false | Duplicate rows (same primary key) will be removed from DataFrame before writing to TiDB. Only one row with same primary key will be written successfully. | false |
 | skipCommitSecondaryKey | - | false | skip commit secondary key | false |
-| sampleFraction | - | false | sample fraction, from 0 to 1 | 0.01 |
+| enableRegionSplit | - | true | do region split to avoid hot region during insertion
+| regionSplitNum | - | 3 | user defined region split number during insertion
 
 TiSpark's common options can also be passed in, e.g. `spark.tispark.plan.allow_agg_pushdown`, `spark.tispark.plan.allow_index_read`, etc.
 

--- a/docs/datasource_api_userguide.md
+++ b/docs/datasource_api_userguide.md
@@ -214,7 +214,7 @@ The following is TiDB-specific options, which can be passed in through `TiDBOpti
 | spark.tispark.tidb.password | tidb.password | true | TiDB Password | - |
 | database | - | true | TiDB Database | - |
 | table | - | true | TiDB Table | - |
-| skipCommitSecondaryKey | - | false | skip commit secondary key | false |
+| skipCommitSecondaryKey | - | false | skip commit secondary key | true |
 | enableRegionSplit | - | false | do region split to avoid hot region during insertion | true|
 | regionSplitNum | - | false | user defined region split number during insertion | 0 |
 | replace | - | false | define the behavior of append. | false| 

--- a/docs/datasource_api_userguide.md
+++ b/docs/datasource_api_userguide.md
@@ -215,8 +215,9 @@ The following is TiDB-specific options, which can be passed in through `TiDBOpti
 | database | - | true | TiDB Database | - |
 | table | - | true | TiDB Table | - |
 | skipCommitSecondaryKey | - | false | skip commit secondary key | false |
-| enableRegionSplit | - | true | do region split to avoid hot region during insertion
-| regionSplitNum | - | 3 | user defined region split number during insertion
+| enableRegionSplit | - | false | do region split to avoid hot region during insertion | true|
+| regionSplitNum | - | false | user defined region split number during insertion | 0 |
+| replace | - | false | define the behavior of append. | false| 
 
 TiSpark's common options can also be passed in, e.g. `spark.tispark.plan.allow_agg_pushdown`, `spark.tispark.plan.allow_index_read`, etc.
 

--- a/tikv-client/src/main/java/com/pingcap/tikv/TiDBJDBCClient.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/TiDBJDBCClient.java
@@ -68,6 +68,19 @@ public class TiDBJDBCClient implements AutoCloseable {
     }
   }
 
+  // SPLIT TABLE table_name [INDEX index_name] BETWEEN (lower_value) AND (upper_value) REGIONS
+  // region_num
+  public boolean splitTableRegion(
+      String dbName, String tblName, long minVal, long maxVal, int regionNum) throws SQLException {
+    try (Statement tidbStmt = connection.createStatement()) {
+      String sql =
+          String.format(
+              "split table `%s.%s` between (%d) and (%d) regions %d",
+              dbName, tblName, minVal, maxVal, regionNum);
+      return tidbStmt.execute(sql);
+    }
+  }
+
   public boolean isClosed() throws SQLException {
     return connection.isClosed();
   }

--- a/tikv-client/src/main/java/com/pingcap/tikv/TiDBJDBCClient.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/TiDBJDBCClient.java
@@ -75,7 +75,7 @@ public class TiDBJDBCClient implements AutoCloseable {
     try (Statement tidbStmt = connection.createStatement()) {
       String sql =
           String.format(
-              "split table `%s.%s` between (%d) and (%d) regions %d",
+              "split table %s.%s between (%d) and (%d) regions %d",
               dbName, tblName, minVal, maxVal, regionNum);
       return tidbStmt.execute(sql);
     }

--- a/tikv-client/src/main/java/com/pingcap/tikv/TiDBJDBCClient.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/TiDBJDBCClient.java
@@ -71,7 +71,7 @@ public class TiDBJDBCClient implements AutoCloseable {
   // SPLIT TABLE table_name [INDEX index_name] BETWEEN (lower_value) AND (upper_value) REGIONS
   // region_num
   public boolean splitTableRegion(
-      String dbName, String tblName, long minVal, long maxVal, int regionNum) throws SQLException {
+      String dbName, String tblName, long minVal, long maxVal, long regionNum) throws SQLException {
     try (Statement tidbStmt = connection.createStatement()) {
       String sql =
           String.format(

--- a/tikv-client/src/main/java/com/pingcap/tikv/TiDBJDBCClient.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/TiDBJDBCClient.java
@@ -25,7 +25,7 @@ import java.util.List;
 import java.util.Map;
 
 public class TiDBJDBCClient implements AutoCloseable {
-  private static Connection connection;
+  private Connection connection;
 
   private static final String UNLOCK_TABLES_SQL = "unlock tables";
   private static final String SELECT_TIDB_CONFIG_SQL = "select @@tidb_config";
@@ -38,8 +38,8 @@ public class TiDBJDBCClient implements AutoCloseable {
     this.connection = connection;
   }
 
-  public static boolean isEnableTableLock() throws IOException, SQLException {
-    Map<String, Object> configMap = readConfMapFronTiDB();
+  public boolean isEnableTableLock() throws IOException, SQLException {
+    Map<String, Object> configMap = readConfMapFromTiDB();
     Object enableTableLock =
         configMap.getOrDefault(ENABLE_TABLE_LOCK_KEY, ENABLE_TABLE_LOCK_DEFAULT);
     return (Boolean) enableTableLock;
@@ -67,7 +67,7 @@ public class TiDBJDBCClient implements AutoCloseable {
     }
   }
 
-  private static Map<String, Object> readConfMapFronTiDB() throws SQLException, IOException {
+  private Map<String, Object> readConfMapFromTiDB() throws SQLException, IOException {
     String configJSON = (String) queryTiDBViaJDBC(SELECT_TIDB_CONFIG_SQL).get(0).get(0);
     ObjectMapper objectMapper = new ObjectMapper();
     TypeReference<HashMap<String, Object>> typeRef =
@@ -75,8 +75,8 @@ public class TiDBJDBCClient implements AutoCloseable {
     return objectMapper.readValue(configJSON, typeRef);
   }
 
-  public static boolean isEnableSplitTable() throws IOException, SQLException {
-    Map<String, Object> configMap = readConfMapFronTiDB();
+  public boolean isEnableSplitTable() throws IOException, SQLException {
+    Map<String, Object> configMap = readConfMapFromTiDB();
     Object splitTable = configMap.getOrDefault(ENABLE_SPLIT_TABLE_KEY, ENABLE_SPLIT_TABLE_DEFAULT);
     return (Boolean) splitTable;
   }
@@ -103,7 +103,7 @@ public class TiDBJDBCClient implements AutoCloseable {
     connection.close();
   }
 
-  private static List<List<Object>> queryTiDBViaJDBC(String query) throws SQLException {
+  private List<List<Object>> queryTiDBViaJDBC(String query) throws SQLException {
     ArrayList<List<Object>> result = new ArrayList<>();
 
     try (Statement tidbStmt = connection.createStatement()) {

--- a/tikv-client/src/main/java/com/pingcap/tikv/TiDBJDBCClient.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/TiDBJDBCClient.java
@@ -25,7 +25,7 @@ import java.util.List;
 import java.util.Map;
 
 public class TiDBJDBCClient implements AutoCloseable {
-  private Connection connection;
+  private static Connection connection;
 
   private static final String UNLOCK_TABLES_SQL = "unlock tables";
   private static final String SELECT_TIDB_CONFIG_SQL = "select @@tidb_config";
@@ -38,7 +38,7 @@ public class TiDBJDBCClient implements AutoCloseable {
     this.connection = connection;
   }
 
-  public boolean isEnableTableLock() throws IOException, SQLException {
+  public static boolean isEnableTableLock() throws IOException, SQLException {
     Map<String, Object> configMap = readConfMapFronTiDB();
     Object enableTableLock =
         configMap.getOrDefault(ENABLE_TABLE_LOCK_KEY, ENABLE_TABLE_LOCK_DEFAULT);
@@ -67,7 +67,7 @@ public class TiDBJDBCClient implements AutoCloseable {
     }
   }
 
-  private Map<String, Object> readConfMapFronTiDB() throws SQLException, IOException {
+  private static Map<String, Object> readConfMapFronTiDB() throws SQLException, IOException {
     String configJSON = (String) queryTiDBViaJDBC(SELECT_TIDB_CONFIG_SQL).get(0).get(0);
     ObjectMapper objectMapper = new ObjectMapper();
     TypeReference<HashMap<String, Object>> typeRef =
@@ -75,7 +75,7 @@ public class TiDBJDBCClient implements AutoCloseable {
     return objectMapper.readValue(configJSON, typeRef);
   }
 
-  public boolean isEnableSplitTable() throws IOException, SQLException {
+  public static boolean isEnableSplitTable() throws IOException, SQLException {
     Map<String, Object> configMap = readConfMapFronTiDB();
     Object splitTable = configMap.getOrDefault(ENABLE_SPLIT_TABLE_KEY, ENABLE_SPLIT_TABLE_DEFAULT);
     return (Boolean) splitTable;
@@ -103,7 +103,7 @@ public class TiDBJDBCClient implements AutoCloseable {
     connection.close();
   }
 
-  private List<List<Object>> queryTiDBViaJDBC(String query) throws SQLException {
+  private static List<List<Object>> queryTiDBViaJDBC(String query) throws SQLException {
     ArrayList<List<Object>> result = new ArrayList<>();
 
     try (Statement tidbStmt = connection.createStatement()) {

--- a/tikv-client/src/main/java/com/pingcap/tikv/meta/TiTableInfo.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/meta/TiTableInfo.java
@@ -44,7 +44,7 @@ public class TiTableInfo implements Serializable {
   private final long maxColumnId;
   private final long maxIndexId;
   private final long oldSchemaId;
-  private final long columnSize; // estimated column size
+  private final long rowSize; // estimated row size
   private final TiPartitionInfo partitionInfo;
   private final TiColumnInfo primaryKeyColumn;
 
@@ -69,7 +69,7 @@ public class TiTableInfo implements Serializable {
     this.collate = collate;
     this.columns = ImmutableList.copyOf(requireNonNull(columns, "columns is null"));
     // TODO: Use more precise predication according to types
-    this.columnSize = columns.stream().mapToLong(TiColumnInfo::getSize).sum();
+    this.rowSize = columns.stream().mapToLong(TiColumnInfo::getSize).sum();
     this.pkIsHandle = pkIsHandle;
     this.indices = indices != null ? ImmutableList.copyOf(indices) : ImmutableList.of();
     this.indices.forEach(x -> x.calculateIndexSize(columns));
@@ -132,8 +132,8 @@ public class TiTableInfo implements Serializable {
     return columns;
   }
 
-  public long getColumnSize() {
-    return columnSize;
+  public long getEstimatedRowSizeInByte() {
+    return rowSize;
   }
 
   public TiColumnInfo getColumn(int offset) {

--- a/tikv-client/src/main/java/com/pingcap/tikv/predicates/TiKVScanAnalyzer.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/predicates/TiKVScanAnalyzer.java
@@ -281,7 +281,7 @@ public class TiKVScanAnalyzer {
     }
 
     // table name and columns
-    long tableColSize = table.getColumnSize() + TABLE_PREFIX_SIZE;
+    long tableColSize = table.getEstimatedRowSizeInByte() + TABLE_PREFIX_SIZE;
 
     if (index == null || index.isFakePrimaryKey()) {
       planBuilder


### PR DESCRIPTION
In this PR, we start using tidb's api to do region presplit. 

We remove original region split and scatter logic and some parameters. 

A test case is added to ensure code works as expected. 