### PR TITLE
Delete TiSession.create()

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/TiContext.scala
+++ b/core/src/main/scala/org/apache/spark/sql/TiContext.scala
@@ -43,7 +43,7 @@ class TiContext(val sparkSession: SparkSession, options: Option[TiDBOptions] = N
   lazy val sqlContext: SQLContext = sparkSession.sqlContext
   val conf: SparkConf = mergeWithDataSourceConfig(sparkSession.sparkContext.conf, options)
   val tiConf: TiConfiguration = TiUtil.sparkConfToTiConf(conf)
-  val tiSession: TiSession = TiSession.create(tiConf)
+  val tiSession: TiSession = TiSession.getInstance(tiConf)
   val meta: MetaManager = new MetaManager(tiSession.getCatalog)
 
   StatisticsManager.initStatisticsManager(tiSession)

--- a/tikv-client/README.md
+++ b/tikv-client/README.md
@@ -29,7 +29,7 @@ It is not recommended to use tikv java client directly; it is better to use toge
 ```java
 // Init tidb cluster configuration
 TiConfiguration conf = TiConfiguration.createDefault("127.0.0.1:2379");
-TiSession session = TiSession.create(conf);
+TiSession session = TiSession.getInstance(conf);
 Catalog cat = session.getCatalog();
 TiDBInfo db = cat.getDatabase("tpch_test");
 TiTableInfo table = cat.getTable(db, "customer");

--- a/tikv-client/src/main/java/com/pingcap/tikv/TiSession.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/TiSession.java
@@ -43,7 +43,7 @@ public class TiSession implements AutoCloseable {
   private volatile RegionManager regionManager;
   private volatile RegionStoreClient.RegionStoreClientBuilder clientBuilder;
 
-  private static Map<String, TiSession> sessionCachedMap = new HashMap<>();
+  private static final Map<String, TiSession> sessionCachedMap = new HashMap<>();
 
   // Since we create session as singleton now, configuration change will not
   // reflect change
@@ -192,9 +192,13 @@ public class TiSession implements AutoCloseable {
 
   @Override
   public synchronized void close() throws Exception {
-    sessionCachedMap.remove(getConf().getPdAddrsString());
-    getThreadPoolForTableScan().shutdownNow();
-    getThreadPoolForIndexScan().shutdownNow();
+    sessionCachedMap.remove(conf.getPdAddrsString());
+    if (tableScanThreadPool != null) {
+      tableScanThreadPool.shutdownNow();
+    }
+    if (indexScanThreadPool != null) {
+      indexScanThreadPool.shutdownNow();
+    }
     if (client != null) {
       getPDClient().close();
     }

--- a/tikv-client/src/main/java/com/pingcap/tikv/TiSession.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/TiSession.java
@@ -29,11 +29,8 @@ import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.function.Function;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class TiSession implements AutoCloseable {
-  private final Logger logger = LoggerFactory.getLogger(TiSession.class);
   private final TiConfiguration conf;
   private final ChannelFactory channelFactory;
   private Function<CacheInvalidateEvent, Void> cacheInvalidateCallback;
@@ -180,10 +177,6 @@ public class TiSession implements AutoCloseable {
     return res;
   }
 
-  public static TiSession create(TiConfiguration conf) {
-    return new TiSession(conf);
-  }
-
   /**
    * This is used for setting call back function to invalidate cache information
    *
@@ -191,6 +184,10 @@ public class TiSession implements AutoCloseable {
    */
   public void injectCallBackFunc(Function<CacheInvalidateEvent, Void> callBackFunc) {
     this.cacheInvalidateCallback = callBackFunc;
+  }
+
+  public static void clearCache() {
+    TiSession.sessionCachedMap.clear();
   }
 
   @Override

--- a/tikv-client/src/main/java/com/pingcap/tikv/TiSession.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/TiSession.java
@@ -191,7 +191,8 @@ public class TiSession implements AutoCloseable {
   }
 
   @Override
-  public void close() throws Exception {
+  public synchronized void close() throws Exception {
+    sessionCachedMap.remove(getConf().getPdAddrsString());
     getThreadPoolForTableScan().shutdownNow();
     getThreadPoolForIndexScan().shutdownNow();
     if (client != null) {

--- a/tikv-client/src/main/java/com/pingcap/tikv/allocator/RowIDAllocator.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/allocator/RowIDAllocator.java
@@ -49,9 +49,9 @@ public final class RowIDAllocator {
       long dbId, long tableId, TiConfiguration conf, boolean unsigned, long step) {
     RowIDAllocator allocator = new RowIDAllocator(dbId, step, conf);
     if (unsigned) {
-      allocator.initUnsigned(TiSession.create(conf).createSnapshot(), tableId);
+      allocator.initUnsigned(TiSession.getInstance(conf).createSnapshot(), tableId);
     } else {
-      allocator.initSigned(TiSession.create(conf).createSnapshot(), tableId);
+      allocator.initSigned(TiSession.getInstance(conf).createSnapshot(), tableId);
     }
     return allocator;
   }

--- a/tikv-client/src/test/java/com/pingcap/tikv/PDMockServerTest.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/PDMockServerTest.java
@@ -40,7 +40,7 @@ public abstract class PDMockServerTest {
             GrpcUtils.makeMember(2, "http://" + addr + ":" + (pdServer.port + 1)),
             GrpcUtils.makeMember(3, "http://" + addr + ":" + (pdServer.port + 2))));
     TiConfiguration conf = TiConfiguration.createDefault(addr + ":" + pdServer.port);
-    session = TiSession.create(conf);
+    session = TiSession.getInstance(conf);
   }
 
   @After

--- a/tikv-client/src/test/java/com/pingcap/tikv/txn/LockResolverRCTest.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/txn/LockResolverRCTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2017 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pingcap.tikv.txn;
+
+import static junit.framework.TestCase.*;
+
+import com.google.protobuf.ByteString;
+import com.pingcap.tikv.TiConfiguration;
+import com.pingcap.tikv.TiSession;
+import com.pingcap.tikv.exception.KeyException;
+import com.pingcap.tikv.meta.TiTimestamp;
+import com.pingcap.tikv.region.RegionStoreClient;
+import com.pingcap.tikv.region.TiRegion;
+import java.util.Collections;
+import org.apache.log4j.Logger;
+import org.junit.Before;
+import org.junit.Test;
+import org.tikv.kvproto.Kvrpcpb.*;
+
+public class LockResolverRCTest extends LockResolverTest {
+  private final Logger logger = Logger.getLogger(this.getClass());
+
+  @Before
+  public void setUp() {
+    TiConfiguration conf = TiConfiguration.createDefault("127.0.0.1:2379");
+    conf.setIsolationLevel(IsolationLevel.RC);
+    try {
+      session = TiSession.getInstance(conf);
+      pdClient = session.getPDClient();
+      this.builder = session.getRegionStoreClientBuilder();
+      init = true;
+    } catch (Exception e) {
+      logger.warn("TiDB cluster may not be present");
+      init = false;
+    }
+  }
+
+  @Test
+  public void getRCTest() {
+    if (!init) {
+      skipTest();
+      return;
+    }
+    putAlphabet();
+    prepareAlphabetLocks();
+
+    versionTest();
+  }
+
+  @Test
+  public void RCTest() {
+    if (!init) {
+      skipTest();
+      return;
+    }
+    TiTimestamp startTs = pdClient.getTimestamp(backOffer);
+    TiTimestamp endTs = pdClient.getTimestamp(backOffer);
+
+    putKV("a", "a", startTs.getVersion(), endTs.getVersion());
+
+    startTs = pdClient.getTimestamp(backOffer);
+    endTs = pdClient.getTimestamp(backOffer);
+
+    lockKey("a", "aa", "a", "aa", false, startTs.getVersion(), endTs.getVersion());
+
+    TiRegion tiRegion =
+        session.getRegionManager().getRegionByKey(ByteString.copyFromUtf8(String.valueOf('a')));
+    RegionStoreClient client = builder.build(tiRegion);
+    ByteString v =
+        client.get(
+            backOffer,
+            ByteString.copyFromUtf8(String.valueOf('a')),
+            pdClient.getTimestamp(backOffer).getVersion());
+    assertEquals(v.toStringUtf8(), String.valueOf('a'));
+
+    try {
+      commit(
+          startTs.getVersion(),
+          endTs.getVersion(),
+          Collections.singletonList(ByteString.copyFromUtf8("a")));
+    } catch (KeyException e) {
+      fail();
+    }
+  }
+}

--- a/tikv-client/src/test/java/com/pingcap/tikv/txn/LockResolverSITest.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/txn/LockResolverSITest.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2017 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pingcap.tikv.txn;
+
+import static junit.framework.TestCase.*;
+
+import com.google.protobuf.ByteString;
+import com.pingcap.tikv.TiConfiguration;
+import com.pingcap.tikv.TiSession;
+import com.pingcap.tikv.exception.KeyException;
+import com.pingcap.tikv.meta.TiTimestamp;
+import com.pingcap.tikv.region.RegionStoreClient;
+import com.pingcap.tikv.region.TiRegion;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.apache.log4j.Logger;
+import org.junit.Before;
+import org.junit.Test;
+import org.tikv.kvproto.Kvrpcpb.*;
+
+public class LockResolverSITest extends LockResolverTest {
+  private final Logger logger = Logger.getLogger(this.getClass());
+
+  @Before
+  public void setUp() {
+    TiConfiguration conf = TiConfiguration.createDefault("127.0.0.1:2379");
+    conf.setIsolationLevel(IsolationLevel.SI);
+    TiSession.clearCache();
+    try {
+      session = TiSession.getInstance(conf);
+      pdClient = session.getPDClient();
+      this.builder = session.getRegionStoreClientBuilder();
+      init = true;
+    } catch (Exception e) {
+      logger.warn("TiDB cluster may not be present");
+      init = false;
+    }
+  }
+
+  @Test
+  public void getSITest() {
+    if (!init) {
+      skipTest();
+      return;
+    }
+    putAlphabet();
+    prepareAlphabetLocks();
+
+    versionTest();
+  }
+
+  @Test
+  public void cleanLockTest() {
+    if (!init) {
+      skipTest();
+      return;
+    }
+    for (int i = 0; i < 26; i++) {
+      String k = String.valueOf((char) ('a' + i));
+      TiTimestamp startTs = pdClient.getTimestamp(backOffer);
+      TiTimestamp endTs = pdClient.getTimestamp(backOffer);
+      lockKey(k, k, k, k, false, startTs.getVersion(), endTs.getVersion());
+    }
+
+    List<Mutation> mutations = new ArrayList<>();
+    List<ByteString> keys = new ArrayList<>();
+    for (int i = 0; i < 26; i++) {
+      String k = String.valueOf((char) ('a' + i));
+      String v = String.valueOf((char) ('a' + i + 1));
+      Mutation m =
+          Mutation.newBuilder()
+              .setKey(ByteString.copyFromUtf8(k))
+              .setOp(Op.Put)
+              .setValue(ByteString.copyFromUtf8(v))
+              .build();
+      mutations.add(m);
+      keys.add(ByteString.copyFromUtf8(k));
+    }
+
+    TiTimestamp startTs = pdClient.getTimestamp(backOffer);
+    TiTimestamp endTs = pdClient.getTimestamp(backOffer);
+
+    boolean res = prewrite(mutations, startTs.getVersion(), mutations.get(0));
+    assertTrue(res);
+    res = commit(startTs.getVersion(), endTs.getVersion(), keys);
+    assertTrue(res);
+
+    for (int i = 0; i < 26; i++) {
+      TiRegion tiRegion =
+          session
+              .getRegionManager()
+              .getRegionByKey(ByteString.copyFromUtf8(String.valueOf((char) ('a' + i))));
+      RegionStoreClient client = builder.build(tiRegion);
+      ByteString v =
+          client.get(
+              backOffer,
+              ByteString.copyFromUtf8(String.valueOf((char) ('a' + i))),
+              pdClient.getTimestamp(backOffer).getVersion());
+      assertEquals(v.toStringUtf8(), String.valueOf((char) ('a' + i + 1)));
+    }
+  }
+
+  @Test
+  public void txnStatusTest() {
+    if (!init) {
+      skipTest();
+      return;
+    }
+    TiTimestamp startTs = pdClient.getTimestamp(backOffer);
+    TiTimestamp endTs = pdClient.getTimestamp(backOffer);
+
+    putKV("a", "a", startTs.getVersion(), endTs.getVersion());
+    TiRegion tiRegion =
+        session.getRegionManager().getRegionByKey(ByteString.copyFromUtf8(String.valueOf('a')));
+    RegionStoreClient client = builder.build(tiRegion);
+    long status =
+        client.lockResolverClient.getTxnStatus(
+            backOffer, startTs.getVersion(), ByteString.copyFromUtf8(String.valueOf('a')));
+    assertEquals(status, endTs.getVersion());
+
+    startTs = pdClient.getTimestamp(backOffer);
+    endTs = pdClient.getTimestamp(backOffer);
+
+    lockKey("a", "a", "a", "a", true, startTs.getVersion(), endTs.getVersion());
+    tiRegion =
+        session.getRegionManager().getRegionByKey(ByteString.copyFromUtf8(String.valueOf('a')));
+    client = builder.build(tiRegion);
+    status =
+        client.lockResolverClient.getTxnStatus(
+            backOffer, startTs.getVersion(), ByteString.copyFromUtf8(String.valueOf('a')));
+    assertEquals(status, endTs.getVersion());
+
+    startTs = pdClient.getTimestamp(backOffer);
+    endTs = pdClient.getTimestamp(backOffer);
+
+    lockKey("a", "a", "a", "a", false, startTs.getVersion(), endTs.getVersion());
+    tiRegion =
+        session.getRegionManager().getRegionByKey(ByteString.copyFromUtf8(String.valueOf('a')));
+    client = builder.build(tiRegion);
+    status =
+        client.lockResolverClient.getTxnStatus(
+            backOffer, startTs.getVersion(), ByteString.copyFromUtf8(String.valueOf('a')));
+    assertNotSame(status, endTs.getVersion());
+  }
+
+  @Test
+  public void SITest() {
+    if (!init) {
+      skipTest();
+      return;
+    }
+    TiTimestamp startTs = pdClient.getTimestamp(backOffer);
+    TiTimestamp endTs = pdClient.getTimestamp(backOffer);
+
+    putKV("a", "a", startTs.getVersion(), endTs.getVersion());
+
+    startTs = pdClient.getTimestamp(backOffer);
+    endTs = pdClient.getTimestamp(backOffer);
+
+    lockKey("a", "aa", "a", "aa", false, startTs.getVersion(), endTs.getVersion());
+
+    TiRegion tiRegion =
+        session.getRegionManager().getRegionByKey(ByteString.copyFromUtf8(String.valueOf('a')));
+    RegionStoreClient client = builder.build(tiRegion);
+    ByteString v =
+        client.get(
+            backOffer,
+            ByteString.copyFromUtf8(String.valueOf('a')),
+            pdClient.getTimestamp(backOffer).getVersion());
+    assertEquals(v.toStringUtf8(), String.valueOf('a'));
+
+    try {
+      commit(
+          startTs.getVersion(),
+          endTs.getVersion(),
+          Collections.singletonList(ByteString.copyFromUtf8("a")));
+      fail();
+    } catch (KeyException e) {
+    }
+  }
+}

--- a/tikv-client/src/test/java/com/pingcap/tikv/txn/LockResolverTest.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/txn/LockResolverTest.java
@@ -20,7 +20,6 @@ import static junit.framework.TestCase.*;
 
 import com.google.protobuf.ByteString;
 import com.pingcap.tikv.ReadOnlyPDClient;
-import com.pingcap.tikv.TiConfiguration;
 import com.pingcap.tikv.TiSession;
 import com.pingcap.tikv.exception.KeyException;
 import com.pingcap.tikv.exception.RegionException;
@@ -38,19 +37,22 @@ import java.util.List;
 import java.util.function.Supplier;
 import org.apache.log4j.Logger;
 import org.junit.Before;
-import org.junit.Test;
 import org.tikv.kvproto.Kvrpcpb.*;
 import org.tikv.kvproto.TikvGrpc;
 
-public class LockResolverTest {
+public abstract class LockResolverTest {
   private final Logger logger = Logger.getLogger(this.getClass());
-  private TiSession session;
+  TiSession session;
   private static final int DefaultTTL = 10;
-  private BackOffer backOffer = ConcreteBackOffer.newCustomBackOff(1000);
-  private ReadOnlyPDClient pdClient;
-  private boolean init;
+  BackOffer backOffer = ConcreteBackOffer.newCustomBackOff(1000);
+  ReadOnlyPDClient pdClient;
+  RegionStoreClient.RegionStoreClientBuilder builder;
+  boolean init;
 
-  private void putKV(String key, String value, long startTS, long commitTS) {
+  @Before
+  public abstract void setUp();
+
+  void putKV(String key, String value, long startTS, long commitTS) {
     Mutation m =
         Mutation.newBuilder()
             .setKey(ByteString.copyFromUtf8(key))
@@ -64,7 +66,7 @@ public class LockResolverTest {
     assertTrue(res);
   }
 
-  private boolean prewrite(List<Mutation> mutations, long startTS, Mutation primary) {
+  boolean prewrite(List<Mutation> mutations, long startTS, Mutation primary) {
     if (mutations.size() == 0) return true;
 
     for (Mutation m : mutations) {
@@ -131,7 +133,7 @@ public class LockResolverTest {
     return true;
   }
 
-  private boolean lockKey(
+  boolean lockKey(
       String key,
       String value,
       String primaryKey,
@@ -171,7 +173,7 @@ public class LockResolverTest {
     return true;
   }
 
-  private boolean commit(long startTS, long commitTS, List<ByteString> keys) {
+  boolean commit(long startTS, long commitTS, List<ByteString> keys) {
     if (keys.size() == 0) return true;
 
     for (ByteString k : keys) {
@@ -208,7 +210,7 @@ public class LockResolverTest {
     return true;
   }
 
-  private void putAlphabet() {
+  void putAlphabet() {
     for (int i = 0; i < 26; i++) {
       long startTs = pdClient.getTimestamp(backOffer).getVersion();
       long endTs = pdClient.getTimestamp(backOffer).getVersion();
@@ -220,7 +222,7 @@ public class LockResolverTest {
     versionTest();
   }
 
-  private void prepareAlphabetLocks() {
+  void prepareAlphabetLocks() {
     TiTimestamp startTs = pdClient.getTimestamp(backOffer);
     TiTimestamp endTs = pdClient.getTimestamp(backOffer);
     while (startTs == endTs) {
@@ -242,40 +244,11 @@ public class LockResolverTest {
     assertTrue(lockKey("d", "dd", "z2", "z2", false, startTs.getVersion(), endTs.getVersion()));
   }
 
-  private RegionStoreClient.RegionStoreClientBuilder builder;
-
-  @Before
-  public void setUp() {
-    TiConfiguration conf = TiConfiguration.createDefault("127.0.0.1:2379");
-    try {
-      session = TiSession.create(conf);
-      pdClient = session.getPDClient();
-      this.builder = session.getRegionStoreClientBuilder();
-      init = true;
-    } catch (Exception e) {
-      logger.warn("TiDB cluster may not be present");
-      init = false;
-    }
-  }
-
-  private void skipTest() {
+  void skipTest() {
     logger.warn("Test skipped due to failure in initializing pd client.");
   }
 
-  @Test
-  public void getSITest() {
-    if (!init) {
-      skipTest();
-      return;
-    }
-    session.getConf().setIsolationLevel(IsolationLevel.SI);
-    putAlphabet();
-    prepareAlphabetLocks();
-
-    versionTest();
-  }
-
-  private void versionTest() {
+  void versionTest() {
     for (int i = 0; i < 26; i++) {
       TiRegion tiRegion =
           session
@@ -288,194 +261,6 @@ public class LockResolverTest {
               ByteString.copyFromUtf8(String.valueOf((char) ('a' + i))),
               pdClient.getTimestamp(backOffer).getVersion());
       assertEquals(v.toStringUtf8(), String.valueOf((char) ('a' + i)));
-    }
-  }
-
-  @Test
-  public void getRCTest() {
-    if (!init) {
-      skipTest();
-      return;
-    }
-    session.getConf().setIsolationLevel(IsolationLevel.RC);
-    putAlphabet();
-    prepareAlphabetLocks();
-
-    versionTest();
-  }
-
-  @Test
-  public void cleanLockTest() {
-    if (!init) {
-      skipTest();
-      return;
-    }
-    session.getConf().setIsolationLevel(IsolationLevel.SI);
-    for (int i = 0; i < 26; i++) {
-      String k = String.valueOf((char) ('a' + i));
-      TiTimestamp startTs = pdClient.getTimestamp(backOffer);
-      TiTimestamp endTs = pdClient.getTimestamp(backOffer);
-      lockKey(k, k, k, k, false, startTs.getVersion(), endTs.getVersion());
-    }
-
-    List<Mutation> mutations = new ArrayList<>();
-    List<ByteString> keys = new ArrayList<>();
-    for (int i = 0; i < 26; i++) {
-      String k = String.valueOf((char) ('a' + i));
-      String v = String.valueOf((char) ('a' + i + 1));
-      Mutation m =
-          Mutation.newBuilder()
-              .setKey(ByteString.copyFromUtf8(k))
-              .setOp(Op.Put)
-              .setValue(ByteString.copyFromUtf8(v))
-              .build();
-      mutations.add(m);
-      keys.add(ByteString.copyFromUtf8(k));
-    }
-
-    TiTimestamp startTs = pdClient.getTimestamp(backOffer);
-    TiTimestamp endTs = pdClient.getTimestamp(backOffer);
-
-    boolean res = prewrite(mutations, startTs.getVersion(), mutations.get(0));
-    assertTrue(res);
-    res = commit(startTs.getVersion(), endTs.getVersion(), keys);
-    assertTrue(res);
-
-    for (int i = 0; i < 26; i++) {
-      TiRegion tiRegion =
-          session
-              .getRegionManager()
-              .getRegionByKey(ByteString.copyFromUtf8(String.valueOf((char) ('a' + i))));
-      RegionStoreClient client = builder.build(tiRegion);
-      ByteString v =
-          client.get(
-              backOffer,
-              ByteString.copyFromUtf8(String.valueOf((char) ('a' + i))),
-              pdClient.getTimestamp(backOffer).getVersion());
-      assertEquals(v.toStringUtf8(), String.valueOf((char) ('a' + i + 1)));
-    }
-
-    session.getConf().setIsolationLevel(IsolationLevel.RC);
-  }
-
-  @Test
-  public void txnStatusTest() {
-    if (!init) {
-      skipTest();
-      return;
-    }
-    session.getConf().setIsolationLevel(IsolationLevel.SI);
-    TiTimestamp startTs = pdClient.getTimestamp(backOffer);
-    TiTimestamp endTs = pdClient.getTimestamp(backOffer);
-
-    putKV("a", "a", startTs.getVersion(), endTs.getVersion());
-    TiRegion tiRegion =
-        session.getRegionManager().getRegionByKey(ByteString.copyFromUtf8(String.valueOf('a')));
-    RegionStoreClient client = builder.build(tiRegion);
-    long status =
-        client.lockResolverClient.getTxnStatus(
-            backOffer, startTs.getVersion(), ByteString.copyFromUtf8(String.valueOf('a')));
-    assertEquals(status, endTs.getVersion());
-
-    startTs = pdClient.getTimestamp(backOffer);
-    endTs = pdClient.getTimestamp(backOffer);
-
-    lockKey("a", "a", "a", "a", true, startTs.getVersion(), endTs.getVersion());
-    tiRegion =
-        session.getRegionManager().getRegionByKey(ByteString.copyFromUtf8(String.valueOf('a')));
-    client = builder.build(tiRegion);
-    status =
-        client.lockResolverClient.getTxnStatus(
-            backOffer, startTs.getVersion(), ByteString.copyFromUtf8(String.valueOf('a')));
-    assertEquals(status, endTs.getVersion());
-
-    startTs = pdClient.getTimestamp(backOffer);
-    endTs = pdClient.getTimestamp(backOffer);
-
-    lockKey("a", "a", "a", "a", false, startTs.getVersion(), endTs.getVersion());
-    tiRegion =
-        session.getRegionManager().getRegionByKey(ByteString.copyFromUtf8(String.valueOf('a')));
-    client = builder.build(tiRegion);
-    status =
-        client.lockResolverClient.getTxnStatus(
-            backOffer, startTs.getVersion(), ByteString.copyFromUtf8(String.valueOf('a')));
-    assertNotSame(status, endTs.getVersion());
-
-    session.getConf().setIsolationLevel(IsolationLevel.RC);
-  }
-
-  @Test
-  public void SITest() {
-    if (!init) {
-      skipTest();
-      return;
-    }
-    session.getConf().setIsolationLevel(IsolationLevel.SI);
-    TiTimestamp startTs = pdClient.getTimestamp(backOffer);
-    TiTimestamp endTs = pdClient.getTimestamp(backOffer);
-
-    putKV("a", "a", startTs.getVersion(), endTs.getVersion());
-
-    startTs = pdClient.getTimestamp(backOffer);
-    endTs = pdClient.getTimestamp(backOffer);
-
-    lockKey("a", "aa", "a", "aa", false, startTs.getVersion(), endTs.getVersion());
-
-    TiRegion tiRegion =
-        session.getRegionManager().getRegionByKey(ByteString.copyFromUtf8(String.valueOf('a')));
-    RegionStoreClient client = builder.build(tiRegion);
-    ByteString v =
-        client.get(
-            backOffer,
-            ByteString.copyFromUtf8(String.valueOf('a')),
-            pdClient.getTimestamp(backOffer).getVersion());
-    assertEquals(v.toStringUtf8(), String.valueOf('a'));
-
-    try {
-      commit(
-          startTs.getVersion(),
-          endTs.getVersion(),
-          Collections.singletonList(ByteString.copyFromUtf8("a")));
-      fail();
-    } catch (KeyException e) {
-    }
-    session.getConf().setIsolationLevel(IsolationLevel.RC);
-  }
-
-  @Test
-  public void RCTest() {
-    if (!init) {
-      skipTest();
-      return;
-    }
-    session.getConf().setIsolationLevel(IsolationLevel.RC);
-    TiTimestamp startTs = pdClient.getTimestamp(backOffer);
-    TiTimestamp endTs = pdClient.getTimestamp(backOffer);
-
-    putKV("a", "a", startTs.getVersion(), endTs.getVersion());
-
-    startTs = pdClient.getTimestamp(backOffer);
-    endTs = pdClient.getTimestamp(backOffer);
-
-    lockKey("a", "aa", "a", "aa", false, startTs.getVersion(), endTs.getVersion());
-
-    TiRegion tiRegion =
-        session.getRegionManager().getRegionByKey(ByteString.copyFromUtf8(String.valueOf('a')));
-    RegionStoreClient client = builder.build(tiRegion);
-    ByteString v =
-        client.get(
-            backOffer,
-            ByteString.copyFromUtf8(String.valueOf('a')),
-            pdClient.getTimestamp(backOffer).getVersion());
-    assertEquals(v.toStringUtf8(), String.valueOf('a'));
-
-    try {
-      commit(
-          startTs.getVersion(),
-          endTs.getVersion(),
-          Collections.singletonList(ByteString.copyFromUtf8("a")));
-    } catch (KeyException e) {
-      fail();
     }
   }
 }


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

Delete a confusing method to create TiSession since we have `getInstance()` already.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change
 - Has interface methods change
