### PR TITLE
adding unique indices test for batch write

### DIFF
--- a/core/src/test/scala/com/pingcap/tispark/datasource/BaseDataSourceTest.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/BaseDataSourceTest.scala
@@ -43,8 +43,10 @@ class BaseDataSourceTest(val table: String,
     TiSession.clearCache()
   }
 
-  protected def dropTable(tblName: String): Unit =
+  protected def dropTable(tblName: String): Unit = {
     jdbcUpdate(s"drop table if exists $database.$tblName")
+  }
+
   protected def tidbWriteWithTable(rows: List[Row],
                                    schema: StructType,
                                    tblName: String,
@@ -197,16 +199,20 @@ class BaseDataSourceTest(val table: String,
 
   protected def compareTiDBSelectWithJDBCWithTable_V2(tblName: String,
                                                       sortCol: String = "i"): Unit = {
-    val sql = s"select * from $database.$tblName order by $sortCol"
+    val sql = s"select * from `$database`.`$tblName` order by $sortCol"
 
     // check jdbc result & data source result
     val jdbcResult = queryTiDBViaJDBC(sql)
     val df = queryDatasourceTiDBWithTable(sortCol, tableName = tblName)
     val tidbResult = seqRowToList(df.collect(), df.schema)
 
-    assert(
-      compResult(jdbcResult, tidbResult)
-    )
+    if (compResult(jdbcResult, tidbResult)) {
+      assert(true)
+    } else {
+      println(s"failed on $tblName")
+      println(tidbResult)
+      assert(false)
+    }
   }
 
   protected def compareTiDBSelectWithJDBC_V2(sortCol: String = "i"): Unit = {

--- a/core/src/test/scala/com/pingcap/tispark/datasource/BaseDataSourceTest.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/BaseDataSourceTest.scala
@@ -44,7 +44,7 @@ class BaseDataSourceTest(val table: String,
   }
 
   protected def dropTable(tblName: String): Unit = {
-    jdbcUpdate(s"drop table if exists $database.$tblName")
+    jdbcUpdate(s"drop table if exists `$database`.`$tblName`")
   }
 
   protected def tidbWriteWithTable(rows: List[Row],

--- a/core/src/test/scala/com/pingcap/tispark/datasource/BaseDataSourceTest.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/BaseDataSourceTest.scala
@@ -27,10 +27,6 @@ class BaseDataSourceTest(val table: String,
   override def beforeAll(): Unit = {
     enableTidbConfigPropertiesInjectedToSpark = _enableTidbConfigPropertiesInjectedToSpark
     super.beforeAllWithoutLoadData()
-    if (!database.equals("tispark_test")) {
-      tidbStmt.execute(s"drop database if exists $database")
-      tidbStmt.execute(s"create database $database")
-    }
     initializeTimeZone()
   }
 

--- a/core/src/test/scala/org/apache/spark/sql/insertion/BatchWriteUniqueIndexSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/insertion/BatchWriteUniqueIndexSuite.scala
@@ -18,6 +18,12 @@ class BatchWriteUniqueIndexSuite
   override val database = "batch_write_test_index"
   override val testDesc = "Test for single PK column and multiple unique index type"
 
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    tidbStmt.execute(s"drop database if exists $database")
+    tidbStmt.execute(s"create database $database")
+  }
+
   private def tiRowToSparkRow(row: TiRow, tiColsInfos: java.util.List[TiColumnInfo]) = {
     val sparkRow = new Array[Any](row.fieldCount())
     for (i <- 0 until row.fieldCount()) {
@@ -62,11 +68,12 @@ class BatchWriteUniqueIndexSuite
     }
   }
 
+  // this is only for
   override def test(): Unit = {}
 
   override def afterAll(): Unit =
     try {
-//      dropTable()
+      dropTable()
     } finally {
       super.afterAll()
     }

--- a/core/src/test/scala/org/apache/spark/sql/insertion/BatchWriteUniqueIndexSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/insertion/BatchWriteUniqueIndexSuite.scala
@@ -1,0 +1,73 @@
+package org.apache.spark.sql.insertion
+
+import com.pingcap.tikv.meta.TiColumnInfo
+import com.pingcap.tispark.datasource.BaseDataSourceTest
+import com.pingcap.tispark.utils.TiUtil
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.test.generator.DataType.ReflectedDataType
+import org.apache.spark.sql.test.generator.Schema
+import org.apache.spark.sql.test.generator.TestDataGenerator._
+
+class BatchWriteUniqueIndexSuite
+    extends BaseDataSourceTest("batch_write_insertion_one_unique_index", "batch_write_test_index")
+    with EnumerationUniqueIndexDataTypeTestAction {
+  // TODO: support binary insertion.
+  override val dataTypes: List[ReflectedDataType] = integers ::: decimals ::: doubles ::: charCharset
+  override val unsignedDataTypes: List[ReflectedDataType] = integers ::: decimals ::: doubles
+  override val dataTypeTestDir = "batch-write-test-index"
+  override val database = "batch_write_test_index"
+  override val testDesc = "Test for single PK column and multiple unique index type"
+
+  private def tiRowToSparkRow(row: TiRow, tiColsInfos: java.util.List[TiColumnInfo]) = {
+    val sparkRow = new Array[Any](row.fieldCount())
+    for (i <- 0 until row.fieldCount()) {
+      val colTp = tiColsInfos.get(i).getType
+      val colVal = row.get(i, colTp)
+      sparkRow(i) = colVal
+    }
+    Row.fromSeq(sparkRow)
+  }
+
+  private def dropAndCreateTbl(schema: Schema): Unit = {
+    // drop table if exits
+    dropTable(schema.tableName)
+
+    // create table in tidb first
+    jdbcUpdate(schema.toString)
+  }
+
+  private def insertAndSelect(schema: Schema): Unit = {
+    val tblName = schema.tableName
+
+    val tiTblInfo = getTableInfo(database, tblName)
+    val tiColInfos = tiTblInfo.getColumns
+    // gen data
+    val rows =
+      generateRandomRows(schema, rowCount, r).map(row => tiRowToSparkRow(row, tiColInfos))
+    // insert data to tikv
+    tidbWriteWithTable(rows, TiUtil.getSchemaFromTable(tiTblInfo), tblName)
+    // select data from tikv and compare with tidb
+    compareTiDBSelectWithJDBCWithTable_V2(tblName = tblName, "col_smallint")
+  }
+
+  override def test() = {
+    test("test unique indices cases") {
+      val schemas = genSchema(dataTypes, table)
+
+      schemas.foreach { schema =>
+        dropAndCreateTbl(schema)
+      }
+
+      schemas.foreach { schema =>
+        insertAndSelect(schema)
+      }
+    }
+  }
+
+  override def afterAll(): Unit =
+    try {
+      dropTable()
+    } finally {
+      super.afterAll()
+    }
+}

--- a/core/src/test/scala/org/apache/spark/sql/insertion/BatchWriteUniqueIndexSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/insertion/BatchWriteUniqueIndexSuite.scala
@@ -47,26 +47,26 @@ class BatchWriteUniqueIndexSuite
     // insert data to tikv
     tidbWriteWithTable(rows, TiUtil.getSchemaFromTable(tiTblInfo), tblName)
     // select data from tikv and compare with tidb
-    compareTiDBSelectWithJDBCWithTable_V2(tblName = tblName, "col_smallint")
+    compareTiDBSelectWithJDBCWithTable_V2(tblName = tblName, "col_bigint")
   }
 
-  override def test() = {
-    test("test unique indices cases") {
-      val schemas = genSchema(dataTypes, table)
+  test("test unique indices cases") {
+    val schemas = genSchema(dataTypes, table)
 
-      schemas.foreach { schema =>
-        dropAndCreateTbl(schema)
-      }
+    schemas.foreach { schema =>
+      dropAndCreateTbl(schema)
+    }
 
-      schemas.foreach { schema =>
-        insertAndSelect(schema)
-      }
+    schemas.foreach { schema =>
+      insertAndSelect(schema)
     }
   }
 
+  override def test(): Unit = {}
+
   override def afterAll(): Unit =
     try {
-      dropTable()
+//      dropTable()
     } finally {
       super.afterAll()
     }

--- a/core/src/test/scala/org/apache/spark/sql/insertion/EnumerationUniqueIndexDataTypeTestAction.scala
+++ b/core/src/test/scala/org/apache/spark/sql/insertion/EnumerationUniqueIndexDataTypeTestAction.scala
@@ -1,0 +1,83 @@
+package org.apache.spark.sql.insertion
+
+import org.apache.commons.math3.util.Combinations
+import org.apache.spark.sql.BaseTestGenerationSpec
+import org.apache.spark.sql.test.generator.DataType.{getBaseType, DECIMAL, ReflectedDataType}
+import org.apache.spark.sql.test.generator.TestDataGenerator.{getDecimal, getLength, isCharOrBinary, isDecimals, isStringType, isVarString, schemaGenerator}
+import org.apache.spark.sql.test.generator._
+import org.apache.spark.sql.types.MultiColumnDataTypeTestSpec
+
+import scala.util.Random
+
+trait EnumerationUniqueIndexDataTypeTestAction
+    extends MultiColumnDataTypeTestSpec
+    with BaseTestGenerationSpec {
+  private def genIndex(dataTypes: List[ReflectedDataType], r: Random): List[Index] = {
+    val size = dataTypes.length
+    // the first step is generate all possible keys
+    val keyList = scala.collection.mutable.ListBuffer.empty[Key]
+    for (i <- 1 until 3) {
+      val combination = new Combinations(size, i)
+      //(i, size)
+      val iterator = combination.iterator()
+      while (iterator.hasNext) {
+        val intArray = iterator.next()
+        val indexColumnList = scala.collection.mutable.ListBuffer.empty[IndexColumn]
+        // index may have multiple column
+        for (j <- 0 until intArray.length) {
+          // we add extra one to the column id since 1 is reserved to primary key
+          if (isStringType(dataTypes(intArray(j)))) {
+            indexColumnList += PrefixColumn(intArray(j) + 1, r.nextInt(4) + 2)
+          } else {
+            indexColumnList += DefaultColumn(intArray(j) + 1)
+          }
+        }
+
+        keyList += Key(indexColumnList.toList)
+      }
+    }
+
+    keyList.toList
+  }
+
+  def genLen(dataType: ReflectedDataType): String = {
+    val baseType = getBaseType(dataType)
+    val length = getLength(baseType)
+    dataType match {
+      case DECIMAL                       => s"$length,${getDecimal(baseType)}"
+      case _ if isVarString(dataType)    => s"$length"
+      case _ if isCharOrBinary(dataType) => "10"
+      case _                             => ""
+    }
+  }
+
+  // this only generate schema with one unique index
+  def genSchema(dataTypes: List[ReflectedDataType], tablePrefix: String): List[Schema] = {
+    val indices = genIndex(dataTypes, r)
+
+    val dataTypesWithDescription = dataTypes.map { dataType =>
+      val len = genLen(dataType)
+      (dataType, len, "")
+    }
+
+    indices.zipWithIndex.map { index =>
+      schemaGenerator(
+        database,
+        tablePrefix + index._2,
+        r,
+        dataTypesWithDescription,
+        List(index._1)
+      )
+    }
+  }
+
+  private def toString(dataTypes: Seq[String]): String = dataTypes.hashCode().toString
+
+  override val rowCount = 50
+  override def getTableName(dataTypes: String*): String = s"test_${toString(dataTypes)}"
+
+  override def getTableNameWithDesc(desc: String, dataTypes: String*): String =
+    s"test_${desc}_${toString(dataTypes)}"
+
+  override def getIndexName(dataTypes: String*): String = s"idx_${toString(dataTypes)}"
+}

--- a/core/src/test/scala/org/apache/spark/sql/insertion/EnumerationUniqueIndexDataTypeTestAction.scala
+++ b/core/src/test/scala/org/apache/spark/sql/insertion/EnumerationUniqueIndexDataTypeTestAction.scala
@@ -3,7 +3,7 @@ package org.apache.spark.sql.insertion
 import org.apache.commons.math3.util.Combinations
 import org.apache.spark.sql.BaseTestGenerationSpec
 import org.apache.spark.sql.test.generator.DataType.{getBaseType, DECIMAL, ReflectedDataType}
-import org.apache.spark.sql.test.generator.TestDataGenerator.{getDecimal, getLength, isCharOrBinary, isDecimals, isStringType, isVarString, schemaGenerator}
+import org.apache.spark.sql.test.generator.TestDataGenerator.{getDecimal, getLength, isCharOrBinary, isNumeric, isStringType, isVarString, schemaGenerator}
 import org.apache.spark.sql.test.generator._
 import org.apache.spark.sql.types.MultiColumnDataTypeTestSpec
 
@@ -57,7 +57,11 @@ trait EnumerationUniqueIndexDataTypeTestAction
 
     val dataTypesWithDescription = dataTypes.map { dataType =>
       val len = genLen(dataType)
-      (dataType, len, "")
+      if (isNumeric(dataType)) {
+        (dataType, len, "not null")
+      } else {
+        (dataType, len, "")
+      }
     }
 
     indices.zipWithIndex.map { index =>
@@ -73,7 +77,8 @@ trait EnumerationUniqueIndexDataTypeTestAction
 
   private def toString(dataTypes: Seq[String]): String = dataTypes.hashCode().toString
 
-  override val rowCount = 50
+  override val rowCount = 10
+
   override def getTableName(dataTypes: String*): String = s"test_${toString(dataTypes)}"
 
   override def getTableNameWithDesc(desc: String, dataTypes: String*): String =

--- a/core/src/test/scala/org/apache/spark/sql/test/generator/IndexColumn.scala
+++ b/core/src/test/scala/org/apache/spark/sql/test/generator/IndexColumn.scala
@@ -77,8 +77,8 @@ case class ColumnInfo(columnName: String,
     }
   }
 
-  val generator: ValueGenerator =
-    ValueGenerator(
+  val generator: ColumnValueGenerator =
+    ColumnValueGenerator(
       dataType,
       len,
       decimal,

--- a/core/src/test/scala/org/apache/spark/sql/test/generator/Schema.scala
+++ b/core/src/test/scala/org/apache/spark/sql/test/generator/Schema.scala
@@ -17,7 +17,9 @@
 
 package org.apache.spark.sql.test.generator
 
+import com.pingcap.tispark.utils.{TiConverter, TiUtil}
 import org.apache.spark.sql.test.generator.DataType._
+import org.apache.spark.sql.types.{StructField, StructType}
 
 /**
  * Case class for Schema of TiDB table

--- a/core/src/test/scala/org/apache/spark/sql/test/generator/Schema.scala
+++ b/core/src/test/scala/org/apache/spark/sql/test/generator/Schema.scala
@@ -19,7 +19,6 @@ package org.apache.spark.sql.test.generator
 
 import com.pingcap.tispark.utils.{TiConverter, TiUtil}
 import org.apache.spark.sql.test.generator.DataType._
-import org.apache.spark.sql.types.{StructField, StructType}
 
 /**
  * Case class for Schema of TiDB table

--- a/core/src/test/scala/org/apache/spark/sql/test/generator/TestDataGenerator.scala
+++ b/core/src/test/scala/org/apache/spark/sql/test/generator/TestDataGenerator.scala
@@ -86,8 +86,8 @@ object TestDataGenerator {
   //  def isBits(dataType: DataType): Boolean = bits.contains(dataType)
   //  def isBooleans(dataType: DataType): Boolean = booleans.contains(dataType)
   //  def isIntegers(dataType: DataType): Boolean = integers.contains(dataType)
-  //  def isDecimals(dataType: DataType): Boolean = decimals.contains(dataType)
-  //  def isDoubles(dataType: DataType): Boolean = doubles.contains(dataType)
+  def isDecimals(dataType: ReflectedDataType): Boolean = decimals.contains(dataType)
+  def isDoubles(dataType: ReflectedDataType): Boolean = doubles.contains(dataType)
   //  def isTimestamps(dataType: DataType): Boolean = timestamps.contains(dataType)
   //  def isDates(dataType: DataType): Boolean = dates.contains(dataType)
   //  def isDurations(dataType: DataType): Boolean = durations.contains(dataType)
@@ -270,15 +270,15 @@ object TestDataGenerator {
     Schema(database, table, columnNames, columnDesc.toMap, idxColumns)
   }
 
-  private def generateRandomValue(row: TiRow,
-                                  offset: Int,
-                                  r: Random,
-                                  valueGenerator: ValueGenerator): Unit = {
-    val value = valueGenerator.next(r)
+  private def generateRandomColValue(row: TiRow,
+                                     offset: Int,
+                                     r: Random,
+                                     colValueGenerator: ColumnValueGenerator): Unit = {
+    val value = colValueGenerator.next(r)
     if (value == null) {
       row.setNull(offset)
     } else {
-      row.set(offset, valueGenerator.tiDataType, value)
+      row.set(offset, colValueGenerator.tiDataType, value)
     }
   }
 
@@ -319,7 +319,7 @@ object TestDataGenerator {
     while (true) {
       for (i <- schema.columnInfo.indices) {
         val columnInfo = schema.columnInfo(i)
-        generateRandomValue(row, i, r, columnInfo.generator)
+        generateRandomColValue(row, i, r, columnInfo.generator)
       }
       if (pkOffset.nonEmpty) {
         val value = pkOffset.map { i =>
@@ -335,7 +335,7 @@ object TestDataGenerator {
     throw new RuntimeException("Inaccessible")
   }
 
-  private def generateRandomRows(schema: Schema, n: Long, r: Random): List[TiRow] = {
+  def generateRandomRows(schema: Schema, n: Long, r: Random): List[TiRow] = {
     val set: mutable.Set[Any] = mutable.HashSet.empty[Any]
     // offset of pk columns
     val pkOffset: List[Int] = {

--- a/tikv-client/src/main/java/com/pingcap/tikv/allocator/RowIDAllocator.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/allocator/RowIDAllocator.java
@@ -53,6 +53,7 @@ public final class RowIDAllocator {
     } else {
       allocator.initSigned(TiSession.getInstance(conf).createSnapshot(), tableId);
     }
+
     return allocator;
   }
 

--- a/tikv-client/src/main/java/com/pingcap/tikv/region/RegionStoreClient.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/region/RegionStoreClient.java
@@ -87,6 +87,7 @@ public class RegionStoreClient extends AbstractGRPCClient<TikvBlockingStub, Tikv
   private boolean checkLockError(BackOffer backOffer, KeyError error) {
     if (error.hasLocked()) {
       Lock lock = new Lock(error.getLocked());
+      logger.warn("resolving lock");
       boolean ok =
           lockResolverClient.resolveLocks(
               backOffer, new ArrayList<>(Collections.singletonList(lock)));


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
Improve the coverage of batch-write on unique indices.

### What is changed and how it works?
In this PR, we are trying to improve the coverage of batch-write on unique indices. 

In order to test the correctness of batch-write, we have to create different schemas with different numbers of the index on the schema. Additionally, we have to prepare data and use batch-write api to perform the insertion. 

After discussion with @birdstorm, we decided we should generate the schema, so does the data. 

To generate different schemas, we create an array of `dataTypes`. Our schema generator enumerates over the `dataTypes` and chooses some of them to become unique indices. 

Once we have schema, we generate data randomly. 

With schema and data, it is ready to test our batch-write api.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Integration test

