### PR TITLE
add auto mode for test.data.load

### DIFF
--- a/core/src/test/Readme.md
+++ b/core/src/test/Readme.md
@@ -20,7 +20,8 @@ spark.tispark.pd.addresses=127.0.0.1:2379
 # Whether to allow index read in tests, you must set this to true to run index tests.
 spark.tispark.plan.allow_index_read=true
 # Whether to load test data before running tests. If you haven't load tispark_test or tpch_test data, set this to true. The next time you run tests, you can set this to false.
-test.data.load=false
+# If you do not want the change this value, please set it to auto, the test data will be loaded only if it does not exist in tidb.
+test.data.load=auto
 # DB prefix for tidb tables in case it conflicts with hive database
 spark.tispark.db_prefix=tidb_
 ```

--- a/core/src/test/resources/tidb_config.properties.template
+++ b/core/src/test/resources/tidb_config.properties.template
@@ -17,7 +17,8 @@
 # Whether to allow index read in tests, you must set this to true to run index tests.
 # spark.tispark.plan.allow_index_read=true
 # Whether to load test data before running tests. If you haven't load tispark_test or tpch_test data, set this to true. The next time you run tests, you can set this to false.
-# test.data.load=true
+# If you do not want the change this value, please set it to auto, the test data will be loaded only if it does not exist in tidb.
+# test.data.load=auto
 # Whether to generate test data. Enabling test data generation may change data of all tests.
 # test.data.generate=true
 # DB prefix for tidb databases in case it conflicts with hive database


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
close https://github.com/pingcap/tispark/issues/992

each time i destroy tidb instance and create a new one, i always forget to change the parameter `test.data.load` to `true`

### What is changed and how it works?
add `auto` for parameter `test.data.load`
