### PR TITLE
adding shard row id bits test

### DIFF
--- a/core/src/test/scala/com/pingcap/tispark/datasource/ShardRowIDBitsSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/ShardRowIDBitsSuite.scala
@@ -1,0 +1,29 @@
+package com.pingcap.tispark.datasource
+
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.types.{IntegerType, StructField, StructType}
+
+class ShardRowIDBitsSuite extends BaseDataSourceTest("test_shard_row_id_bits") {
+  private val row1 = Row(1)
+  private val row2 = Row(2)
+  private val row3 = Row(3)
+  private val schema = StructType(
+    List(
+      StructField("a", IntegerType)
+    )
+  )
+
+  test("reading from a table with shard_row_id_bits") {
+    dropTable()
+    jdbcUpdate(
+      s"CREATE TABLE  $dbtable ( `a` int(11))  SHARD_ROW_ID_BITS = 4"
+    )
+
+    jdbcUpdate(
+      s"insert into $dbtable values(null)"
+    )
+
+    tidbWrite(List(row1, row2, row3), schema)
+    testTiDBSelect(List(Row(null), row1, row2, row3), sortCol = "a")
+  }
+}

--- a/core/src/test/scala/com/pingcap/tispark/datasource/ShardRowIDBitsSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/ShardRowIDBitsSuite.scala
@@ -13,7 +13,7 @@ class ShardRowIDBitsSuite extends BaseDataSourceTest("test_shard_row_id_bits") {
     )
   )
 
-  test("reading from a table with shard_row_id_bits") {
+  test("reading and writing a table with shard_row_id_bits") {
     dropTable()
     jdbcUpdate(
       s"CREATE TABLE  $dbtable ( `a` int(11))  SHARD_ROW_ID_BITS = 4"


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
This PR adds a test suite to ensure that we can read/write against a table with `shard_row_id_bits`. 

### What is changed and how it works?
A new test suite is added. In the test suite, we first create a table with `shard_row_id_bits` and then insert via jdbc. Later, we use out batch write api to insert some data. The way to check the correctness is select data from TiKV. 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Integration test


Side effects
No side effects. 
