### PR TITLE
[DNM] Bugfix/kehu

### DIFF
--- a/core/src/test/scala/org/apache/spark/sql/BeikeSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/BeikeSuite.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2017 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql
+
+class BeikeSuite extends BaseTiSparkTest {
+  test("beike") {
+    spark.sql("use tidb_test")
+    spark
+      .sql("SELECT collection_code,count(1) as a from ttt group by collection_code")
+      .explain(true)
+    spark.sql("SELECT collection_code,count(1) as a from ttt group by collection_code").show(false)
+  }
+}

--- a/core/src/test/scala/org/apache/spark/sql/KehuSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/KehuSuite.scala
@@ -15,12 +15,38 @@
 
 package org.apache.spark.sql
 
-class BeikeSuite extends BaseTiSparkTest {
-  test("beike") {
+class KehuSuite extends BaseTiSparkTest {
+  /*
+  use test;
+
+  create table ttt (
+`id` bigint(20) NOT NULL AUTO_INCREMENT,
+`collection_code` int(4) ,
+PRIMARY KEY (`id`),
+KEY `idx_collection_code` (`collection_code`)
+);
+
+insert into ttt values(1, 1);
+insert into ttt values(2, 1);
+insert into ttt values(3, 2);
+insert into ttt values(4, 3);
+   */
+
+  test("kehu") {
     spark.sql("use tidb_test")
     spark
       .sql("SELECT collection_code,count(1) as a from ttt group by collection_code")
       .explain(true)
     spark.sql("SELECT collection_code,count(1) as a from ttt group by collection_code").show(false)
+  }
+
+  test("kehu2") {
+    spark.sql("use tidb_test")
+    spark
+      .sql("SELECT id, collection_code,count(1) as a from ttt group by collection_code, id")
+      .explain(true)
+    spark
+      .sql("SELECT id, collection_code,count(1) as a from ttt group by collection_code, id")
+      .show(false)
   }
 }

--- a/tikv-client/src/main/java/com/pingcap/tikv/predicates/TiKVScanAnalyzer.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/predicates/TiKVScanAnalyzer.java
@@ -42,7 +42,7 @@ import java.util.stream.Collectors;
 import org.tikv.kvproto.Coprocessor.KeyRange;
 
 public class TiKVScanAnalyzer {
-  private static final double INDEX_SCAN_COST_FACTOR = 1.2;
+  private static final double INDEX_SCAN_COST_FACTOR = 0.00002;
   private static final double TABLE_SCAN_COST_FACTOR = 1.0;
   private static final double DOUBLE_READ_COST_FACTOR = TABLE_SCAN_COST_FACTOR * 3;
   private static final long TABLE_PREFIX_SIZE = 8;

--- a/tikv-client/src/main/java/com/pingcap/tikv/predicates/TiKVScanAnalyzer.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/predicates/TiKVScanAnalyzer.java
@@ -38,13 +38,12 @@ import com.pingcap.tikv.statistics.IndexStatistics;
 import com.pingcap.tikv.statistics.TableStatistics;
 import com.pingcap.tikv.util.Pair;
 import java.util.*;
-import java.util.stream.Collectors;
 import org.tikv.kvproto.Coprocessor.KeyRange;
 
 public class TiKVScanAnalyzer {
-  private static final double INDEX_SCAN_COST_FACTOR = 0.00002;
+  private static final double INDEX_SCAN_COST_FACTOR = 0.000000000001;
   private static final double TABLE_SCAN_COST_FACTOR = 1.0;
-  private static final double DOUBLE_READ_COST_FACTOR = TABLE_SCAN_COST_FACTOR * 3;
+  private static final double DOUBLE_READ_COST_FACTOR = 0;
   private static final long TABLE_PREFIX_SIZE = 8;
   private static final long INDEX_PREFIX_SIZE = 8;
 
@@ -426,7 +425,7 @@ public class TiKVScanAnalyzer {
   // query engine doesn't have to lookup the table again compared with double read.
   boolean isCoveringIndex(
       List<TiColumnInfo> columns, TiIndexInfo indexColumns, boolean pkIsHandle) {
-    Map<String, TiIndexColumn> colInIndex =
+    /* Map<String, TiIndexColumn> colInIndex =
         indexColumns
             .getIndexColumns()
             .stream()
@@ -453,7 +452,8 @@ public class TiKVScanAnalyzer {
         return false;
       }
     }
-    return true;
+    return true;*/
+    return false;
   }
 
   @VisibleForTesting


### PR DESCRIPTION
`SELECT id, collection_code,count(1) as a from ttt group by collection_code, id` success

```
== Parsed Logical Plan ==
'Aggregate ['collection_code, 'id], ['id, 'collection_code, 'count(1) AS a#135]
+- 'UnresolvedRelation `tidb_test`.`ttt`

== Analyzed Logical Plan ==
id: bigint, collection_code: bigint, a: bigint
Aggregate [collection_code#145L, id#144L], [id#144L, collection_code#145L, count(1) AS a#135L]
+- SubqueryAlias ttt
   +- Relation[id#144L,collection_code#145L] TiDBRelation(com.pingcap.tikv.TiSession@23dc70c1,TiTableReference(tidb_test,ttt,56),com.pingcap.tispark.MetaManager@53b907d9,null,None)

== Optimized Logical Plan ==
Aggregate [collection_code#145L, id#144L], [id#144L, collection_code#145L, count(1) AS a#135L]
+- Relation[id#144L,collection_code#145L] TiDBRelation(com.pingcap.tikv.TiSession@23dc70c1,TiTableReference(tidb_test,ttt,56),com.pingcap.tispark.MetaManager@53b907d9,null,None)

== Physical Plan ==
*(2) HashAggregate(keys=[collection_code#145L, id#144L], functions=[specialsum(count(1)#146L, LongType, 0)], output=[id#144L, collection_code#145L, a#135L])
+- Exchange hashpartitioning(collection_code#145L, id#144L, 200)
   +- *(1) HashAggregate(keys=[collection_code#145L, id#144L], functions=[partial_specialsum(count(1)#146L, LongType, 0)], output=[collection_code#145L, id#144L, rewriteSum#151L])
      +- TiSpark RegionTaskExec{downgradeThreshold=1000000000,downgradeFilter=[]
         +- TiDB HandleRDD{[table: ttt] IndexScan[Index: idx_collection_code] , Columns: [id], [collection_code], KeyRange: ([t\200\000\000\000\000\000\000\215_i\200\000\000\000\000\000\000\001\000], [t\200\000\000\000\000\000\000\215_i\200\000\000\000\000\000\000\001\372]), Group By: [[collection_code] ASC], [[id] ASC], startTs: 410295538769985537} EstimatedCount:4
+---+---------------+---+
|id |collection_code|a  |
+---+---------------+---+
|1  |1              |1  |
|4  |3              |1  |
|3  |2              |1  |
|2  |1              |1  |
+---+---------------+---+
```

bug `SELECT collection_code,count(1) as a from ttt group by collection_code` fail

```
== Physical Plan ==
*(2) HashAggregate(keys=[collection_code#144L], functions=[specialsum(count(1)#145L, LongType, 0)], output=[collection_code#144L, a#135L])
+- Exchange hashpartitioning(collection_code#144L, 200)
   +- *(1) HashAggregate(keys=[collection_code#144L], functions=[partial_specialsum(count(1)#145L, LongType, 0)], output=[collection_code#144L, rewriteSum#150L])
      +- TiSpark RegionTaskExec{downgradeThreshold=1000000000,downgradeFilter=[]
         +- TiDB HandleRDD{[table: ttt] IndexScan[Index: idx_collection_code] , Columns: [collection_code], KeyRange: ([t\200\000\000\000\000\000\000\215_i\200\000\000\000\000\000\000\001\000], [t\200\000\000\000\000\000\000\215_i\200\000\000\000\000\000\000\001\372]), Aggregates: Count(1), First([collection_code]), Group By: [[collection_code] ASC], startTs: 410295446455975937} EstimatedCount:4
19/08/07 12:41:58 ERROR Executor: Exception in task 0.0 in stage 1.0 (TID 1)
java.lang.RuntimeException: java.io.EOFException
	at com.pingcap.tikv.codec.CodecDataInput.readByte(CodecDataInput.java:160)
	at com.pingcap.tikv.codec.CodecDataInput.peekByte(CodecDataInput.java:284)
	at com.pingcap.tikv.types.DataType.isNextNull(DataType.java:192)
	at com.pingcap.tikv.row.DefaultRowReader.readRow(DefaultRowReader.java:39)
	at com.pingcap.tikv.operation.iterator.CoprocessIterator$2.next(CoprocessIterator.java:113)
	at com.pingcap.tikv.operation.iterator.CoprocessIterator$2.next(CoprocessIterator.java:109)
	at scala.collection.convert.Wrappers$JIteratorWrapper.next(Wrappers.scala:43)
	at scala.collection.Iterator$class.foreach(Iterator.scala:893)
	at scala.collection.AbstractIterator.foreach(Iterator.scala:1336)
	at org.apache.spark.sql.tispark.TiHandleRDD$$anon$2.handleList$lzycompute(TiHandleRDD.scala:63)
	at org.apache.spark.sql.tispark.TiHandleRDD$$anon$2.handleList(TiHandleRDD.scala:61)
	at org.apache.spark.sql.tispark.TiHandleRDD$$anon$2.<init>(TiHandleRDD.scala:77)
	at org.apache.spark.sql.tispark.TiHandleRDD.compute(TiHandleRDD.scala:52)
	at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:324)
	at org.apache.spark.rdd.RDD.iterator(RDD.scala:288)
	at org.apache.spark.rdd.MapPartitionsRDD.compute(MapPartitionsRDD.scala:49)
	at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:324)
	at org.apache.spark.rdd.RDD.iterator(RDD.scala:288)
	at org.apache.spark.rdd.MapPartitionsRDD.compute(MapPartitionsRDD.scala:49)
	at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:324)
	at org.apache.spark.rdd.RDD.iterator(RDD.scala:288)
	at org.apache.spark.rdd.MapPartitionsRDD.compute(MapPartitionsRDD.scala:49)
	at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:324)
	at org.apache.spark.rdd.RDD.iterator(RDD.scala:288)
	at org.apache.spark.rdd.MapPartitionsRDD.compute(MapPartitionsRDD.scala:49)
	at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:324)
	at org.apache.spark.rdd.RDD.iterator(RDD.scala:288)
	at org.apache.spark.rdd.MapPartitionsRDD.compute(MapPartitionsRDD.scala:49)
	at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:324)
	at org.apache.spark.rdd.RDD.iterator(RDD.scala:288)
	at org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:96)
	at org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:53)
	at org.apache.spark.scheduler.Task.run(Task.scala:109)
	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:345)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Caused by: java.io.EOFException
	at java.io.DataInputStream.readByte(DataInputStream.java:267)
	at com.pingcap.tikv.codec.CodecDataInput.readByte(CodecDataInput.java:158)
	... 36 more
19/08/07 12:41:58 WARN TaskSetManager: Lost task 0.0 in stage 1.0 (TID 1, localhost, executor driver): java.lang.RuntimeException: java.io.EOFException
	at com.pingcap.tikv.codec.CodecDataInput.readByte(CodecDataInput.java:160)
	at com.pingcap.tikv.codec.CodecDataInput.peekByte(CodecDataInput.java:284)
	at com.pingcap.tikv.types.DataType.isNextNull(DataType.java:192)
	at com.pingcap.tikv.row.DefaultRowReader.readRow(DefaultRowReader.java:39)
	at com.pingcap.tikv.operation.iterator.CoprocessIterator$2.next(CoprocessIterator.java:113)
	at com.pingcap.tikv.operation.iterator.CoprocessIterator$2.next(CoprocessIterator.java:109)
	at scala.collection.convert.Wrappers$JIteratorWrapper.next(Wrappers.scala:43)
	at scala.collection.Iterator$class.foreach(Iterator.scala:893)
	at scala.collection.AbstractIterator.foreach(Iterator.scala:1336)
	at org.apache.spark.sql.tispark.TiHandleRDD$$anon$2.handleList$lzycompute(TiHandleRDD.scala:63)
	at org.apache.spark.sql.tispark.TiHandleRDD$$anon$2.handleList(TiHandleRDD.scala:61)
	at org.apache.spark.sql.tispark.TiHandleRDD$$anon$2.<init>(TiHandleRDD.scala:77)
	at org.apache.spark.sql.tispark.TiHandleRDD.compute(TiHandleRDD.scala:52)
	at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:324)
	at org.apache.spark.rdd.RDD.iterator(RDD.scala:288)
	at org.apache.spark.rdd.MapPartitionsRDD.compute(MapPartitionsRDD.scala:49)
	at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:324)
	at org.apache.spark.rdd.RDD.iterator(RDD.scala:288)
	at org.apache.spark.rdd.MapPartitionsRDD.compute(MapPartitionsRDD.scala:49)
	at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:324)
	at org.apache.spark.rdd.RDD.iterator(RDD.scala:288)
	at org.apache.spark.rdd.MapPartitionsRDD.compute(MapPartitionsRDD.scala:49)
	at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:324)
	at org.apache.spark.rdd.RDD.iterator(RDD.scala:288)
	at org.apache.spark.rdd.MapPartitionsRDD.compute(MapPartitionsRDD.scala:49)
	at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:324)
	at org.apache.spark.rdd.RDD.iterator(RDD.scala:288)
	at org.apache.spark.rdd.MapPartitionsRDD.compute(MapPartitionsRDD.scala:49)
	at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:324)
	at org.apache.spark.rdd.RDD.iterator(RDD.scala:288)
	at org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:96)
	at org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:53)
	at org.apache.spark.scheduler.Task.run(Task.scala:109)
	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:345)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Caused by: java.io.EOFException
	at java.io.DataInputStream.readByte(DataInputStream.java:267)
	at com.pingcap.tikv.codec.CodecDataInput.readByte(CodecDataInput.java:158)
	... 36 more
```

