### PR TITLE
fix compare bigdecimal

### DIFF
--- a/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
@@ -122,10 +122,6 @@ abstract class QueryTest extends PlanTest {
               }
               true
             }
-          case _: java.math.BigDecimal if rhs.isInstanceOf[java.math.BigDecimal] =>
-            lhs
-              .asInstanceOf[java.math.BigDecimal]
-              .compareTo(rhs.asInstanceOf[java.math.BigDecimal]) == 0
           case _: Double | _: Float | _: BigDecimal | _: java.math.BigDecimal =>
             val l = toDouble(lhs)
             val r = toDouble(rhs)

--- a/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
@@ -122,14 +122,14 @@ abstract class QueryTest extends PlanTest {
               }
               true
             }
-          case _: Double | _: Float | _: BigDecimal | _: java.math.BigDecimal =>
-            val l = toDouble(lhs)
-            val r = toDouble(rhs)
-            Math.abs(l - r) < eps || Math.abs(r) > eps && Math.abs((l - r) / r) < eps
           case _: java.math.BigDecimal if rhs.isInstanceOf[java.math.BigDecimal] =>
             lhs
               .asInstanceOf[java.math.BigDecimal]
               .compareTo(rhs.asInstanceOf[java.math.BigDecimal]) == 0
+          case _: Double | _: Float | _: BigDecimal | _: java.math.BigDecimal =>
+            val l = toDouble(lhs)
+            val r = toDouble(rhs)
+            Math.abs(l - r) < eps || Math.abs(r) > eps && Math.abs((l - r) / r) < eps
           case _: Number | _: BigInt | _: java.math.BigInteger =>
             toInteger(lhs) == toInteger(rhs)
           case _: Timestamp =>


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
close https://github.com/pingcap/tispark/issues/928

![image](https://user-images.githubusercontent.com/5574887/61258036-30675980-a7a6-11e9-87aa-cb60eaad3dab.png)

the second case will never be called, because it is included in the first case.

### What is changed and how it works?
delete the second case
