### PR TITLE
add lock ttl as parameter

### DIFF
--- a/core/src/main/scala/com/pingcap/tispark/TiBatchWrite.scala
+++ b/core/src/main/scala/com/pingcap/tispark/TiBatchWrite.scala
@@ -317,14 +317,15 @@ class TiBatchWrite(@transient val df: DataFrame,
     logger.info(s"startTS: $startTs")
 
     // driver primary pre-write
-    val ti2PCClient = new TwoPhaseCommitter(tiConf, startTs, options.lockTTLSeconds)
+    val ti2PCClient = new TwoPhaseCommitter(tiConf, startTs, options.lockTTLSeconds * 1000)
     val prewritePrimaryBackoff =
       ConcreteBackOffer.newCustomBackOff(BackOffer.BATCH_PREWRITE_BACKOFF)
     ti2PCClient.prewritePrimaryKey(prewritePrimaryBackoff, primaryKey.bytes, primaryRow)
 
     // executors secondary pre-write
     finalWriteRDD.foreachPartition { iterator =>
-      val ti2PCClientOnExecutor = new TwoPhaseCommitter(tiConf, startTs, options.lockTTLSeconds)
+      val ti2PCClientOnExecutor =
+        new TwoPhaseCommitter(tiConf, startTs, options.lockTTLSeconds * 1000)
 
       val pairs = iterator.map {
         case (key, row) =>

--- a/core/src/main/scala/com/pingcap/tispark/TiBatchWrite.scala
+++ b/core/src/main/scala/com/pingcap/tispark/TiBatchWrite.scala
@@ -317,14 +317,14 @@ class TiBatchWrite(@transient val df: DataFrame,
     logger.info(s"startTS: $startTs")
 
     // driver primary pre-write
-    val ti2PCClient = new TwoPhaseCommitter(tiConf, startTs)
+    val ti2PCClient = new TwoPhaseCommitter(tiConf, startTs, options.lockTTLSeconds)
     val prewritePrimaryBackoff =
       ConcreteBackOffer.newCustomBackOff(BackOffer.BATCH_PREWRITE_BACKOFF)
     ti2PCClient.prewritePrimaryKey(prewritePrimaryBackoff, primaryKey.bytes, primaryRow)
 
     // executors secondary pre-write
     finalWriteRDD.foreachPartition { iterator =>
-      val ti2PCClientOnExecutor = new TwoPhaseCommitter(tiConf, startTs)
+      val ti2PCClientOnExecutor = new TwoPhaseCommitter(tiConf, startTs, options.lockTTLSeconds)
 
       val pairs = iterator.map {
         case (key, row) =>

--- a/core/src/main/scala/com/pingcap/tispark/TiDBOptions.scala
+++ b/core/src/main/scala/com/pingcap/tispark/TiDBOptions.scala
@@ -70,6 +70,8 @@ class TiDBOptions(@transient val parameters: CaseInsensitiveMap[String]) extends
   val enableRegionSplit: Boolean =
     parameters.getOrElse(TIDB_ENABLE_REGION_SPLIT, "true").toBoolean
 
+  val lockTTLSeconds: Long = parameters.getOrElse(TIDB_LOCK_TTL_SECONDS, "3600").toLong
+
   // ------------------------------------------------------------
   // Calculated parameters
   // ------------------------------------------------------------
@@ -112,4 +114,5 @@ object TiDBOptions {
   val TIDB_SKIP_COMMIT_SECONDARY_KEY: String = newOption("skipCommitSecondaryKey")
   val TIDB_REGION_SPLIT_NUM: String = newOption("regionSplitNum")
   val TIDB_ENABLE_REGION_SPLIT: String = newOption("enableRegionSplit")
+  val TIDB_LOCK_TTL_SECONDS: String = newOption("lockTTLSeconds")
 }

--- a/core/src/main/scala/com/pingcap/tispark/TiDBOptions.scala
+++ b/core/src/main/scala/com/pingcap/tispark/TiDBOptions.scala
@@ -63,7 +63,7 @@ class TiDBOptions(@transient val parameters: CaseInsensitiveMap[String]) extends
   // It is an optimize by the nature of 2pc protocol
   // We leave other txn, gc or read to resolve locks.
   val skipCommitSecondaryKey: Boolean =
-    parameters.getOrElse(TIDB_SKIP_COMMIT_SECONDARY_KEY, "true").toBoolean
+    parameters.getOrElse(TIDB_SKIP_COMMIT_SECONDARY_KEY, "false").toBoolean
 
   val regionSplitNum: Int = parameters.getOrElse(TIDB_REGION_SPLIT_NUM, "0").toInt
 

--- a/docs/datasource_api_userguide.md
+++ b/docs/datasource_api_userguide.md
@@ -23,12 +23,12 @@ Since TiDB is a database that supports transaction, TiDB Spark Connector also su
 2. no data in DataFrame will be written to TiDB successfully, if conflicts exist
 3. no partial changes is visible to other session until commit.
 
-## Replace and insert semantics 
-TiSpark only supports `Append` SaveMode. The behavior is controlled by 
+## Replace and insert semantics
+TiSpark only supports `Append` SaveMode. The behavior is controlled by
 `replace` option. The default value is false. In addition, if `replace` is true,
 data to be inserted will be deduplicate before insertion.
 
-If `replace` is true, then 
+If `replace` is true, then
 * if primary key or unique index exists in db, data will be updated
 * if no same primary key or unique index exists, data will be inserted.
 
@@ -38,7 +38,7 @@ If `replace` is false, then
 
 | SaveMode | Support | Semantics |
 | -------- | ------- | --------- |
-| Append | true | TiSpark's `Append` means upsert or insert which is controlled by `replace` option. 
+| Append | true | TiSpark's `Append` means upsert or insert which is controlled by `replace` option.
 | Overwrite | false |  - |
 | ErrorIfExists | false | - |
 | Ignore | false | - |
@@ -205,19 +205,20 @@ df.write
 ## TiDB Options
 The following is TiDB-specific options, which can be passed in through `TiDBOptions` or `SparkConf`.
 
-|    Key    | Short Name | Required | Description | Default |
-| ---------- | --------- | -------- | ----------- | ------- |
-| spark.tispark.pd.addresses | - | true | PD Cluster Addresses, split by comma | - |
-| spark.tispark.tidb.addr | tidb.addr | true | TiDB Address, currently only support one instance | - |
-| spark.tispark.tidb.port | tidb.port | true | TiDB Port | - |
-| spark.tispark.tidb.user | tidb.user | true | TiDB User | - |
-| spark.tispark.tidb.password | tidb.password | true | TiDB Password | - |
-| database | - | true | TiDB Database | - |
-| table | - | true | TiDB Table | - |
-| skipCommitSecondaryKey | - | false | skip commit secondary key | true |
-| enableRegionSplit | - | false | do region split to avoid hot region during insertion | true|
-| regionSplitNum | - | false | user defined region split number during insertion | 0 |
-| replace | - | false | define the behavior of append. | false| 
+| Key                         | Short Name    | Required | Description                                                                                   | Default |
+| --------------------------- | ------------- | -------- | --------------------------------------------------------------------------------------------- | ------- |
+| spark.tispark.pd.addresses  | -             | true     | PD Cluster Addresses, split by comma                                                          | -       |
+| spark.tispark.tidb.addr     | tidb.addr     | true     | TiDB Address, currently only support one instance                                             | -       |
+| spark.tispark.tidb.port     | tidb.port     | true     | TiDB Port                                                                                     | -       |
+| spark.tispark.tidb.user     | tidb.user     | true     | TiDB User                                                                                     | -       |
+| spark.tispark.tidb.password | tidb.password | true     | TiDB Password                                                                                 | -       |
+| database                    | -             | true     | TiDB Database                                                                                 | -       |
+| table                       | -             | true     | TiDB Table                                                                                    | -       |
+| skipCommitSecondaryKey      | -             | false    | skip commit secondary key                                                                     | true    |
+| enableRegionSplit           | -             | false    | do region split to avoid hot region during insertion                                          | true    |
+| regionSplitNum              | -             | false    | user defined region split number during insertion                                             | 0       |
+| replace                     | -             | false    | define the behavior of append.                                                                | false   |
+| lockTTLSeconds              | -             | false    | tikv lock ttl, write duration must < `lockTTLSeconds`, otherwise write may fail because of gc | 3600    |
 
 TiSpark's common options can also be passed in, e.g. `spark.tispark.plan.allow_agg_pushdown`, `spark.tispark.plan.allow_index_read`, etc.
 

--- a/docs/datasource_api_userguide.md
+++ b/docs/datasource_api_userguide.md
@@ -214,7 +214,7 @@ The following is TiDB-specific options, which can be passed in through `TiDBOpti
 | spark.tispark.tidb.password | tidb.password | true     | TiDB Password                                                                                 | -       |
 | database                    | -             | true     | TiDB Database                                                                                 | -       |
 | table                       | -             | true     | TiDB Table                                                                                    | -       |
-| skipCommitSecondaryKey      | -             | false    | skip commit secondary key                                                                     | true    |
+| skipCommitSecondaryKey      | -             | false    | skip commit secondary key                                                                     | false   |
 | enableRegionSplit           | -             | false    | do region split to avoid hot region during insertion                                          | true    |
 | regionSplitNum              | -             | false    | user defined region split number during insertion                                             | 0       |
 | replace                     | -             | false    | define the behavior of append.                                                                | false   |

--- a/tikv-client/src/main/java/com/pingcap/tikv/TwoPhaseCommitter.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/TwoPhaseCommitter.java
@@ -96,8 +96,8 @@ public class TwoPhaseCommitter {
    */
   private static final int TXN_COMMIT_BATCH_SIZE = 768 * 1024;
 
-  /** unit is second */
-  private static final long DEFAULT_BATCH_WRITE_LOCK_TTL = 3600;
+  /** unit is millisecond */
+  private static final long DEFAULT_BATCH_WRITE_LOCK_TTL = 3600000;
 
   private static final long MAX_RETRY_TIMES = 3;
 
@@ -109,6 +109,7 @@ public class TwoPhaseCommitter {
   /** start timestamp of transaction which get from PD */
   private final long startTs;
 
+  /** unit is millisecond */
   private final long lockTTL;
 
   public TwoPhaseCommitter(TiConfiguration conf, long startTime) {

--- a/tikv-client/src/main/java/com/pingcap/tikv/TwoPhaseCommitter.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/TwoPhaseCommitter.java
@@ -97,7 +97,7 @@ public class TwoPhaseCommitter {
   private static final int TXN_COMMIT_BATCH_SIZE = 768 * 1024;
 
   /** unit is second */
-  private static final long DEFAULT_BATCH_WRITE_LOCK_TTL = 3000;
+  private static final long DEFAULT_BATCH_WRITE_LOCK_TTL = 3600;
 
   private static final long MAX_RETRY_TIMES = 3;
 
@@ -109,10 +109,20 @@ public class TwoPhaseCommitter {
   /** start timestamp of transaction which get from PD */
   private final long startTs;
 
+  private final long lockTTL;
+
   public TwoPhaseCommitter(TiConfiguration conf, long startTime) {
     this.kvClient = TiSessionCache.getSession(conf).createTxnClient();
     this.regionManager = kvClient.getRegionManager();
     this.startTs = startTime;
+    this.lockTTL = DEFAULT_BATCH_WRITE_LOCK_TTL;
+  }
+
+  public TwoPhaseCommitter(TiConfiguration conf, long startTime, long lockTTL) {
+    this.kvClient = TiSessionCache.getSession(conf).createTxnClient();
+    this.regionManager = kvClient.getRegionManager();
+    this.startTs = startTime;
+    this.lockTTL = lockTTL;
   }
 
   public void close() throws Exception {}
@@ -552,11 +562,11 @@ public class TwoPhaseCommitter {
 
   private long getTxnLockTTL(long startTime) {
     // TODO: calculate txn lock ttl
-    return DEFAULT_BATCH_WRITE_LOCK_TTL;
+    return this.lockTTL;
   }
 
   private long getTxnLockTTL(long startTime, int txnSize) {
     // TODO: calculate txn lock ttl
-    return DEFAULT_BATCH_WRITE_LOCK_TTL;
+    return this.lockTTL;
   }
 }


### PR DESCRIPTION
close https://github.com/pingcap/tispark/issues/912

1. add lock ttl as user parameter
2. fix bug: lock ttl time unit is millisecond instead of second
3. change skipCommitSecondaryKey default value to false (if primary key is commit, but secondary key is not commit and ttl is not reached, tidb cannot resolve the lock)