### PR TITLE
fix reflection bug: pass in different arguments for different version of same function

### DIFF
--- a/core/src/main/scala/com/pingcap/tispark/utils/ReflectionUtil.scala
+++ b/core/src/main/scala/com/pingcap/tispark/utils/ReflectionUtil.scala
@@ -15,8 +15,6 @@
 
 package com.pingcap.tispark.utils
 
-import java.lang.reflect.Method
-
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow
@@ -43,85 +41,89 @@ object ReflectionUtil {
   //      isOrderSensitive: Boolean = false): RDD[U]
   //
   // Hereby we use reflection to support different Spark versions.
-  private val mapPartitionsWithIndexInternal: Method = spark_version match {
-    case "2.3.0" | "2.3.1" =>
-      tryLoadMethod(
-        "mapPartitionsWithIndexInternal",
-        mapPartitionsWithIndexInternalV1,
-        mapPartitionsWithIndexInternalV2
-      )
-    case _ =>
-      // Spark version >= 2.3.2
-      tryLoadMethod(
-        "mapPartitionsWithIndexInternal",
-        mapPartitionsWithIndexInternalV2,
-        mapPartitionsWithIndexInternalV1
-      )
-  }
-
-  // Spark HDP Release may not compatible with official Release
-  // see https://github.com/pingcap/tispark/issues/1006
-  private def tryLoadMethod(name: String, f1: () => Method, f2: () => Method): Method = {
-    try {
-      f1.apply()
-    } catch {
-      case _: Throwable =>
-        try {
-          f2.apply()
-        } catch {
-          case _: Throwable =>
-            throw ScalaReflectionException(
-              s"Cannot find reflection of Method $name, current Spark version is %s"
-                .format(spark_version)
-            )
-        }
-    }
-  }
-
-  // Spark-2.3.0 & Spark-2.3.1
-  private def mapPartitionsWithIndexInternalV1(): Method =
-    classOf[RDD[InternalRow]].getDeclaredMethod(
-      "mapPartitionsWithIndexInternal",
-      classOf[(Int, Iterator[InternalRow]) => Iterator[UnsafeRow]],
-      classOf[Boolean],
-      classOf[ClassTag[UnsafeRow]]
-    )
-
-  // >= Spark-2.3.2
-  private def mapPartitionsWithIndexInternalV2(): Method =
-    classOf[RDD[InternalRow]].getDeclaredMethod(
-      "mapPartitionsWithIndexInternal",
-      classOf[(Int, Iterator[InternalRow]) => Iterator[UnsafeRow]],
-      classOf[Boolean],
-      classOf[Boolean],
-      classOf[ClassTag[UnsafeRow]]
-    )
-
   case class ReflectionMapPartitionWithIndexInternal(
     rdd: RDD[InternalRow],
     internalRowToUnsafeRowWithIndex: (Int, Iterator[InternalRow]) => Iterator[UnsafeRow]
   ) {
+    // Spark HDP Release may not compatible with official Release
+    // see https://github.com/pingcap/tispark/issues/1006
     def invoke(): RDD[InternalRow] =
       spark_version match {
         case "2.3.0" | "2.3.1" =>
-          mapPartitionsWithIndexInternal
-            .invoke(
-              rdd,
-              internalRowToUnsafeRowWithIndex,
-              Boolean.box(false),
-              ClassTag.apply(classOf[UnsafeRow])
-            )
-            .asInstanceOf[RDD[InternalRow]]
+          try {
+            mapPartitionsWithIndexInternalV1(rdd, internalRowToUnsafeRowWithIndex)
+          } catch {
+            case _: Throwable =>
+              try {
+                mapPartitionsWithIndexInternalV2(rdd, internalRowToUnsafeRowWithIndex)
+              } catch {
+                case _: Throwable =>
+                  throw ScalaReflectionException(
+                    s"Cannot find reflection of Method mapPartitionsWithIndexInternal, current Spark version is %s"
+                      .format(spark_version)
+                  )
+              }
+          }
         case _ =>
-          mapPartitionsWithIndexInternal
-            .invoke(
-              rdd,
-              internalRowToUnsafeRowWithIndex,
-              Boolean.box(false),
-              Boolean.box(false),
-              ClassTag.apply(classOf[UnsafeRow])
-            )
-            .asInstanceOf[RDD[InternalRow]]
+          try {
+            mapPartitionsWithIndexInternalV2(rdd, internalRowToUnsafeRowWithIndex)
+          } catch {
+            case _: Throwable =>
+              try {
+                mapPartitionsWithIndexInternalV1(rdd, internalRowToUnsafeRowWithIndex)
+              } catch {
+                case _: Throwable =>
+                  throw ScalaReflectionException(
+                    s"Cannot find reflection of Method mapPartitionsWithIndexInternal, current Spark version is %s"
+                      .format(spark_version)
+                  )
+              }
+          }
       }
+  }
+
+  // Spark-2.3.0 & Spark-2.3.1
+  private def mapPartitionsWithIndexInternalV1(
+    rdd: RDD[InternalRow],
+    internalRowToUnsafeRowWithIndex: (Int, Iterator[InternalRow]) => Iterator[UnsafeRow]
+  ): RDD[InternalRow] = {
+    val method = classOf[RDD[InternalRow]].getDeclaredMethod(
+      "mapPartitionsWithIndexInternal",
+      classOf[(Int, Iterator[InternalRow]) => Iterator[UnsafeRow]],
+      classOf[Boolean],
+      classOf[ClassTag[UnsafeRow]]
+    )
+    method
+      .invoke(
+        rdd,
+        internalRowToUnsafeRowWithIndex,
+        Boolean.box(false),
+        ClassTag.apply(classOf[UnsafeRow])
+      )
+      .asInstanceOf[RDD[InternalRow]]
+
+  }
+
+  // >= Spark-2.3.2
+  private def mapPartitionsWithIndexInternalV2(
+    rdd: RDD[InternalRow],
+    internalRowToUnsafeRowWithIndex: (Int, Iterator[InternalRow]) => Iterator[UnsafeRow]
+  ): RDD[InternalRow] = {
+    val method = classOf[RDD[InternalRow]].getDeclaredMethod(
+      "mapPartitionsWithIndexInternal",
+      classOf[(Int, Iterator[InternalRow]) => Iterator[UnsafeRow]],
+      classOf[Boolean],
+      classOf[Boolean],
+      classOf[ClassTag[UnsafeRow]]
+    )
+    method
+      .invoke(
+        rdd,
+        internalRowToUnsafeRowWithIndex,
+        Boolean.box(false),
+        Boolean.box(false),
+        ClassTag.apply(classOf[UnsafeRow])
+      )
+      .asInstanceOf[RDD[InternalRow]]
   }
 }


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
close https://github.com/pingcap/tispark/issues/1006

this PR https://github.com/pingcap/tispark/pull/1017 introduces a new bug:

```
Caused by: java.lang.IllegalArgumentException: wrong number of arguments
  at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
  at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
  at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
  at java.lang.reflect.Method.invoke(Method.java:498)
  at com.pingcap.tispark.utils.ReflectionUtil$ReflectionMapPartitionWithIndexInternal.invoke(ReflectionUtil.scala:117)
  at org.apache.spark.sql.execution.CoprocessorRDD$$anonfun$doExecute$1.apply(CoprocessorRDD.scala:82)
  at org.apache.spark.sql.execution.CoprocessorRDD$$anonfun$doExecute$1.apply(CoprocessorRDD.scala:78)
  at scala.collection.immutable.List.map(List.scala:273)
```

### How to fix
pass in different arguments for a different version of the same function

### Cherry Pick
to master branch