### PR TITLE
refactor batch write region pre-split

### DIFF
--- a/.ci/integration_test.groovy
+++ b/.ci/integration_test.groovy
@@ -188,7 +188,7 @@ def call(ghprbActualCommit, ghprbCommentBody, ghprbPullId, ghprbPullTitle, ghprb
                             sleep 60
                             """
     
-                            timeout(60) {
+                            timeout(120) {
                                 run_test(chunk_suffix)
                             }
                         } catch (err) {

--- a/core/src/main/scala/com/pingcap/tispark/TiConfigConst.scala
+++ b/core/src/main/scala/com/pingcap/tispark/TiConfigConst.scala
@@ -39,6 +39,7 @@ object TiConfigConst {
   val WRITE_ALLOW_SPARK_SQL: String = "spark.tispark.write.allow_spark_sql"
   val WRITE_ENABLE: String = "spark.tispark.write.enable"
   val WRITE_WITHOUT_LOCK_TABLE: String = "spark.tispark.write.without_lock_table"
+  val TIKV_REGION_SPLIT_SIZE_IN_MB: String = "spark.tispark.tikv.region_split_size_in_mb"
 
   val SNAPSHOT_ISOLATION_LEVEL: String = "SI"
   val READ_COMMITTED_ISOLATION_LEVEL: String = "RC"

--- a/core/src/main/scala/com/pingcap/tispark/TiDBOptions.scala
+++ b/core/src/main/scala/com/pingcap/tispark/TiDBOptions.scala
@@ -80,8 +80,6 @@ class TiDBOptions(@transient val parameters: CaseInsensitiveMap[String]) extends
   val url: String =
     s"jdbc:mysql://address=(protocol=tcp)(host=$address)(port=$port)/?user=$user&password=$password&useSSL=false&rewriteBatchedStatements=true"
 
-  val dbtable: String = s"$database.$table"
-
   val tiTableRef: TiTableReference = {
     val dbPrefix = parameters.getOrElse(TiConfigConst.DB_PREFIX, "")
     TiTableReference(dbPrefix + database, table)

--- a/core/src/main/scala/com/pingcap/tispark/TiDBUtils.scala
+++ b/core/src/main/scala/com/pingcap/tispark/TiDBUtils.scala
@@ -15,7 +15,7 @@ object TiDBUtils {
    * Returns true if the table already exists in the TiDB.
    */
   def tableExists(conn: Connection, options: TiDBOptions): Boolean = {
-    val sql = s"SELECT * FROM ${options.dbtable} WHERE 1=0"
+    val sql = s"SELECT * FROM `${options.database}`.`${options.table}` WHERE 1=0"
     Try {
       val statement = conn.prepareStatement(sql)
       try {

--- a/core/src/main/scala/com/pingcap/tispark/TiDBWriter.scala
+++ b/core/src/main/scala/com/pingcap/tispark/TiDBWriter.scala
@@ -25,7 +25,9 @@ object TiDBWriter {
             )
         }
       } else {
-        throw new TiBatchWriteException(s"table ${options.dbtable} does not exists!")
+        throw new TiBatchWriteException(
+          s"table `${options.database}`.`${options.table}` does not exists!"
+        )
         // TiDBUtils.createTable(conn, df, options, tiContext)
         // TiDBUtils.saveTable(tiContext, df, Some(df.schema), options)
       }

--- a/core/src/main/scala/com/pingcap/tispark/utils/TiUtil.scala
+++ b/core/src/main/scala/com/pingcap/tispark/utils/TiUtil.scala
@@ -188,6 +188,10 @@ object TiUtil {
       tiConf.setWriteAllowSparkSQL(conf.get(TiConfigConst.WRITE_ALLOW_SPARK_SQL).toBoolean)
     }
 
+    if (conf.contains(TiConfigConst.TIKV_REGION_SPLIT_SIZE_IN_MB)) {
+      tiConf.setTikvRegionSplitSizeInMB(conf.get(TiConfigConst.TIKV_REGION_SPLIT_SIZE_IN_MB).toInt)
+    }
+
     tiConf
   }
 

--- a/core/src/test/scala/com/pingcap/tispark/TiBatchWriteSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/TiBatchWriteSuite.scala
@@ -33,15 +33,15 @@ class TiBatchWriteSuite extends BaseTiSparkTest {
       "SUPPLIER" ::
       Nil
 
-  private val batchWriteTablePrefix = "BATCH_WRITE"
+  private val batchWriteTablePrefix = "BATCH.WRITE"
 
   override def beforeAll(): Unit = {
     super.beforeAll()
     database = tpchDBName
     setCurrentDatabase(database)
     for (table <- tables) {
-      tidbStmt.execute(s"drop table if exists ${batchWriteTablePrefix}_$table")
-      tidbStmt.execute(s"create table if not exists ${batchWriteTablePrefix}_$table like $table ")
+      tidbStmt.execute(s"drop table if exists `${batchWriteTablePrefix}_$table`")
+      tidbStmt.execute(s"create table if not exists `${batchWriteTablePrefix}_$table` like $table ")
     }
   }
 
@@ -67,12 +67,12 @@ class TiBatchWriteSuite extends BaseTiSparkTest {
       setCurrentDatabase(database)
 
       // select
-      queryTiDBViaJDBC(s"select * from ${batchWriteTablePrefix}_$table")
+      queryTiDBViaJDBC(s"select * from `${batchWriteTablePrefix}_$table`")
 
       // assert
       val originCount = queryViaTiSpark(s"select count(*) from $table").head.head.asInstanceOf[Long]
       // cannot use count since batch write is not support index writing yet.
-      val count = queryViaTiSpark(s"select * from ${batchWriteTablePrefix}_$table").length
+      val count = queryViaTiSpark(s"select * from `${batchWriteTablePrefix}_$table`").length
         .asInstanceOf[Long]
       assert(count == originCount)
     }
@@ -98,7 +98,7 @@ class TiBatchWriteSuite extends BaseTiSparkTest {
     try {
       setCurrentDatabase(database)
       for (table <- tables) {
-        tidbStmt.execute(s"drop table if exists ${batchWriteTablePrefix}_$table")
+        tidbStmt.execute(s"drop table if exists `${batchWriteTablePrefix}_$table`")
       }
     } finally {
       super.afterAll()

--- a/core/src/test/scala/com/pingcap/tispark/datasource/BaseDataSourceTest.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/BaseDataSourceTest.scala
@@ -21,7 +21,7 @@ class BaseDataSourceTest(val table: String,
                          val database: String = "tispark_test",
                          val _enableTidbConfigPropertiesInjectedToSpark: Boolean = true)
     extends BaseTiSparkTest {
-  protected def dbtable = s"$database.$table"
+  protected def dbtable = s"`$database`.`$table`"
 
   override def beforeAll(): Unit = {
     enableTidbConfigPropertiesInjectedToSpark = _enableTidbConfigPropertiesInjectedToSpark

--- a/core/src/test/scala/com/pingcap/tispark/datasource/InsertSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/InsertSuite.scala
@@ -6,7 +6,7 @@ import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructT
 
 import scala.collection.mutable.ArrayBuffer
 
-class InsertSuite extends BaseDataSourceTest("test_datasource_insert") {
+class InsertSuite extends BaseDataSourceTest("test.datasource_insert") {
   private val row1 = Row(null, "Hello")
   private val row5 = Row(5, "Duplicate")
 

--- a/core/src/test/scala/com/pingcap/tispark/datasource/RegionSplitSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/RegionSplitSuite.scala
@@ -34,7 +34,7 @@ class RegionSplitSuite extends BaseDataSourceTest("region_split_test") {
     val regionsNum = TiBatchWriteUtils
       .getRegionByIndex(ti.tiSession, tiTableInfo, tiTableInfo.getIndices.get(0))
       .size()
-    assert(regionsNum == 4)
+    assert(regionsNum == 3)
   }
 
   test("table region split test") {
@@ -50,7 +50,7 @@ class RegionSplitSuite extends BaseDataSourceTest("region_split_test") {
 
     val options = Some(Map("enableRegionSplit" -> "true", "regionSplitNum" -> "3"))
 
-    tidbWrite(List(row1), schema, options)
+    tidbWrite(List(row1, row2, row3), schema, options)
 
     val tiTableInfo =
       ti.tiSession.getCatalog.getTable(dbPrefix + database, table)

--- a/tikv-client/src/main/java/com/pingcap/tikv/TiConfiguration.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/TiConfiguration.java
@@ -48,6 +48,7 @@ public class TiConfiguration implements Serializable {
   private static final boolean DEF_WRITE_ENABLE = true;
   private static final boolean DEF_WRITE_ALLOW_SPARK_SQL = false;
   private static final boolean DEF_WRITE_WITHOUT_LOCK_TABLE = false;
+  private static final int DEF_TIKV_REGION_SPLIT_SIZE_IN_MB = 96;
 
   private int timeout = DEF_TIMEOUT;
   private TimeUnit timeoutUnit = DEF_TIMEOUT_UNIT;
@@ -69,6 +70,7 @@ public class TiConfiguration implements Serializable {
   private boolean writeAllowSparkSQL = DEF_WRITE_ALLOW_SPARK_SQL;
   private boolean writeEnable = DEF_WRITE_ENABLE;
   private boolean writeWithoutLockTable = DEF_WRITE_WITHOUT_LOCK_TABLE;
+  private int tikvRegionSplitSizeInMB = DEF_TIKV_REGION_SPLIT_SIZE_IN_MB;
 
   public static TiConfiguration createDefault(String pdAddrsStr) {
     Objects.requireNonNull(pdAddrsStr, "pdAddrsStr is null");
@@ -261,5 +263,13 @@ public class TiConfiguration implements Serializable {
 
   public void setWriteAllowSparkSQL(boolean writeAllowSparkSQL) {
     this.writeAllowSparkSQL = writeAllowSparkSQL;
+  }
+
+  public void setTikvRegionSplitSizeInMB(int tikvRegionSplitSizeInMB) {
+    this.tikvRegionSplitSizeInMB = tikvRegionSplitSizeInMB;
+  }
+
+  public int getTikvRegionSplitSizeInMB() {
+    return tikvRegionSplitSizeInMB;
   }
 }

--- a/tikv-client/src/main/java/com/pingcap/tikv/TiDBJDBCClient.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/TiDBJDBCClient.java
@@ -109,6 +109,7 @@ public class TiDBJDBCClient implements AutoCloseable {
           String.format(
               "split table `%s`.`%s` between (%d) and (%d) regions %d",
               dbName, tblName, minVal, maxVal, regionNum);
+      logger.info("split table region: " + sql);
       tidbStmt.execute(sql);
     } catch (Exception ignored) {
       logger.warn("failed to split table region");
@@ -133,6 +134,7 @@ public class TiDBJDBCClient implements AutoCloseable {
           String.format(
               "split table `%s`.`%s` index %s between (%d) and (%d) regions %d",
               dbName, tblName, idxName, minVal, maxVal, regionNum);
+      logger.info("split index region: " + sql);
       tidbStmt.execute(sql);
     } catch (Exception ignored) {
       logger.warn("failed to split index region");

--- a/tikv-client/src/main/java/com/pingcap/tikv/TiDBJDBCClient.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/TiDBJDBCClient.java
@@ -107,11 +107,35 @@ public class TiDBJDBCClient implements AutoCloseable {
     try (Statement tidbStmt = connection.createStatement()) {
       String sql =
           String.format(
-              "split table %s.%s between (%d) and (%d) regions %d",
+              "split table `%s`.`%s` between (%d) and (%d) regions %d",
               dbName, tblName, minVal, maxVal, regionNum);
       tidbStmt.execute(sql);
     } catch (Exception ignored) {
       logger.warn("failed to split table region");
+    }
+  }
+
+  /**
+   * split index region by calling tidb jdbc command `SPLIT TABLE`, e.g. SPLIT TABLE t INDEX idx
+   * BETWEEN (-9223372036854775808) AND (9223372036854775807) REGIONS 16;
+   *
+   * @param dbName
+   * @param tblName
+   * @param idxName
+   * @param minVal
+   * @param maxVal
+   * @param regionNum
+   */
+  public void splitIndexRegion(
+      String dbName, String tblName, String idxName, long minVal, long maxVal, long regionNum) {
+    try (Statement tidbStmt = connection.createStatement()) {
+      String sql =
+          String.format(
+              "split table `%s`.`%s` index %s between (%d) and (%d) regions %d",
+              dbName, tblName, idxName, minVal, maxVal, regionNum);
+      tidbStmt.execute(sql);
+    } catch (Exception ignored) {
+      logger.warn("failed to split index region");
     }
   }
 

--- a/tikv-client/src/main/java/com/pingcap/tikv/TiDBJDBCClient.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/TiDBJDBCClient.java
@@ -120,12 +120,12 @@ public class TiDBJDBCClient implements AutoCloseable {
    * split index region by calling tidb jdbc command `SPLIT TABLE`, e.g. SPLIT TABLE t INDEX idx
    * BETWEEN (-9223372036854775808) AND (9223372036854775807) REGIONS 16;
    *
-   * @param dbName
-   * @param tblName
-   * @param idxName
-   * @param minVal
-   * @param maxVal
-   * @param regionNum
+   * @param dbName database name in tidb
+   * @param tblName table name in tidb
+   * @param idxName index name in table
+   * @param minVal min value
+   * @param maxVal max value
+   * @param regionNum number of regions to split
    */
   public void splitIndexRegion(
       String dbName, String tblName, String idxName, long minVal, long maxVal, long regionNum) {


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
close https://github.com/pingcap/tispark/issues/891

refine row size estimation when calculate how many regions need to be split.

### What is changed and how it works?
1. use data's real byte size to calculate `region split number`
2. use `SPLIT TABLE t INDEX BETWEEN` instead of `SPLIT TABLE t INDEX BY` 
3. add config `spark.tispark.tikv.region_split_size_in_mb`
4. fix bug: table and database should be wrapped with `

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
