### PR TITLE
prohibit agg or groupby pushdown on double read

### DIFF
--- a/tikv-client/src/main/java/com/pingcap/tikv/meta/TiDAGRequest.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/meta/TiDAGRequest.java
@@ -463,6 +463,7 @@ public class TiDAGRequest implements Serializable {
     }
 
     if (!getGroupByItems().isEmpty() || !getAggregates().isEmpty()) {
+      // only allow table scan or covering index scan push down groupby and agg
       if (!isIndexDoubleScan || (isGroupByCoveredByIndex() && isAggregateCoveredByIndex())) {
         pushDownAggAndGroupBy(dagRequestBuilder, executorBuilder, colOffsetInFieldMap);
       } else {
@@ -472,6 +473,7 @@ public class TiDAGRequest implements Serializable {
 
     if (!getOrderByItems().isEmpty()) {
       if (!isIndexDoubleScan || isOrderByCoveredByIndex()) {
+        // only allow table scan or covering index scan push down orderby
         pushDownOrderBy(dagRequestBuilder, executorBuilder, colOffsetInFieldMap);
       }
     } else if (getLimit() != 0) {
@@ -667,7 +669,7 @@ public class TiDAGRequest implements Serializable {
    * @param mode truncate mode
    * @return a TiDAGRequest
    */
-  public TiDAGRequest setTruncateMode(TiDAGRequest.TruncateMode mode) {
+  TiDAGRequest setTruncateMode(TiDAGRequest.TruncateMode mode) {
     flags = requireNonNull(mode, "mode is null").mask(flags);
     return this;
   }
@@ -719,7 +721,7 @@ public class TiDAGRequest implements Serializable {
     return this;
   }
 
-  public List<Expression> getAggregates() {
+  List<Expression> getAggregates() {
     return aggregates.stream().map(p -> p.first).collect(Collectors.toList());
   }
 
@@ -928,7 +930,7 @@ public class TiDAGRequest implements Serializable {
    *
    * @return boolean
    */
-  public boolean isCoveringIndexScan() {
+  private boolean isCoveringIndexScan() {
     return hasIndex() && !isDoubleRead();
   }
 

--- a/tikv-client/src/main/java/com/pingcap/tikv/meta/TiDAGRequest.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/meta/TiDAGRequest.java
@@ -25,6 +25,7 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.pingcap.tidb.tipb.*;
+import com.pingcap.tidb.tipb.DAGRequest.Builder;
 import com.pingcap.tikv.codec.KeyUtils;
 import com.pingcap.tikv.exception.DAGRequestException;
 import com.pingcap.tikv.exception.TiClientInternalException;
@@ -463,59 +464,79 @@ public class TiDAGRequest implements Serializable {
 
     if (!getGroupByItems().isEmpty() || !getAggregates().isEmpty()) {
       if (!isIndexDoubleScan || (isGroupByCoveredByIndex() && isAggregateCoveredByIndex())) {
-        Aggregation.Builder aggregationBuilder = Aggregation.newBuilder();
-        getGroupByItems()
-            .forEach(
-                tiByItem ->
-                    aggregationBuilder.addGroupBy(
-                        ProtoConverter.toProto(tiByItem.getExpr(), colOffsetInFieldMap)));
-        getAggregates()
-            .forEach(
-                tiExpr ->
-                    aggregationBuilder.addAggFunc(
-                        ProtoConverter.toProto(tiExpr, colOffsetInFieldMap)));
-        executorBuilder.setTp(ExecType.TypeAggregation);
-        dagRequestBuilder.addExecutors(executorBuilder.setAggregation(aggregationBuilder));
-        executorBuilder.clear();
-        addPushDownGroupBys();
-        addPushDownAggregates();
-      } else {
+		  pushDownAggAndGroupBy(dagRequestBuilder, executorBuilder,
+			  colOffsetInFieldMap);
+	  } else {
         return dagRequestBuilder;
       }
     }
 
     if (!getOrderByItems().isEmpty()) {
       if (!isIndexDoubleScan || isOrderByCoveredByIndex()) {
-        TopN.Builder topNBuilder = TopN.newBuilder();
-        getOrderByItems()
-            .forEach(
-                tiByItem ->
-                    topNBuilder.addOrderBy(
-                        com.pingcap.tidb.tipb.ByItem.newBuilder()
-                            .setExpr(
-                                ProtoConverter.toProto(tiByItem.getExpr(), colOffsetInFieldMap))
-                            .setDesc(tiByItem.isDesc())));
-        executorBuilder.setTp(ExecType.TypeTopN);
-        topNBuilder.setLimit(getLimit());
-        dagRequestBuilder.addExecutors(executorBuilder.setTopN(topNBuilder));
-        executorBuilder.clear();
-        addPushDownOrderBys();
-      }
+		  pushDownOrderBy(dagRequestBuilder, executorBuilder,
+			  colOffsetInFieldMap);
+	  }
     } else if (getLimit() != 0) {
       if (!isIndexDoubleScan) {
-        Limit.Builder limitBuilder = Limit.newBuilder();
-        limitBuilder.setLimit(getLimit());
-        executorBuilder.setTp(ExecType.TypeLimit);
-        dagRequestBuilder.addExecutors(executorBuilder.setLimit(limitBuilder));
-        executorBuilder.clear();
-        addPushDownLimits();
-      }
+		  pushDownLimit(dagRequestBuilder, executorBuilder);
+	  }
     }
 
     return dagRequestBuilder;
   }
 
-  private boolean isExpressionCoveredByIndex(Expression expr) {
+	private void pushDownLimit(DAGRequest.Builder dagRequestBuilder,
+		Executor.Builder executorBuilder) {
+		Limit.Builder limitBuilder = Limit.newBuilder();
+		limitBuilder.setLimit(getLimit());
+		executorBuilder.setTp(ExecType.TypeLimit);
+		dagRequestBuilder.addExecutors(executorBuilder.setLimit(limitBuilder));
+		executorBuilder.clear();
+		addPushDownLimits();
+	}
+
+	private void pushDownOrderBy(DAGRequest.Builder dagRequestBuilder,
+		Executor.Builder executorBuilder,
+		Map<ColumnRef, Integer> colOffsetInFieldMap) {
+		TopN.Builder topNBuilder = TopN.newBuilder();
+		getOrderByItems()
+			.forEach(
+				tiByItem ->
+					topNBuilder.addOrderBy(
+						com.pingcap.tidb.tipb.ByItem.newBuilder()
+							.setExpr(
+								ProtoConverter.toProto(tiByItem.getExpr(), colOffsetInFieldMap))
+							.setDesc(tiByItem.isDesc())));
+		executorBuilder.setTp(ExecType.TypeTopN);
+		topNBuilder.setLimit(getLimit());
+		dagRequestBuilder.addExecutors(executorBuilder.setTopN(topNBuilder));
+		executorBuilder.clear();
+		addPushDownOrderBys();
+	}
+
+	private void pushDownAggAndGroupBy(DAGRequest.Builder dagRequestBuilder,
+		Executor.Builder executorBuilder,
+		Map<ColumnRef, Integer> colOffsetInFieldMap) {
+		Aggregation.Builder aggregationBuilder = Aggregation.newBuilder();
+		getGroupByItems()
+			.forEach(
+				tiByItem ->
+					aggregationBuilder.addGroupBy(
+						ProtoConverter
+							.toProto(tiByItem.getExpr(), colOffsetInFieldMap)));
+		getAggregates()
+			.forEach(
+				tiExpr ->
+					aggregationBuilder.addAggFunc(
+						ProtoConverter.toProto(tiExpr, colOffsetInFieldMap)));
+		executorBuilder.setTp(ExecType.TypeAggregation);
+		dagRequestBuilder.addExecutors(executorBuilder.setAggregation(aggregationBuilder));
+		executorBuilder.clear();
+		addPushDownGroupBys();
+		addPushDownAggregates();
+	}
+
+	private boolean isExpressionCoveredByIndex(Expression expr) {
     Set<String> indexColumnRefSet =
         indexInfo
             .getIndexColumns()
@@ -523,7 +544,7 @@ public class TiDAGRequest implements Serializable {
             .filter(x -> !x.isPrefixIndex())
             .map(TiIndexColumn::getName)
             .collect(Collectors.toSet());
-    return PredicateUtils.extractColumnRefFromExpression(expr)
+    return !isDoubleRead() && PredicateUtils.extractColumnRefFromExpression(expr)
         .stream()
         .map(ColumnRef::getName)
         .allMatch(indexColumnRefSet::contains);


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
This solves an index bug.
### What is changed and how it works?
We prohibit agg or groupby pushdown on double read case. 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Manual test (add detailed scripts or steps below)

Related changes
 - Need to cherry-pick to the release branch

