### PR TITLE
Refactor RegionStoreClient logic

### DIFF
--- a/core/src/test/scala/org/apache/spark/sql/BaseTiSparkTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/BaseTiSparkTest.scala
@@ -124,6 +124,7 @@ class BaseTiSparkTest extends QueryTest with SharedSQLContext {
 
   protected def loadTestData(databases: Seq[String] = defaultTestDatabases): Unit =
     try {
+      ti.meta.reloadAllMeta()
       tableNames = Seq.empty[String]
       for (dbName <- databases) {
         setCurrentDatabase(dbName)

--- a/core/src/test/scala/org/apache/spark/sql/BaseTiSparkTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/BaseTiSparkTest.scala
@@ -396,29 +396,6 @@ class BaseTiSparkTest extends QueryTest with SharedSQLContext {
     }
   }
 
-  private def listToString(result: List[List[Any]]): String =
-    if (result == null) s"[len: null] = null"
-    else if (result.isEmpty) s"[len: 0] = Empty"
-    else s"[len: ${result.length}] = ${result.map(mapStringList).mkString(",")}"
-
-  private def mapStringList(result: List[Any]): String =
-    if (result == null) "null" else "List(" + result.map(mapString).mkString(",") + ")"
-
-  private def mapString(result: Any): String =
-    if (result == null) "null"
-    else
-      result match {
-        case _: Array[Byte] =>
-          var str = "["
-          for (s <- result.asInstanceOf[Array[Byte]]) {
-            str += " " + s.toString
-          }
-          str += " ]"
-          str
-        case _ =>
-          result.toString
-      }
-
   protected def explainTestAndCollect(sql: String): Unit = {
     val df = spark.sql(sql)
     df.explain

--- a/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
@@ -226,7 +226,7 @@ class IssueTestSuite extends BaseTiSparkTest {
     tidbStmt.execute("insert into t values(1)")
     tidbStmt.execute("insert into t values(2)")
     tidbStmt.execute("insert into t values(4)")
-    ti.meta.reloadAllMeta()
+    loadTestData()
     runTest("select count(c1) from t")
     runTest("select count(c1 + 1) from t")
     runTest("select count(1 + c1) from t")
@@ -234,7 +234,7 @@ class IssueTestSuite extends BaseTiSparkTest {
     tidbStmt.execute("create table t(c1 int not null, c2 int not null)")
     tidbStmt.execute("insert into t values(1, 4)")
     tidbStmt.execute("insert into t values(2, 2)")
-    ti.meta.reloadAllMeta()
+    loadTestData()
     runTest("select count(c1 + c2) from t")
   }
 

--- a/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
@@ -196,6 +196,29 @@ abstract class QueryTest extends SparkFunSuite {
     }
   }
 
+  def listToString(result: List[List[Any]]): String =
+    if (result == null) s"[len: null] = null"
+    else if (result.isEmpty) s"[len: 0] = Empty"
+    else s"[len: ${result.length}] = ${result.map(mapStringList).mkString(",")}"
+
+  private def mapStringList(result: List[Any]): String =
+    if (result == null) "null" else "List(" + result.map(mapString).mkString(",") + ")"
+
+  private def mapString(result: Any): String =
+    if (result == null) "null"
+    else
+      result match {
+        case _: Array[Byte] =>
+          var str = "["
+          for (s <- result.asInstanceOf[Array[Byte]]) {
+            str += " " + s.toString
+          }
+          str += " ]"
+          str
+        case _ =>
+          result.toString
+      }
+
   protected def toOutput(value: Any, colType: String): Any = value match {
     case _: BigDecimal =>
       value.asInstanceOf[BigDecimal].setScale(2, BigDecimal.RoundingMode.HALF_UP)

--- a/core/src/test/scala/org/apache/spark/sql/types/BaseDataTypeTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/types/BaseDataTypeTest.scala
@@ -35,7 +35,7 @@ trait BaseDataTypeTest extends BaseTiSparkTest {
     setCurrentDatabase(dbName)
     val tblName = generator.getTableNameWithDesc(desc, dataType)
     val query = s"select ${generator.getColumnName(dataType)} from $tblName"
-    println(query)
+    logger.info(query)
     runTest(query)
   }
 

--- a/tikv-client/src/main/java/com/pingcap/tikv/AbstractGRPCClient.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/AbstractGRPCClient.java
@@ -37,10 +37,23 @@ public abstract class AbstractGRPCClient<
   protected final Logger logger = Logger.getLogger(this.getClass());
   protected TiConfiguration conf;
   protected final ChannelFactory channelFactory;
+  protected BlockingStubT blockingStub;
+  protected StubT asyncStub;
 
   protected AbstractGRPCClient(TiConfiguration conf, ChannelFactory channelFactory) {
     this.conf = conf;
     this.channelFactory = channelFactory;
+  }
+
+  protected AbstractGRPCClient(
+      TiConfiguration conf,
+      ChannelFactory channelFactory,
+      BlockingStubT blockingStub,
+      StubT asyncStub) {
+    this.conf = conf;
+    this.channelFactory = channelFactory;
+    this.blockingStub = blockingStub;
+    this.asyncStub = asyncStub;
   }
 
   public TiConfiguration getConf() {

--- a/tikv-client/src/main/java/com/pingcap/tikv/KVClient.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/KVClient.java
@@ -1,0 +1,227 @@
+/*
+ *
+ * Copyright 2019 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.pingcap.tikv;
+
+import com.google.protobuf.ByteString;
+import com.pingcap.tikv.exception.TiKVException;
+import com.pingcap.tikv.operation.iterator.ConcreteScanIterator;
+import com.pingcap.tikv.region.RegionStoreClient;
+import com.pingcap.tikv.region.RegionStoreClient.*;
+import com.pingcap.tikv.region.TiRegion;
+import com.pingcap.tikv.util.BackOffFunction;
+import com.pingcap.tikv.util.BackOffer;
+import com.pingcap.tikv.util.ConcreteBackOffer;
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.stream.Collectors;
+import org.apache.log4j.Logger;
+import org.tikv.kvproto.Kvrpcpb;
+import org.tikv.kvproto.Kvrpcpb.KvPair;
+
+public class KVClient implements AutoCloseable {
+  private final RegionStoreClientBuilder clientBuilder;
+  private final TiConfiguration conf;
+  private final ExecutorCompletionService<List<KvPair>> completionService;
+  private static final Logger logger = Logger.getLogger(KVClient.class);
+
+  private static final int BATCH_GET_SIZE = 16 * 1024;
+
+  public KVClient(TiConfiguration conf, RegionStoreClientBuilder clientBuilder) {
+    Objects.requireNonNull(conf, "conf is null");
+    Objects.requireNonNull(clientBuilder, "clientBuilder is null");
+    this.conf = conf;
+    this.clientBuilder = clientBuilder;
+    //    ExecutorService executors = Executors.newFixedThreadPool(conf.getKVClientConcurrency());
+    ExecutorService executors = Executors.newFixedThreadPool(20);
+    this.completionService = new ExecutorCompletionService<>(executors);
+  }
+
+  @Override
+  public void close() {}
+
+  /**
+   * Get a raw key-value pair from TiKV if key exists
+   *
+   * @param key raw key
+   * @return a ByteString value if key exists, ByteString.EMPTY if key does not exist
+   */
+  public ByteString get(ByteString key, long version) {
+    BackOffer backOffer = ConcreteBackOffer.newGetBackOff();
+    while (true) {
+      RegionStoreClient client = clientBuilder.build(key);
+      try {
+        return client.get(backOffer, key, version);
+      } catch (final TiKVException e) {
+        backOffer.doBackOff(BackOffFunction.BackOffFuncType.BoRegionMiss, e);
+      }
+    }
+  }
+
+  /**
+   * Get a set of key-value pair by keys from TiKV
+   *
+   * @param keys keys
+   */
+  public List<KvPair> batchGet(List<ByteString> keys, long version) {
+    return batchGet(ConcreteBackOffer.newBatchGetMaxBackOff(), keys, version);
+  }
+
+  private List<KvPair> batchGet(BackOffer backOffer, List<ByteString> keys, long version) {
+    Set<ByteString> set = new HashSet<>(keys);
+    return batchGet(backOffer, set, version);
+  }
+
+  private List<KvPair> batchGet(BackOffer backOffer, Set<ByteString> keys, long version) {
+    Map<TiRegion, List<ByteString>> groupKeys = groupKeysByRegion(keys);
+    List<Batch> batches = new ArrayList<>();
+
+    for (Map.Entry<TiRegion, List<ByteString>> entry : groupKeys.entrySet()) {
+      appendBatches(batches, entry.getKey(), entry.getValue(), BATCH_GET_SIZE);
+    }
+    return sendBatchGet(backOffer, batches, version);
+  }
+
+  /**
+   * Scan raw key-value pairs from TiKV in range [startKey, endKey)
+   *
+   * @param startKey raw start key, inclusive
+   * @param endKey raw end key, exclusive
+   * @return list of key-value pairs in range
+   */
+  public List<Kvrpcpb.KvPair> scan(ByteString startKey, ByteString endKey, long version) {
+    Iterator<Kvrpcpb.KvPair> iterator =
+        scanIterator(conf, clientBuilder, startKey, endKey, version);
+    List<Kvrpcpb.KvPair> result = new ArrayList<>();
+    iterator.forEachRemaining(result::add);
+    return result;
+  }
+
+  /**
+   * Scan raw key-value pairs from TiKV in range [startKey, endKey)
+   *
+   * @param startKey raw start key, inclusive
+   * @param limit limit of key-value pairs
+   * @return list of key-value pairs in range
+   */
+  public List<Kvrpcpb.KvPair> scan(ByteString startKey, int limit) {
+    Iterator<Kvrpcpb.KvPair> iterator = scanIterator(conf, clientBuilder, startKey, limit);
+    List<Kvrpcpb.KvPair> result = new ArrayList<>();
+    iterator.forEachRemaining(result::add);
+    return result;
+  }
+
+  /** A Batch containing the region, a list of keys to send */
+  private static final class Batch {
+    private final TiRegion region;
+    private final List<ByteString> keys;
+
+    Batch(TiRegion region, List<ByteString> keys) {
+      this.region = region;
+      this.keys = keys;
+    }
+  }
+
+  /**
+   * Append batch to list and split them according to batch limit
+   *
+   * @param batches a grouped batch
+   * @param region region
+   * @param keys keys
+   * @param limit batch max limit
+   */
+  private void appendBatches(
+      List<Batch> batches, TiRegion region, List<ByteString> keys, int limit) {
+    List<ByteString> tmpKeys = new ArrayList<>();
+    for (int i = 0; i < keys.size(); i++) {
+      if (i >= limit) {
+        batches.add(new Batch(region, tmpKeys));
+        tmpKeys.clear();
+      }
+      tmpKeys.add(keys.get(i));
+    }
+    if (!tmpKeys.isEmpty()) {
+      batches.add(new Batch(region, tmpKeys));
+    }
+  }
+
+  /**
+   * Group by list of keys according to its region
+   *
+   * @param keys keys
+   * @return a mapping of keys and their region
+   */
+  private Map<TiRegion, List<ByteString>> groupKeysByRegion(Set<ByteString> keys) {
+    return keys.stream()
+        .collect(Collectors.groupingBy(clientBuilder.getRegionManager()::getRegionByKey));
+  }
+
+  /**
+   * Send batchPut request concurrently
+   *
+   * @param backOffer current backOffer
+   * @param batches list of batch to send
+   */
+  private List<KvPair> sendBatchGet(BackOffer backOffer, List<Batch> batches, long version) {
+    for (Batch batch : batches) {
+      completionService.submit(
+          () -> {
+            RegionStoreClient client = clientBuilder.build(batch.region);
+            BackOffer singleBatchBackOffer = ConcreteBackOffer.create(backOffer);
+            List<ByteString> keys = batch.keys;
+            try {
+              return client.batchGet(singleBatchBackOffer, keys, version);
+            } catch (final TiKVException e) {
+              // TODO: any elegant way to re-split the ranges if fails?
+              singleBatchBackOffer.doBackOff(BackOffFunction.BackOffFuncType.BoRegionMiss, e);
+              logger.warn("ReSplitting ranges for BatchPutRequest");
+              // recursive calls
+              return batchGet(singleBatchBackOffer, batch.keys, version);
+            }
+          });
+    }
+    try {
+      List<KvPair> result = new ArrayList<>();
+      for (int i = 0; i < batches.size(); i++) {
+        result.addAll(
+            completionService.take().get(BackOffer.BATCH_GET_MAX_BACKOFF, TimeUnit.SECONDS));
+      }
+      return result;
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new TiKVException("Current thread interrupted.", e);
+    } catch (TimeoutException e) {
+      throw new TiKVException("TimeOut Exceeded for current operation. ", e);
+    } catch (ExecutionException e) {
+      throw new TiKVException("Execution exception met.", e);
+    }
+  }
+
+  private Iterator<Kvrpcpb.KvPair> scanIterator(
+      TiConfiguration conf,
+      RegionStoreClientBuilder builder,
+      ByteString startKey,
+      ByteString endKey,
+      long version) {
+    return new ConcreteScanIterator(conf, builder, startKey, endKey, version);
+  }
+
+  private Iterator<Kvrpcpb.KvPair> scanIterator(
+      TiConfiguration conf, RegionStoreClientBuilder builder, ByteString startKey, int limit) {
+    return new ConcreteScanIterator(conf, builder, startKey, limit);
+  }
+}

--- a/tikv-client/src/main/java/com/pingcap/tikv/KVClient.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/KVClient.java
@@ -82,7 +82,7 @@ public class KVClient implements AutoCloseable {
    *
    * @param keys keys
    */
-  public List<KvPair> batchGet(List<ByteString> keys, long version) {
+  public List<KvPair> batchGet(List<ByteString> keys, long version) throws GrpcException {
     return batchGet(ConcreteBackOffer.newBatchGetMaxBackOff(), keys, version);
   }
 
@@ -108,7 +108,8 @@ public class KVClient implements AutoCloseable {
    * @param endKey raw end key, exclusive
    * @return list of key-value pairs in range
    */
-  public List<Kvrpcpb.KvPair> scan(ByteString startKey, ByteString endKey, long version) {
+  public List<Kvrpcpb.KvPair> scan(ByteString startKey, ByteString endKey, long version)
+      throws GrpcException {
     Iterator<Kvrpcpb.KvPair> iterator =
         scanIterator(conf, clientBuilder, startKey, endKey, version);
     List<Kvrpcpb.KvPair> result = new ArrayList<>();
@@ -123,7 +124,7 @@ public class KVClient implements AutoCloseable {
    * @param limit limit of key-value pairs
    * @return list of key-value pairs in range
    */
-  public List<Kvrpcpb.KvPair> scan(ByteString startKey, int limit) {
+  public List<Kvrpcpb.KvPair> scan(ByteString startKey, int limit) throws GrpcException {
     Iterator<Kvrpcpb.KvPair> iterator = scanIterator(conf, clientBuilder, startKey, limit);
     List<Kvrpcpb.KvPair> result = new ArrayList<>();
     iterator.forEachRemaining(result::add);

--- a/tikv-client/src/main/java/com/pingcap/tikv/PDClient.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/PDClient.java
@@ -218,7 +218,7 @@ public class PDClient extends AbstractGRPCClient<PDBlockingStub, PDStub>
     return leaderWrapper;
   }
 
-  class LeaderWrapper {
+  static class LeaderWrapper {
     private final String leaderInfo;
     private final PDBlockingStub blockingStub;
     private final PDStub asyncStub;
@@ -348,6 +348,9 @@ public class PDClient extends AbstractGRPCClient<PDBlockingStub, PDStub>
 
   private PDClient(TiConfiguration conf, ChannelFactory channelFactory) {
     super(conf, channelFactory);
+    initCluster();
+    this.blockingStub = getBlockingStub();
+    this.asyncStub = getAsyncStub();
   }
 
   private void initCluster() {
@@ -383,19 +386,6 @@ public class PDClient extends AbstractGRPCClient<PDBlockingStub, PDStub>
   }
 
   static PDClient createRaw(TiConfiguration conf, ChannelFactory channelFactory) {
-    PDClient client = null;
-    try {
-      client = new PDClient(conf, channelFactory);
-      client.initCluster();
-    } catch (Exception e) {
-      if (client != null) {
-        try {
-          client.close();
-        } catch (InterruptedException ignore) {
-        }
-      }
-      throw e;
-    }
-    return client;
+    return new PDClient(conf, channelFactory);
   }
 }

--- a/tikv-client/src/main/java/com/pingcap/tikv/Snapshot.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/Snapshot.java
@@ -19,6 +19,7 @@ import static com.pingcap.tikv.operation.iterator.CoprocessIterator.getHandleIte
 import static com.pingcap.tikv.operation.iterator.CoprocessIterator.getRowIterator;
 
 import com.google.protobuf.ByteString;
+import com.pingcap.tikv.key.Key;
 import com.pingcap.tikv.meta.TiDAGRequest;
 import com.pingcap.tikv.meta.TiTimestamp;
 import com.pingcap.tikv.operation.iterator.ConcreteScanIterator;
@@ -107,9 +108,35 @@ public class Snapshot {
     return getHandleIterator(dagRequest, tasks, session);
   }
 
+  /**
+   * scan all keys after startKey, inclusive
+   *
+   * @param startKey start of keys
+   * @return iterator of kvPair
+   */
   public Iterator<KvPair> scan(ByteString startKey) {
     return new ConcreteScanIterator(
-        session.getConf(), session.getRegionStoreClientBuilder(), startKey, timestamp.getVersion());
+        session.getConf(),
+        session.getRegionStoreClientBuilder(),
+        startKey,
+        timestamp.getVersion(),
+        Integer.MAX_VALUE);
+  }
+
+  /**
+   * scan all keys with prefix
+   *
+   * @param prefix prefix of keys
+   * @return iterator of kvPair
+   */
+  public Iterator<KvPair> scanPrefix(ByteString prefix) {
+    ByteString nextPrefix = Key.toRawKey(prefix).nextPrefix().toByteString();
+    return new ConcreteScanIterator(
+        session.getConf(),
+        session.getRegionStoreClientBuilder(),
+        prefix,
+        nextPrefix,
+        timestamp.getVersion());
   }
 
   public TiConfiguration getConf() {

--- a/tikv-client/src/main/java/com/pingcap/tikv/codec/MetaCodec.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/codec/MetaCodec.java
@@ -98,15 +98,12 @@ public class MetaCodec {
     MetaCodec.encodeHashDataKeyPrefix(cdo, key.toByteArray());
     ByteString encodedKey = cdo.toByteString();
 
-    Iterator<KvPair> iterator = snapshot.scan(encodedKey);
+    Iterator<KvPair> iterator = snapshot.scanPrefix(encodedKey);
     List<Pair<ByteString, ByteString>> fields = new ArrayList<>();
     while (iterator.hasNext()) {
       Kvrpcpb.KvPair kv = iterator.next();
       if (kv == null || kv.getKey() == null) {
         continue;
-      }
-      if (!KeyUtils.hasPrefix(kv.getKey(), encodedKey)) {
-        break;
       }
       fields.add(Pair.create(MetaCodec.decodeHashDataKey(kv.getKey()).second, kv.getValue()));
     }

--- a/tikv-client/src/main/java/com/pingcap/tikv/exception/KeyException.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/exception/KeyException.java
@@ -20,6 +20,7 @@ import org.tikv.kvproto.Kvrpcpb;
 public class KeyException extends TiKVException {
 
   private static final long serialVersionUID = 6649195220216182286L;
+  private Kvrpcpb.KeyError keyError;
 
   public KeyException(String errMsg) {
     super(errMsg);
@@ -27,5 +28,10 @@ public class KeyException extends TiKVException {
 
   public KeyException(Kvrpcpb.KeyError keyErr) {
     super(String.format("Key exception occurred and the reason is %s", keyErr.toString()));
+    this.keyError = keyErr;
+  }
+
+  public Kvrpcpb.KeyError getKeyError() {
+    return keyError;
   }
 }

--- a/tikv-client/src/main/java/com/pingcap/tikv/operation/iterator/ConcreteScanIterator.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/operation/iterator/ConcreteScanIterator.java
@@ -1,0 +1,97 @@
+/*
+ *
+ * Copyright 2019 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.pingcap.tikv.operation.iterator;
+
+import com.google.protobuf.ByteString;
+import com.pingcap.tikv.TiConfiguration;
+import com.pingcap.tikv.exception.KeyException;
+import com.pingcap.tikv.region.RegionStoreClient;
+import com.pingcap.tikv.region.RegionStoreClient.RegionStoreClientBuilder;
+import com.pingcap.tikv.region.TiRegion;
+import com.pingcap.tikv.util.BackOffer;
+import com.pingcap.tikv.util.ConcreteBackOffer;
+import com.pingcap.tikv.util.Pair;
+import java.util.Objects;
+import org.apache.log4j.Logger;
+import org.tikv.kvproto.Kvrpcpb;
+import org.tikv.kvproto.Kvrpcpb.KvPair;
+import org.tikv.kvproto.Metapb;
+
+public class ConcreteScanIterator extends ScanIterator {
+  private final long version;
+  private final Logger logger = Logger.getLogger(ConcreteScanIterator.class);
+
+  public ConcreteScanIterator(
+      TiConfiguration conf, RegionStoreClientBuilder builder, ByteString startKey, long version) {
+    // Passing endKey as ByteString.EMPTY means that endKey is +INF by default,
+    this(conf, builder, startKey, ByteString.EMPTY, version);
+  }
+
+  public ConcreteScanIterator(
+      TiConfiguration conf,
+      RegionStoreClientBuilder builder,
+      ByteString startKey,
+      ByteString endKey,
+      long version) {
+    super(conf, builder, startKey, endKey, Integer.MAX_VALUE);
+    this.version = version;
+  }
+
+  TiRegion loadCurrentRegionToCache() throws Exception {
+    TiRegion region;
+    try (RegionStoreClient client = builder.build(startKey)) {
+      region = client.getRegion();
+      BackOffer backOffer = ConcreteBackOffer.newScannerNextMaxBackOff();
+      currentCache = client.scan(backOffer, startKey, version);
+      return region;
+    }
+  }
+
+  private ByteString resolveCurrentLock(Kvrpcpb.KvPair current) {
+    logger.warn(String.format("resolve current key error %s", current.getError().toString()));
+    Pair<TiRegion, Metapb.Store> pair =
+        builder.getRegionManager().getRegionStorePairByKey(startKey);
+    TiRegion region = pair.first;
+    Metapb.Store store = pair.second;
+    BackOffer backOffer = ConcreteBackOffer.newGetBackOff();
+    try (RegionStoreClient client = builder.build(region, store)) {
+      return client.get(backOffer, current.getKey(), version);
+    } catch (Exception e) {
+      throw new KeyException(current.getError());
+    }
+  }
+
+  @Override
+  public KvPair next() {
+    KvPair current;
+    // continue when cache is empty but not null
+    for (current = getCurrent(); currentCache != null && current == null; current = getCurrent()) {
+      if (cacheLoadFails()) {
+        return null;
+      }
+    }
+
+    Objects.requireNonNull(current, "current kv pair cannot be null");
+    if (current.hasError()) {
+      ByteString val = resolveCurrentLock(current);
+      current = KvPair.newBuilder().setKey(current.getKey()).setValue(val).build();
+    }
+
+    return current;
+  }
+}

--- a/tikv-client/src/main/java/com/pingcap/tikv/operation/iterator/ConcreteScanIterator.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/operation/iterator/ConcreteScanIterator.java
@@ -19,6 +19,7 @@ package com.pingcap.tikv.operation.iterator;
 
 import com.google.protobuf.ByteString;
 import com.pingcap.tikv.TiConfiguration;
+import com.pingcap.tikv.exception.GrpcException;
 import com.pingcap.tikv.exception.KeyException;
 import com.pingcap.tikv.region.RegionStoreClient;
 import com.pingcap.tikv.region.RegionStoreClient.RegionStoreClientBuilder;
@@ -52,7 +53,7 @@ public class ConcreteScanIterator extends ScanIterator {
     this.version = version;
   }
 
-  TiRegion loadCurrentRegionToCache() throws Exception {
+  TiRegion loadCurrentRegionToCache() throws GrpcException {
     TiRegion region;
     try (RegionStoreClient client = builder.build(startKey)) {
       region = client.getRegion();

--- a/tikv-client/src/main/java/com/pingcap/tikv/operation/iterator/ScanIterator.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/operation/iterator/ScanIterator.java
@@ -19,6 +19,7 @@ import static java.util.Objects.requireNonNull;
 
 import com.google.protobuf.ByteString;
 import com.pingcap.tikv.TiConfiguration;
+import com.pingcap.tikv.exception.GrpcException;
 import com.pingcap.tikv.exception.TiClientInternalException;
 import com.pingcap.tikv.key.Key;
 import com.pingcap.tikv.region.RegionStoreClient.RegionStoreClientBuilder;
@@ -57,7 +58,7 @@ public abstract class ScanIterator implements Iterator<Kvrpcpb.KvPair> {
     this.builder = builder;
   }
 
-  abstract TiRegion loadCurrentRegionToCache() throws Exception;
+  abstract TiRegion loadCurrentRegionToCache() throws GrpcException;
 
   // return true if current cache is not loaded or empty
   boolean cacheLoadFails() {

--- a/tikv-client/src/main/java/com/pingcap/tikv/operation/iterator/ScanIterator.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/operation/iterator/ScanIterator.java
@@ -18,115 +18,110 @@ package com.pingcap.tikv.operation.iterator;
 import static java.util.Objects.requireNonNull;
 
 import com.google.protobuf.ByteString;
-import com.pingcap.tikv.TiSession;
-import com.pingcap.tikv.exception.KeyException;
+import com.pingcap.tikv.TiConfiguration;
 import com.pingcap.tikv.exception.TiClientInternalException;
 import com.pingcap.tikv.key.Key;
-import com.pingcap.tikv.region.RegionManager;
-import com.pingcap.tikv.region.RegionStoreClient;
+import com.pingcap.tikv.region.RegionStoreClient.RegionStoreClientBuilder;
 import com.pingcap.tikv.region.TiRegion;
-import com.pingcap.tikv.util.BackOffer;
-import com.pingcap.tikv.util.ConcreteBackOffer;
-import com.pingcap.tikv.util.Pair;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Objects;
-import org.apache.log4j.Logger;
 import org.tikv.kvproto.Kvrpcpb;
-import org.tikv.kvproto.Kvrpcpb.KvPair;
-import org.tikv.kvproto.Metapb;
 
-public class ScanIterator implements Iterator<Kvrpcpb.KvPair> {
-  private final Logger logger = Logger.getLogger(ScanIterator.class);
-  protected final TiSession session;
-  private final RegionManager regionCache;
-  protected final long version;
-
-  private List<Kvrpcpb.KvPair> currentCache;
+public abstract class ScanIterator implements Iterator<Kvrpcpb.KvPair> {
+  protected final TiConfiguration conf;
+  protected final RegionStoreClientBuilder builder;
+  protected List<Kvrpcpb.KvPair> currentCache;
   protected ByteString startKey;
   protected int index = -1;
-  private boolean endOfScan = false;
+  protected int limit;
+  protected boolean endOfScan = false;
 
-  public ScanIterator(ByteString startKey, TiSession session, long version) {
+  protected Key endKey;
+  protected boolean hasEndKey;
+  protected boolean lastBatch = false;
+
+  ScanIterator(
+      TiConfiguration conf,
+      RegionStoreClientBuilder builder,
+      ByteString startKey,
+      ByteString endKey,
+      int limit) {
     this.startKey = requireNonNull(startKey, "start key is null");
     if (startKey.isEmpty()) {
       throw new IllegalArgumentException("start key cannot be empty");
     }
-    this.session = session;
-    this.regionCache = session.getRegionManager();
-    this.version = version;
+    this.endKey = Key.toRawKey(requireNonNull(endKey, "end key is null"));
+    this.hasEndKey = !endKey.equals(ByteString.EMPTY);
+    this.limit = limit;
+    this.conf = conf;
+    this.builder = builder;
   }
 
-  // return false if current cache is not loaded or empty
-  private boolean loadCache() {
-    if (endOfScan) {
-      return false;
+  abstract TiRegion loadCurrentRegionToCache() throws Exception;
+
+  // return true if current cache is not loaded or empty
+  boolean cacheLoadFails() {
+    if (endOfScan || lastBatch) {
+      return true;
     }
     if (startKey.isEmpty()) {
-      return false;
+      return true;
     }
-    Pair<TiRegion, Metapb.Store> pair = regionCache.getRegionStorePairByKey(startKey);
-    TiRegion region = pair.first;
-    Metapb.Store store = pair.second;
-    try (RegionStoreClient client = session.getRegionStoreClientBuilder().build(region, store)) {
-      BackOffer backOffer = ConcreteBackOffer.newScannerNextMaxBackOff();
-      currentCache = client.scan(backOffer, startKey, version);
+    try {
+      TiRegion region = loadCurrentRegionToCache();
+      ByteString curRegionEndKey = region.getEndKey();
       // currentCache is null means no keys found, whereas currentCache is empty means no values
       // found. The difference lies in whether to continue scanning, because chances are that
       // an empty region exists due to deletion, region split, e.t.c.
       // See https://github.com/pingcap/tispark/issues/393 for details
       if (currentCache == null) {
-        return false;
+        return true;
       }
       index = 0;
+      Key lastKey = Key.EMPTY;
       // Session should be single-threaded itself
       // so that we don't worry about conf change in the middle
       // of a transaction. Otherwise below code might lose data
-      if (currentCache.size() < session.getConf().getScanBatchSize()) {
-        // Current region done, start new batch from next region
-        startKey = region.getEndKey();
+      if (currentCache.size() < conf.getScanBatchSize()) {
+        startKey = curRegionEndKey;
       } else {
         // Start new scan from exact next key in current region
-        Key lastKey = Key.toRawKey(currentCache.get(currentCache.size() - 1).getKey());
+        lastKey = Key.toRawKey(currentCache.get(currentCache.size() - 1).getKey());
         startKey = lastKey.next().toByteString();
+      }
+      // notify last batch if lastKey is greater than or equal to endKey
+      if (hasEndKey && lastKey.compareTo(endKey) >= 0) {
+        lastBatch = true;
+        startKey = null;
       }
     } catch (Exception e) {
       throw new TiClientInternalException("Error scanning data from region.", e);
     }
-    return true;
+    return false;
   }
 
-  private boolean isCacheDrained() {
-    return currentCache == null || index >= currentCache.size() || index == -1;
+  boolean isCacheDrained() {
+    return currentCache == null || limit <= 0 || index >= currentCache.size() || index == -1;
   }
 
   @Override
   public boolean hasNext() {
-    if (isCacheDrained() && !loadCache()) {
+    if (isCacheDrained() && cacheLoadFails()) {
       endOfScan = true;
       return false;
     }
     return true;
   }
 
-  private Kvrpcpb.KvPair getCurrent() {
+  Kvrpcpb.KvPair getCurrent() {
     if (isCacheDrained()) {
       return null;
     }
-    return currentCache.get(index++);
-  }
-
-  private ByteString resolveCurrentLock(Kvrpcpb.KvPair current) {
-    logger.warn(String.format("resolve current key error %s", current.getError().toString()));
-    Pair<TiRegion, Metapb.Store> pair = regionCache.getRegionStorePairByKey(startKey);
-    TiRegion region = pair.first;
-    Metapb.Store store = pair.second;
-    BackOffer backOffer = ConcreteBackOffer.newGetBackOff();
-    try (RegionStoreClient client = session.getRegionStoreClientBuilder().build(region, store)) {
-      return client.get(backOffer, current.getKey(), version);
-    } catch (Exception e) {
-      throw new KeyException(current.getError());
+    if (index < currentCache.size()) {
+      --limit;
+      return currentCache.get(index++);
     }
+    return null;
   }
 
   @Override
@@ -134,17 +129,10 @@ public class ScanIterator implements Iterator<Kvrpcpb.KvPair> {
     Kvrpcpb.KvPair current;
     // continue when cache is empty but not null
     for (current = getCurrent(); currentCache != null && current == null; current = getCurrent()) {
-      if (!loadCache()) {
+      if (cacheLoadFails()) {
         return null;
       }
     }
-
-    Objects.requireNonNull(current, "current kv pair cannot be null");
-    if (current.hasError()) {
-      ByteString val = resolveCurrentLock(current);
-      current = KvPair.newBuilder().setKey(current.getKey()).setValue(val).build();
-    }
-
     return current;
   }
 }

--- a/tikv-client/src/main/java/com/pingcap/tikv/region/AbstractRegionStoreClient.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/region/AbstractRegionStoreClient.java
@@ -1,0 +1,111 @@
+/*
+ *
+ * Copyright 2019 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.pingcap.tikv.region;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.pingcap.tikv.AbstractGRPCClient;
+import com.pingcap.tikv.TiConfiguration;
+import com.pingcap.tikv.util.ChannelFactory;
+import io.grpc.ManagedChannel;
+import org.tikv.kvproto.Metapb;
+import org.tikv.kvproto.TikvGrpc;
+
+public abstract class AbstractRegionStoreClient
+    extends AbstractGRPCClient<TikvGrpc.TikvBlockingStub, TikvGrpc.TikvStub>
+    implements RegionErrorReceiver {
+
+  protected TiRegion region;
+  protected final RegionManager regionManager;
+
+  protected AbstractRegionStoreClient(
+      TiConfiguration conf,
+      TiRegion region,
+      ChannelFactory channelFactory,
+      TikvGrpc.TikvBlockingStub blockingStub,
+      TikvGrpc.TikvStub asyncStub,
+      RegionManager regionManager) {
+    super(conf, channelFactory, blockingStub, asyncStub);
+    checkNotNull(region, "Region is empty");
+    checkNotNull(region.getLeader(), "Leader Peer is null");
+    checkArgument(region.getLeader() != null, "Leader Peer is null");
+    this.region = region;
+    this.regionManager = regionManager;
+  }
+
+  public TiRegion getRegion() {
+    return region;
+  }
+
+  @Override
+  protected TikvGrpc.TikvBlockingStub getBlockingStub() {
+    return blockingStub.withDeadlineAfter(getConf().getTimeout(), getConf().getTimeoutUnit());
+  }
+
+  @Override
+  protected TikvGrpc.TikvStub getAsyncStub() {
+    return asyncStub.withDeadlineAfter(getConf().getTimeout(), getConf().getTimeoutUnit());
+  }
+
+  @Override
+  public void close() throws Exception {}
+
+  /**
+   * onNotLeader deals with NotLeaderError and returns whether re-splitting key range is needed
+   *
+   * @param newStore the new store presented by NotLeader Error
+   * @return false when re-split is needed.
+   */
+  @Override
+  public boolean onNotLeader(Metapb.Store newStore) {
+    if (logger.isDebugEnabled()) {
+      logger.debug(region + ", new leader = " + newStore.getId());
+    }
+    TiRegion cachedRegion = regionManager.getRegionById(region.getId());
+    // When switch leader fails or the region changed its key range,
+    // it would be necessary to re-split task's key range for new region.
+    if (!region.getStartKey().equals(cachedRegion.getStartKey())
+        || !region.getEndKey().equals(cachedRegion.getEndKey())) {
+      return false;
+    }
+    region = cachedRegion;
+    String addressStr = regionManager.getStoreById(region.getLeader().getStoreId()).getAddress();
+    ManagedChannel channel = channelFactory.getChannel(addressStr);
+    blockingStub = TikvGrpc.newBlockingStub(channel);
+    asyncStub = TikvGrpc.newStub(channel);
+    return true;
+  }
+
+  @Override
+  public void onStoreNotMatch(Metapb.Store store) {
+    String addressStr = store.getAddress();
+    ManagedChannel channel = channelFactory.getChannel(addressStr);
+    blockingStub = TikvGrpc.newBlockingStub(channel);
+    asyncStub = TikvGrpc.newStub(channel);
+    if (logger.isDebugEnabled() && region.getLeader().getStoreId() != store.getId()) {
+      logger.debug(
+          "store_not_match may occur? "
+              + region
+              + ", original store = "
+              + store.getId()
+              + " address = "
+              + addressStr);
+    }
+  }
+}

--- a/tikv-client/src/main/java/com/pingcap/tikv/region/AbstractRegionStoreClient.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/region/AbstractRegionStoreClient.java
@@ -22,6 +22,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.pingcap.tikv.AbstractGRPCClient;
 import com.pingcap.tikv.TiConfiguration;
+import com.pingcap.tikv.exception.GrpcException;
 import com.pingcap.tikv.util.ChannelFactory;
 import io.grpc.ManagedChannel;
 import org.tikv.kvproto.Metapb;
@@ -64,7 +65,7 @@ public abstract class AbstractRegionStoreClient
   }
 
   @Override
-  public void close() throws Exception {}
+  public void close() throws GrpcException {}
 
   /**
    * onNotLeader deals with NotLeaderError and returns whether re-splitting key range is needed

--- a/tikv-client/src/main/java/com/pingcap/tikv/region/RegionStoreClient.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/region/RegionStoreClient.java
@@ -611,7 +611,7 @@ public class RegionStoreClient extends AbstractRegionStoreClient {
       this.regionManager = regionManager;
     }
 
-    public RegionStoreClient build(TiRegion region, Store store) {
+    public RegionStoreClient build(TiRegion region, Store store) throws GrpcException {
       Objects.requireNonNull(region, "region is null");
       Objects.requireNonNull(store, "store is null");
 
@@ -628,12 +628,12 @@ public class RegionStoreClient extends AbstractRegionStoreClient {
           conf, region, channelFactory, blockingStub, asyncStub, regionManager);
     }
 
-    public RegionStoreClient build(ByteString key) {
+    public RegionStoreClient build(ByteString key) throws GrpcException {
       Pair<TiRegion, Store> pair = regionManager.getRegionStorePairByKey(key);
       return build(pair.first, pair.second);
     }
 
-    public RegionStoreClient build(TiRegion region) {
+    public RegionStoreClient build(TiRegion region) throws GrpcException {
       Store store = regionManager.getStoreById(region.getLeader().getStoreId());
       return build(region, store);
     }

--- a/tikv-client/src/main/java/com/pingcap/tikv/streaming/StreamingResponse.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/streaming/StreamingResponse.java
@@ -58,7 +58,6 @@ public class StreamingResponse implements Iterable {
         return response.getRegionError();
       }
     }
-
     return null;
   }
 

--- a/tikv-client/src/main/java/com/pingcap/tikv/txn/LockResolverClient.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/txn/LockResolverClient.java
@@ -20,19 +20,17 @@ package com.pingcap.tikv.txn;
 import static com.pingcap.tikv.util.BackOffFunction.BackOffFuncType.BoRegionMiss;
 
 import com.google.protobuf.ByteString;
-import com.pingcap.tikv.AbstractGRPCClient;
 import com.pingcap.tikv.TiConfiguration;
 import com.pingcap.tikv.exception.KeyException;
 import com.pingcap.tikv.exception.RegionException;
 import com.pingcap.tikv.operation.KVErrorHandler;
-import com.pingcap.tikv.region.RegionErrorReceiver;
+import com.pingcap.tikv.region.AbstractRegionStoreClient;
 import com.pingcap.tikv.region.RegionManager;
 import com.pingcap.tikv.region.TiRegion;
 import com.pingcap.tikv.region.TiRegion.RegionVerID;
 import com.pingcap.tikv.util.BackOffer;
 import com.pingcap.tikv.util.ChannelFactory;
 import com.pingcap.tikv.util.TsoUtils;
-import io.grpc.ManagedChannel;
 import java.util.*;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -42,14 +40,12 @@ import org.tikv.kvproto.Kvrpcpb.CleanupRequest;
 import org.tikv.kvproto.Kvrpcpb.CleanupResponse;
 import org.tikv.kvproto.Kvrpcpb.ResolveLockRequest;
 import org.tikv.kvproto.Kvrpcpb.ResolveLockResponse;
-import org.tikv.kvproto.Metapb.Store;
 import org.tikv.kvproto.TikvGrpc;
 import org.tikv.kvproto.TikvGrpc.TikvBlockingStub;
 import org.tikv.kvproto.TikvGrpc.TikvStub;
 
 // LockResolver resolves locks and also caches resolved txn status.
-public class LockResolverClient extends AbstractGRPCClient<TikvBlockingStub, TikvStub>
-    implements RegionErrorReceiver {
+public class LockResolverClient extends AbstractRegionStoreClient {
   // ResolvedCacheSize is max number of cached txn status.
   private static final long RESOLVED_TXN_CACHE_SIZE = 2048;
   // By default, locks after 3000ms is considered unusual (the client created the
@@ -70,24 +66,18 @@ public class LockResolverClient extends AbstractGRPCClient<TikvBlockingStub, Tik
   private final Map<Long, Long> resolved;
   // the list is chain of txn for O(1) lru cache
   private final Queue<Long> recentResolved;
-  private TikvBlockingStub blockingStub;
-  private TikvStub asyncStub;
-  private TiRegion region;
-  private final RegionManager regionManager;
 
   public LockResolverClient(
       TiConfiguration conf,
+      TiRegion region,
       TikvBlockingStub blockingStub,
       TikvStub asyncStub,
       ChannelFactory channelFactory,
       RegionManager regionManager) {
-    super(conf, channelFactory);
+    super(conf, region, channelFactory, blockingStub, asyncStub, regionManager);
     resolved = new HashMap<>();
     recentResolved = new LinkedList<>();
     readWriteLock = new ReentrantReadWriteLock();
-    this.blockingStub = blockingStub;
-    this.regionManager = regionManager;
-    this.asyncStub = asyncStub;
   }
 
   private void saveResolved(long txnID, long status) {
@@ -139,9 +129,10 @@ public class LockResolverClient extends AbstractGRPCClient<TikvBlockingStub, Tik
           new KVErrorHandler<>(
               regionManager,
               this,
+              this,
               region,
-              resp -> resp.hasRegionError() ? resp.getRegionError() : null);
-
+              resp -> resp.hasRegionError() ? resp.getRegionError() : null,
+              resp -> null);
       CleanupResponse resp = callWithRetry(bo, TikvGrpc.METHOD_KV_CLEANUP, factory, handler);
 
       status = 0L;
@@ -236,9 +227,10 @@ public class LockResolverClient extends AbstractGRPCClient<TikvBlockingStub, Tik
           new KVErrorHandler<>(
               regionManager,
               this,
+              this,
               region,
-              resp -> resp.hasRegionError() ? resp.getRegionError() : null);
-
+              resp -> resp.hasRegionError() ? resp.getRegionError() : null,
+              resp -> null);
       ResolveLockResponse resp =
           callWithRetry(bo, TikvGrpc.METHOD_KV_RESOLVE_LOCK, factory, handler);
 
@@ -256,52 +248,5 @@ public class LockResolverClient extends AbstractGRPCClient<TikvBlockingStub, Tik
       cleanRegion.add(region.getVerID());
       return;
     }
-  }
-
-  @Override
-  protected TikvBlockingStub getBlockingStub() {
-    return blockingStub.withDeadlineAfter(getConf().getTimeout(), getConf().getTimeoutUnit());
-  }
-
-  @Override
-  protected TikvStub getAsyncStub() {
-    return asyncStub.withDeadlineAfter(getConf().getTimeout(), getConf().getTimeoutUnit());
-  }
-
-  @Override
-  public void close() throws Exception {}
-
-  /**
-   * onNotLeader deals with NotLeaderError and returns whether re-splitting key range is needed
-   *
-   * @param newStore the new store presented by NotLeader Error
-   * @return false when re-split is needed.
-   */
-  @Override
-  public boolean onNotLeader(Store newStore) {
-    if (logger.isDebugEnabled()) {
-      logger.debug(region + ", new leader = " + newStore.getId());
-    }
-    TiRegion cachedRegion = regionManager.getRegionById(region.getId());
-    // When switch leader fails or the region changed its key range,
-    // it would be necessary to re-split task's key range for new region.
-    if (!region.getStartKey().equals(cachedRegion.getStartKey())
-        || !region.getEndKey().equals(cachedRegion.getEndKey())) {
-      return false;
-    }
-    region = cachedRegion;
-    String addressStr = newStore.getAddress();
-    ManagedChannel channel = channelFactory.getChannel(addressStr);
-    blockingStub = TikvGrpc.newBlockingStub(channel);
-    asyncStub = TikvGrpc.newStub(channel);
-    return true;
-  }
-
-  @Override
-  public void onStoreNotMatch(Store store) {
-    String addressStr = store.getAddress();
-    ManagedChannel channel = channelFactory.getChannel(addressStr);
-    blockingStub = TikvGrpc.newBlockingStub(channel);
-    asyncStub = TikvGrpc.newStub(channel);
   }
 }

--- a/tikv-client/src/main/java/com/pingcap/tikv/util/ConcreteBackOffer.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/util/ConcreteBackOffer.java
@@ -64,11 +64,22 @@ public class ConcreteBackOffer implements BackOffer {
     return new ConcreteBackOffer(TSO_MAX_BACKOFF);
   }
 
+  public static ConcreteBackOffer create(BackOffer source) {
+    return new ConcreteBackOffer(((ConcreteBackOffer) source));
+  }
+
   private ConcreteBackOffer(int maxSleep) {
     Preconditions.checkArgument(maxSleep >= 0, "Max sleep time cannot be less than 0.");
     this.maxSleep = maxSleep;
     this.errors = new ArrayList<>();
     this.backOffFunctionMap = new HashMap<>();
+  }
+
+  private ConcreteBackOffer(ConcreteBackOffer source) {
+    this.maxSleep = source.maxSleep;
+    this.totalSleep = source.totalSleep;
+    this.errors = source.errors;
+    this.backOffFunctionMap = source.backOffFunctionMap;
   }
 
   /**

--- a/tikv-client/src/test/java/com/pingcap/tikv/PDClientTest.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/PDClientTest.java
@@ -258,7 +258,7 @@ public class PDClientTest extends PDMockServerTest {
           () -> client.getStore(ConcreteBackOffer.newCustomBackOff(5000), 0);
       Future<Store> storeFuture = service.submit(storeCallable);
       try {
-        Store r = storeFuture.get(5, TimeUnit.SECONDS);
+        Store r = storeFuture.get(50, TimeUnit.SECONDS);
         assertEquals(r.getId(), storeId);
       } catch (TimeoutException e) {
         fail();

--- a/tikv-client/src/test/java/com/pingcap/tikv/txn/LockResolverRCTest.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/txn/LockResolverRCTest.java
@@ -70,28 +70,36 @@ public class LockResolverRCTest extends LockResolverTest {
     TiTimestamp startTs = pdClient.getTimestamp(backOffer);
     TiTimestamp endTs = pdClient.getTimestamp(backOffer);
 
+    // Put <a, a> into kv
     putKV("a", "a", startTs.getVersion(), endTs.getVersion());
 
     startTs = pdClient.getTimestamp(backOffer);
     endTs = pdClient.getTimestamp(backOffer);
 
-    lockKey("a", "aa", "a", "aa", false, startTs.getVersion(), endTs.getVersion());
+    // Prewrite <a, aa> as primary without committing it
+    assertTrue(lockKey("a", "aa", "a", "aa", false, startTs.getVersion(), endTs.getVersion()));
 
-    TiRegion tiRegion =
-        session.getRegionManager().getRegionByKey(ByteString.copyFromUtf8(String.valueOf('a')));
+    TiRegion tiRegion = session.getRegionManager().getRegionByKey(ByteString.copyFromUtf8("a"));
     RegionStoreClient client = builder.build(tiRegion);
+    // In RC mode, lock will not be read. <a, a> is retrieved.
     ByteString v =
         client.get(
-            backOffer,
-            ByteString.copyFromUtf8(String.valueOf('a')),
-            pdClient.getTimestamp(backOffer).getVersion());
-    assertEquals(v.toStringUtf8(), String.valueOf('a'));
+            backOffer, ByteString.copyFromUtf8("a"), pdClient.getTimestamp(backOffer).getVersion());
+    assertEquals(v.toStringUtf8(), "a");
 
     try {
-      commit(
-          startTs.getVersion(),
-          endTs.getVersion(),
-          Collections.singletonList(ByteString.copyFromUtf8("a")));
+      // After committing <a, aa>, we can read it.
+      assertTrue(
+          commit(
+              startTs.getVersion(),
+              endTs.getVersion(),
+              Collections.singletonList(ByteString.copyFromUtf8("a"))));
+      v =
+          client.get(
+              backOffer,
+              ByteString.copyFromUtf8("a"),
+              pdClient.getTimestamp(backOffer).getVersion());
+      assertEquals(v.toStringUtf8(), "aa");
     } catch (KeyException e) {
       fail();
     }

--- a/tikv-client/src/test/java/com/pingcap/tikv/txn/LockResolverSITest.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/txn/LockResolverSITest.java
@@ -74,7 +74,7 @@ public class LockResolverSITest extends LockResolverTest {
       String k = String.valueOf((char) ('a' + i));
       TiTimestamp startTs = pdClient.getTimestamp(backOffer);
       TiTimestamp endTs = pdClient.getTimestamp(backOffer);
-      lockKey(k, k, k, k, false, startTs.getVersion(), endTs.getVersion());
+      assertTrue(lockKey(k, k, k, k, false, startTs.getVersion(), endTs.getVersion()));
     }
 
     List<Mutation> mutations = new ArrayList<>();
@@ -125,36 +125,33 @@ public class LockResolverSITest extends LockResolverTest {
     TiTimestamp endTs = pdClient.getTimestamp(backOffer);
 
     putKV("a", "a", startTs.getVersion(), endTs.getVersion());
-    TiRegion tiRegion =
-        session.getRegionManager().getRegionByKey(ByteString.copyFromUtf8(String.valueOf('a')));
+    TiRegion tiRegion = session.getRegionManager().getRegionByKey(ByteString.copyFromUtf8("a"));
     RegionStoreClient client = builder.build(tiRegion);
     long status =
         client.lockResolverClient.getTxnStatus(
-            backOffer, startTs.getVersion(), ByteString.copyFromUtf8(String.valueOf('a')));
+            backOffer, startTs.getVersion(), ByteString.copyFromUtf8("a"));
     assertEquals(status, endTs.getVersion());
 
     startTs = pdClient.getTimestamp(backOffer);
     endTs = pdClient.getTimestamp(backOffer);
 
-    lockKey("a", "a", "a", "a", true, startTs.getVersion(), endTs.getVersion());
-    tiRegion =
-        session.getRegionManager().getRegionByKey(ByteString.copyFromUtf8(String.valueOf('a')));
+    assertTrue(lockKey("a", "a", "a", "a", true, startTs.getVersion(), endTs.getVersion()));
+    tiRegion = session.getRegionManager().getRegionByKey(ByteString.copyFromUtf8("a"));
     client = builder.build(tiRegion);
     status =
         client.lockResolverClient.getTxnStatus(
-            backOffer, startTs.getVersion(), ByteString.copyFromUtf8(String.valueOf('a')));
+            backOffer, startTs.getVersion(), ByteString.copyFromUtf8("a"));
     assertEquals(status, endTs.getVersion());
 
     startTs = pdClient.getTimestamp(backOffer);
     endTs = pdClient.getTimestamp(backOffer);
 
-    lockKey("a", "a", "a", "a", false, startTs.getVersion(), endTs.getVersion());
-    tiRegion =
-        session.getRegionManager().getRegionByKey(ByteString.copyFromUtf8(String.valueOf('a')));
+    assertTrue(lockKey("a", "a", "a", "a", false, startTs.getVersion(), endTs.getVersion()));
+    tiRegion = session.getRegionManager().getRegionByKey(ByteString.copyFromUtf8("a"));
     client = builder.build(tiRegion);
     status =
         client.lockResolverClient.getTxnStatus(
-            backOffer, startTs.getVersion(), ByteString.copyFromUtf8(String.valueOf('a')));
+            backOffer, startTs.getVersion(), ByteString.copyFromUtf8("a"));
     assertNotSame(status, endTs.getVersion());
   }
 
@@ -167,30 +164,43 @@ public class LockResolverSITest extends LockResolverTest {
     TiTimestamp startTs = pdClient.getTimestamp(backOffer);
     TiTimestamp endTs = pdClient.getTimestamp(backOffer);
 
+    // Put <a, a> into kv
     putKV("a", "a", startTs.getVersion(), endTs.getVersion());
 
     startTs = pdClient.getTimestamp(backOffer);
     endTs = pdClient.getTimestamp(backOffer);
 
-    lockKey("a", "aa", "a", "aa", false, startTs.getVersion(), endTs.getVersion());
+    // Prewrite <a, aa> as primary without committing it
+    assertTrue(lockKey("a", "aa", "a", "aa", false, startTs.getVersion(), endTs.getVersion()));
 
-    TiRegion tiRegion =
-        session.getRegionManager().getRegionByKey(ByteString.copyFromUtf8(String.valueOf('a')));
+    TiRegion tiRegion = session.getRegionManager().getRegionByKey(ByteString.copyFromUtf8("a"));
     RegionStoreClient client = builder.build(tiRegion);
+
+    try {
+      // In SI mode, a lock <a, aa> is read. Try resolve it if expires TTL.
+      client.get(
+          backOffer, ByteString.copyFromUtf8("a"), pdClient.getTimestamp(backOffer).getVersion());
+      fail();
+    } catch (KeyException e) {
+      assertEquals(ByteString.copyFromUtf8("a"), e.getKeyError().getLocked().getKey());
+    }
+
+    // With TTL set to 10, after 10 milliseconds <a, aa> is resolved.
+    // We should be able to read <a, a> instead.
     ByteString v =
         client.get(
-            backOffer,
-            ByteString.copyFromUtf8(String.valueOf('a')),
-            pdClient.getTimestamp(backOffer).getVersion());
+            backOffer, ByteString.copyFromUtf8("a"), pdClient.getTimestamp(backOffer).getVersion());
     assertEquals(v.toStringUtf8(), String.valueOf('a'));
 
     try {
+      // Trying to continue the commit phase of <a, aa> will fail because TxnLockNotFound
       commit(
           startTs.getVersion(),
           endTs.getVersion(),
           Collections.singletonList(ByteString.copyFromUtf8("a")));
       fail();
     } catch (KeyException e) {
+      assertFalse(e.getKeyError().getRetryable().isEmpty());
     }
   }
 }

--- a/tikv-client/src/test/java/com/pingcap/tikv/txn/LockResolverTest.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/txn/LockResolverTest.java
@@ -69,6 +69,18 @@ public abstract class LockResolverTest {
   boolean prewrite(List<Mutation> mutations, long startTS, Mutation primary) {
     if (mutations.size() == 0) return true;
 
+    /*for (Mutation m : mutations) {
+      while (true) {
+        try {
+          TiRegion region = session.getRegionManager().getRegionByKey(m.getKey());
+          RegionStoreClient client = builder.build(region);
+          client.prewrite(backOffer, primary.getKey(), mutations, startTS, DefaultTTL);
+          break;
+        } catch (Exception e) {
+          logger.warn(e.getMessage());
+        }
+      }
+    }*/
     for (Mutation m : mutations) {
       TiRegion region = session.getRegionManager().getRegionByKey(m.getKey());
       RegionStoreClient client = builder.build(region);
@@ -197,7 +209,7 @@ public abstract class LockResolverTest {
               client.lockResolverClient,
               tiRegion,
               resp -> resp.hasRegionError() ? resp.getRegionError() : null,
-              resp -> null);
+              resp -> resp.hasError() ? resp.getError() : null);
       CommitResponse resp =
           client.callWithRetry(backOffer, TikvGrpc.METHOD_KV_COMMIT, factory, handler);
 


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
An alternative enhancement against #986.
Provide an example solution for #987. 
Fix #988

### What is changed and how it works?

**IMPORTANT: SEE TODO IN COMMENTS**

Try to change the RegionStoreClient interface so that it should only deal with retryable errors in one region and one store(as it is named). This PR does part of the job by first making `RegionStoreClient.get()` throw an error whenever an un-retryable exception is encountered, so that it will not need to fetch the region again.

We introduce a new API for all those who want to continue to use RegionStoreClient directly: KVClient. In upper logics such as KVClient and TxnClient, developers should implement the logic of resolving un-retryable exceptions, for instance, re-splitting keys across regions. It will make the error handling more concise for reviewers.

The PR also moves ResolveLock logic to ErrorHandler so that the ErrorHandler should be integrated to handle all kinds of manageable errors.

Changes are made to ScanIterator because it should deal with more circumstances such as scanning a range of keys, and resolve locks when they were present during scan.

Logic fixed in LockResolverTest, the test was incorrectly set according to #988. @zhexuany We may discuss it again later.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Related changes

 - Need to cherry-pick to the release branch (should be decided after discussion)
