### PR TITLE
fix range partition throw UnsupportedSyntaxException error

### DIFF
--- a/tikv-client/src/main/java/com/pingcap/tikv/expression/visitor/PrunedPartitionBuilder.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/expression/visitor/PrunedPartitionBuilder.java
@@ -18,6 +18,7 @@ package com.pingcap.tikv.expression.visitor;
 import com.google.common.collect.RangeSet;
 import com.google.common.collect.TreeRangeSet;
 import com.pingcap.tikv.exception.UnsupportedPartitionExprException;
+import com.pingcap.tikv.exception.UnsupportedSyntaxException;
 import com.pingcap.tikv.expression.*;
 import com.pingcap.tikv.expression.ComparisonBinaryExpression.NormalizedPredicate;
 import com.pingcap.tikv.meta.TiPartitionDef;
@@ -71,7 +72,7 @@ public class PrunedPartitionBuilder extends RangeSetBuilder<Long> {
 
     try {
       partExprs = generateRangePartExprs(tblInfo);
-    } catch (UnsupportedPartitionExprException e) {
+    } catch (UnsupportedSyntaxException | UnsupportedPartitionExprException e) {
       return false;
     }
 


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
close https://github.com/pingcap/tispark/issues/957

read from Range Partition should not throw UnsupportedSyntaxException when using unsupported partition function like `mod`, instead tispark should use full table scan
