### PR TITLE
Fix scala compiler version

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -261,7 +261,7 @@
             <!-- Scala Format Plug-in -->
             <plugin>
                 <groupId>org.antipathy</groupId>
-                <artifactId>mvn-scalafmt_${scala.version}</artifactId>
+                <artifactId>mvn-scalafmt_${scala.binary.version}</artifactId>
                 <version>0.10_1.5.1</version>
                 <configuration>
                     <sourceDirectories> <!-- (Optional) Paths to source-directories. Overrides ${project.build.sourceDirectory} -->

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <spark.version.compile>2.3.3</spark.version.compile>
         <spark.version.test>2.4.3</spark.version.test>
         <scala.binary.version>2.11</scala.binary.version>
-        <scala.version>2.11.0</scala.version>
+        <scala.version>2.11.12</scala.version>
         <scalatest.version>3.0.4</scalatest.version>
         <argLine>-Dfile.encoding=UTF-8 -Duser.timezone=GMT+8</argLine>
         <mysql.connector.version>5.1.44</mysql.connector.version>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <spark.version.compile>2.3.3</spark.version.compile>
         <spark.version.test>2.4.3</spark.version.test>
         <scala.binary.version>2.11</scala.binary.version>
-        <scala.version>2.11</scala.version>
+        <scala.version>2.11.0</scala.version>
         <scalatest.version>3.0.4</scalatest.version>
         <argLine>-Dfile.encoding=UTF-8 -Duser.timezone=GMT+8</argLine>
         <mysql.connector.version>5.1.44</mysql.connector.version>

--- a/spark-wrapper/spark-2.3/pom.xml
+++ b/spark-wrapper/spark-2.3/pom.xml
@@ -101,7 +101,7 @@
             <!-- Scala Format Plug-in -->
             <plugin>
                 <groupId>org.antipathy</groupId>
-                <artifactId>mvn-scalafmt_${scala.version}</artifactId>
+                <artifactId>mvn-scalafmt_${scala.binary.version}</artifactId>
                 <version>0.10_1.5.1</version>
                 <configuration>
                     <sourceDirectories> <!-- (Optional) Paths to source-directories. Overrides ${project.build.sourceDirectory} -->

--- a/spark-wrapper/spark-2.4/pom.xml
+++ b/spark-wrapper/spark-2.4/pom.xml
@@ -101,7 +101,7 @@
             <!-- Scala Format Plug-in -->
             <plugin>
                 <groupId>org.antipathy</groupId>
-                <artifactId>mvn-scalafmt_${scala.version}</artifactId>
+                <artifactId>mvn-scalafmt_${scala.binary.version}</artifactId>
                 <version>0.10_1.5.1</version>
                 <configuration>
                     <sourceDirectories> <!-- (Optional) Paths to source-directories. Overrides ${project.build.sourceDirectory} -->


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix #1009 

### What is changed and how it works?
set scala version to `2.11.0` instead of `2.11`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

Related changes

 - Need to cherry-pick to the release branch
