### PR TITLE
fix cost model in table scan

### DIFF
--- a/tikv-client/src/main/java/com/pingcap/tikv/predicates/TiKVScanAnalyzer.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/predicates/TiKVScanAnalyzer.java
@@ -106,7 +106,6 @@ public class TiKVScanAnalyzer {
 
       // TODO: Fine-grained statistics usage
       Builder calculateCostAndEstimateCount(long tableColSize) {
-        cost = 100.0;
         cost *= tableColSize * TABLE_SCAN_COST_FACTOR;
         return this;
       }
@@ -266,6 +265,8 @@ public class TiKVScanAnalyzer {
     TiKVScanPlan.Builder planBuilder = TiKVScanPlan.Builder.newBuilder();
     ScanSpec result = extractConditions(conditions, table, index);
 
+    // this is calcuated for downgrade if there is no statstics info we can
+    // retrieve from TiKV.
     double cost = SelectivityCalculator.calcPseudoSelectivity(result);
     planBuilder.setCost(cost);
 


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
During refactoring DAGRequst, cost is accidentally reassigned by 100.0. This PR resolves this issue.
### What is changed and how it works?
Do not assign 100 to cost again.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Manual test (add detailed scripts or steps below)

Related changes
 - Need to cherry-pick to the release branch
