### PR TITLE
support setting random seed in daily regression test

### DIFF
--- a/.ci/log4j-ci.properties
+++ b/.ci/log4j-ci.properties
@@ -25,3 +25,4 @@ log4j.logger.org.apache.hadoop.hive.ql.exec.FunctionRegistry=ERROR
  # tispark
 log4j.logger.com.pingcap=ERROR
 log4j.logger.com.pingcap.tispark.utils.ReflectionUtil=DEBUG
+log4j.logger.org.apache.spark.sql.test.SharedSQLContext=DEBUG

--- a/.ci/tidb_config-for-daily-test.properties
+++ b/.ci/tidb_config-for-daily-test.properties
@@ -1,27 +1,2 @@
-# TiDB address
-# tidb.addr=127.0.0.1
-# TiDB port
-# tidb.port=4000
-# TiDB login user
-# tidb.user=root
-# TiDB login password
-# tidb.password=
-# TPC-H database name, if you already have a tpch database in TiDB, specify the db name so that TPC-H tests will run on this database
-# TPC-H test is enabled by default, you may turn it off by setting tpch.db=
-# tpch.db=tpch_test
-# TPC-DS database name, if you already have a tpcds database in TiDB, specify the db name so that TPC-DS tests will run on this database
-# TPC-DS test is disabled by default
-# tpcds.db=tpcds_test
-# Placement Driver address:port
-# spark.tispark.pd.addresses=127.0.0.1:2379
-# Whether to allow index read in tests, you must set this to true to run index tests.
-# spark.tispark.plan.allow_index_read=true
-# Whether to load test data before running tests. If you haven't load tispark_test or tpch_test data, set this to true. The next time you run tests, you can set this to false.
-# If you do not want the change this value, please set it to auto, the test data will be loaded only if it does not exist in tidb.
-# test.data.load=auto
-# Whether to generate test data. Enabling test data generation may change data of all tests.
-# test.data.generate=true
 # The seed used to generate test data (0 means random).
 test.data.generate.seed=0
-# DB prefix for tidb databases in case it conflicts with hive database
-# spark.tispark.db_prefix=tidb_

--- a/.ci/tidb_config-for-daily-test.properties
+++ b/.ci/tidb_config-for-daily-test.properties
@@ -1,0 +1,27 @@
+# TiDB address
+# tidb.addr=127.0.0.1
+# TiDB port
+# tidb.port=4000
+# TiDB login user
+# tidb.user=root
+# TiDB login password
+# tidb.password=
+# TPC-H database name, if you already have a tpch database in TiDB, specify the db name so that TPC-H tests will run on this database
+# TPC-H test is enabled by default, you may turn it off by setting tpch.db=
+# tpch.db=tpch_test
+# TPC-DS database name, if you already have a tpcds database in TiDB, specify the db name so that TPC-DS tests will run on this database
+# TPC-DS test is disabled by default
+# tpcds.db=tpcds_test
+# Placement Driver address:port
+# spark.tispark.pd.addresses=127.0.0.1:2379
+# Whether to allow index read in tests, you must set this to true to run index tests.
+# spark.tispark.plan.allow_index_read=true
+# Whether to load test data before running tests. If you haven't load tispark_test or tpch_test data, set this to true. The next time you run tests, you can set this to false.
+# If you do not want the change this value, please set it to auto, the test data will be loaded only if it does not exist in tidb.
+# test.data.load=auto
+# Whether to generate test data. Enabling test data generation may change data of all tests.
+# test.data.generate=true
+# The seed used to generate test data (0 means random).
+test.data.generate.seed=0
+# DB prefix for tidb databases in case it conflicts with hive database
+# spark.tispark.db_prefix=tidb_

--- a/core/src/test/resources/tidb_config.properties.template
+++ b/core/src/test/resources/tidb_config.properties.template
@@ -21,5 +21,7 @@
 # test.data.load=auto
 # Whether to generate test data. Enabling test data generation may change data of all tests.
 # test.data.generate=true
+# The seed used to generate test data (0 means random).
+# test.data.generate.seed=1234
 # DB prefix for tidb databases in case it conflicts with hive database
 # spark.tispark.db_prefix=tidb_ 

--- a/core/src/test/scala/org/apache/spark/sql/TiSparkTestSpec.scala
+++ b/core/src/test/scala/org/apache/spark/sql/TiSparkTestSpec.scala
@@ -17,13 +17,15 @@
 
 package org.apache.spark.sql
 
+import org.apache.spark.sql.test.SharedSQLContext
+
 import scala.util.Random
 
-trait TiSparkTestSpec {
+trait TiSparkTestSpec extends SharedSQLContext {
   val database: String
   val testDesc: String
   // Randomizer for tests
-  val r: Random = new Random(1234)
+  val r: Random = new Random(generateDataSeed)
 
   def test(): Unit
 }

--- a/core/src/test/scala/org/apache/spark/sql/test/SharedSQLContext.scala
+++ b/core/src/test/scala/org/apache/spark/sql/test/SharedSQLContext.scala
@@ -103,6 +103,8 @@ trait SharedSQLContext extends SparkFunSuite with Eventually with BeforeAndAfter
 
   protected def generateData: Boolean = SharedSQLContext.generateData
 
+  protected def generateDataSeed: Long = SharedSQLContext.generateDataSeed
+
   /**
    * The [[TestSparkSession]] to use for all tests in this suite.
    */
@@ -163,6 +165,7 @@ object SharedSQLContext extends Logging {
   protected var tidbPort: Int = _
   protected var pdAddresses: String = _
   protected var generateData: Boolean = _
+  protected var generateDataSeed: Long = _
 
   protected implicit def spark: SparkSession = _spark
 
@@ -391,8 +394,13 @@ object SharedSQLContext extends Logging {
 
       generateData = getOrElse(_tidbConf, SHOULD_GENERATE_DATA, "true").toLowerCase.toBoolean
 
+      generateDataSeed = getOrElse(_tidbConf, GENERATE_DATA_SEED, "1234").toLong
+      if (generateDataSeed == 0) {
+        generateDataSeed = System.currentTimeMillis()
+      }
+
       if (generateData) {
-        logger.info("generate data is enabled")
+        logger.info(s"generate data is enabled and seed is $generateDataSeed")
       }
 
       if (isTidbConfigPropertiesInjectedToSparkEnabled) {

--- a/core/src/test/scala/org/apache/spark/sql/test/TestConstants.scala
+++ b/core/src/test/scala/org/apache/spark/sql/test/TestConstants.scala
@@ -26,5 +26,6 @@ object TestConstants {
   val TPCDS_DB_NAME = "tpcds.db"
   val SHOULD_LOAD_DATA = "test.data.load"
   val SHOULD_GENERATE_DATA = "test.data.generate"
+  val GENERATE_DATA_SEED = "test.data.generate.seed"
   val SHOULD_SKIP_TEST = "test.skip"
 }


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
We want to use random test data in daily regression test in order to find more bugs.

### What is changed and how it works?
add a new parameter `test.data.generate.seed`

