### PR TITLE
make tispark reading data from a hash partition table

### DIFF
--- a/tikv-client/src/main/java/com/pingcap/tikv/meta/TiPartitionDef.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/meta/TiPartitionDef.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -39,7 +40,11 @@ public class TiPartitionDef implements Serializable {
       @JsonProperty("comment") String comment) {
     this.id = id;
     this.name = name.getL();
-    this.lessThan = ImmutableList.copyOf(lessThan);
+    if (lessThan == null || lessThan.isEmpty()) {
+      this.lessThan = new ArrayList<>();
+    } else {
+      this.lessThan = ImmutableList.copyOf(lessThan);
+    }
     this.comment = comment;
   }
 


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
This PR closes #958. 

### What is changed and how it works?
The problem is `lessThan` being `null` in hash partition table case. To resolve this, we just check the value of `lessThan` and assign an empty array list to it. 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

Related changes
 - Need to cherry-pick to the release branch
