### PR TITLE
Fix session cache

### DIFF
--- a/core/src/main/scala/com/pingcap/tispark/TiSessionCache.scala
+++ b/core/src/main/scala/com/pingcap/tispark/TiSessionCache.scala
@@ -17,17 +17,14 @@ package com.pingcap.tispark
 
 import com.pingcap.tikv.{TiConfiguration, TiSession}
 
+import scala.collection.mutable
+
 object TiSessionCache {
-  private var sessionCached: TiSession = null
+  private val sessionCachedMap = mutable.Map[String, TiSession]()
 
   // Since we create session as singleton now, configuration change will not
   // reflect change
   def getSession(conf: TiConfiguration): TiSession = this.synchronized {
-    if (sessionCached == null) {
-      sessionCached = TiSession.create(conf)
-      sessionCached
-    } else {
-      sessionCached
-    }
+    sessionCachedMap.getOrElseUpdate(conf.getPdAddrsString(), TiSession.create(conf))
   }
 }

--- a/core/src/main/scala/org/apache/spark/sql/TiContext.scala
+++ b/core/src/main/scala/org/apache/spark/sql/TiContext.scala
@@ -41,7 +41,7 @@ class TiContext(val sparkSession: SparkSession) extends Serializable with Loggin
   lazy val sqlContext: SQLContext = sparkSession.sqlContext
   val conf: SparkConf = sparkSession.sparkContext.conf
   val tiConf: TiConfiguration = TiUtil.sparkConfToTiConf(conf)
-  val tiSession: TiSession = TiSession.create(tiConf)
+  val tiSession: TiSession = TiSessionCache.getSession(tiConf)
   val meta: MetaManager = new MetaManager(tiSession.getCatalog)
 
   StatisticsManager.initStatisticsManager(tiSession)

--- a/tikv-client/src/main/java/com/pingcap/tikv/TiConfiguration.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/TiConfiguration.java
@@ -18,7 +18,6 @@ package com.pingcap.tikv;
 import com.pingcap.tikv.pd.PDUtils;
 import java.io.Serializable;
 import java.net.URI;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
@@ -52,7 +51,8 @@ public class TiConfiguration implements Serializable {
   private TimeUnit metaReloadUnit = DEF_META_RELOAD_UNIT;
   private int metaReloadPeriod = DEF_META_RELOAD_PERIOD;
   private int maxFrameSize = DEF_MAX_FRAME_SIZE;
-  private List<URI> pdAddrs = new ArrayList<>();
+  private final List<URI> pdAddrs;
+  private final String pdAddsStr;
   private int indexScanBatchSize = DEF_INDEX_SCAN_BATCH_SIZE;
   private int indexScanConcurrency = DEF_INDEX_SCAN_CONCURRENCY;
   private int tableScanConcurrency = DEF_TABLE_SCAN_CONCURRENCY;
@@ -62,10 +62,18 @@ public class TiConfiguration implements Serializable {
   private boolean showRowId = DEF_SHOW_ROWID;
   private String dbPrefix = DEF_DB_PREFIX;
 
+  private TiConfiguration(String pdAddrsStr) {
+    this.pdAddrs = strToURI(pdAddrsStr);
+    StringBuilder sb = new StringBuilder();
+    for (URI uri : this.pdAddrs) {
+      sb.append(uri.toString());
+    }
+    pdAddsStr = sb.toString();
+  }
+
   public static TiConfiguration createDefault(String pdAddrsStr) {
     Objects.requireNonNull(pdAddrsStr, "pdAddrsStr is null");
-    TiConfiguration conf = new TiConfiguration();
-    conf.pdAddrs = strToURI(pdAddrsStr);
+    TiConfiguration conf = new TiConfiguration(pdAddrsStr);
     return conf;
   }
 
@@ -113,6 +121,10 @@ public class TiConfiguration implements Serializable {
 
   public List<URI> getPdAddrs() {
     return pdAddrs;
+  }
+
+  public String getPdAddrsString() {
+    return pdAddsStr;
   }
 
   public int getScanBatchSize() {

--- a/tikv-client/src/main/java/com/pingcap/tikv/pd/PDUtils.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/pd/PDUtils.java
@@ -15,8 +15,9 @@
 
 package com.pingcap.tikv.pd;
 
-import com.google.common.collect.ImmutableList;
 import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class PDUtils {
@@ -29,10 +30,11 @@ public class PDUtils {
   }
 
   public static List<URI> addrsToUrls(String[] addrs) {
-    ImmutableList.Builder<URI> urlsBuilder = new ImmutableList.Builder<>();
+    ArrayList<URI> urlsBuilder = new ArrayList<>();
     for (String addr : addrs) {
       urlsBuilder.add(addrToUrl(addr));
     }
-    return urlsBuilder.build();
+    Collections.sort(urlsBuilder);
+    return Collections.unmodifiableList(urlsBuilder);
   }
 }


### PR DESCRIPTION
Fix session cache for TiFlash build branch. This will enforce session created only once and PD string returns a deterministic string no matter what conf input order it is.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tispark/962)
<!-- Reviewable:end -->
