### PR TITLE
fix table not found bug in TiSession because of synchronization

### DIFF
--- a/tikv-client/src/main/java/com/pingcap/tikv/TiSession.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/TiSession.java
@@ -190,12 +190,12 @@ public class TiSession implements AutoCloseable {
 
   public static void clearCache() {
     synchronized (sessionCachedMap) {
-      TiSession.sessionCachedMap.clear();
+      sessionCachedMap.clear();
     }
   }
 
   @Override
-  public void close() throws Exception {
+  public synchronized void close() throws Exception {
     synchronized (sessionCachedMap) {
       sessionCachedMap.remove(conf.getPdAddrsString());
     }


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
close https://github.com/pingcap/tispark/issues/1040

Table not found in daily regression test

https://internal.pingcap.net/idc-jenkins/blue/organizations/jenkins/tispark_regression_test_daily/detail/tispark_regression_test_daily/46/pipeline/1372

```
[2019-08-18T18:20:32.335Z] - Test Simple Comparisons without extensions *** FAILED ***
[2019-08-18T18:20:32.335Z]   com.pingcap.tikv.exception.TiClientInternalException: Table not exist TiTableReference(tispark_test,test_datasource_without_extensions,9223372036854775807)
[2019-08-18T18:20:32.335Z]   at com.pingcap.tispark.TiDBRelation$$anonfun$1.apply(TiDBRelation.scala:42)
[2019-08-18T18:20:32.335Z]   at com.pingcap.tispark.TiDBRelation$$anonfun$1.apply(TiDBRelation.scala:42)
[2019-08-18T18:20:32.335Z]   at scala.Option.getOrElse(Option.scala:121)
[2019-08-18T18:20:32.335Z]   at com.pingcap.tispark.TiDBRelation.<init>(TiDBRelation.scala:42)
[2019-08-18T18:20:32.335Z]   at com.pingcap.tispark.TiDBDataSource.createRelation(TiDBDataSource.scala:45)
[2019-08-18T18:20:32.335Z]   at org.apache.spark.sql.execution.datasources.DataSource.resolveRelation(DataSource.scala:318)
[2019-08-18T18:20:32.335Z]   at org.apache.spark.sql.DataFrameReader.loadV1Source(DataFrameReader.scala:223)
[2019-08-18T18:20:32.335Z]   at org.apache.spark.sql.DataFrameReader.load(DataFrameReader.scala:211)
[2019-08-18T18:20:32.335Z]   at org.apache.spark.sql.DataFrameReader.load(DataFrameReader.scala:167)
[2019-08-18T18:20:32.335Z]   at com.pingcap.tispark.datasource.BaseDataSourceTest.testTiDBSelectFilter(BaseDataSourceTest.scala:266)
```

### What is changed and how it works?
add missing synchronized at function `TiSession::close`
