### PR TITLE
use one unique seed

### DIFF
--- a/core/src/test/scala/org/apache/spark/sql/TiSparkTestSpec.scala
+++ b/core/src/test/scala/org/apache/spark/sql/TiSparkTestSpec.scala
@@ -25,7 +25,7 @@ trait TiSparkTestSpec extends SharedSQLContext {
   val database: String
   val testDesc: String
   // Randomizer for tests
-  val r: Random = new Random(generateDataSeed)
+  lazy val r: Random = new Random(generateDataSeed)
 
   def test(): Unit
 }

--- a/core/src/test/scala/org/apache/spark/sql/test/SharedSQLContext.scala
+++ b/core/src/test/scala/org/apache/spark/sql/test/SharedSQLContext.scala
@@ -165,7 +165,7 @@ object SharedSQLContext extends Logging {
   protected var tidbPort: Int = _
   protected var pdAddresses: String = _
   protected var generateData: Boolean = _
-  protected var generateDataSeed: Long = _
+  protected var generateDataSeed: Option[Long] = None
 
   protected implicit def spark: SparkSession = _spark
 
@@ -394,9 +394,12 @@ object SharedSQLContext extends Logging {
 
       generateData = getOrElse(_tidbConf, SHOULD_GENERATE_DATA, "true").toLowerCase.toBoolean
 
-      generateDataSeed = getOrElse(_tidbConf, GENERATE_DATA_SEED, "1234").toLong
-      if (generateDataSeed == 0) {
-        generateDataSeed = System.currentTimeMillis()
+      if (generateDataSeed.isEmpty) {
+        var tmpSeed = getOrElse(_tidbConf, GENERATE_DATA_SEED, "1234").toLong
+        if (tmpSeed == 0) {
+          tmpSeed = System.currentTimeMillis()
+        }
+        generateDataSeed = Some(tmpSeed)
       }
 
       if (generateData) {

--- a/core/src/test/scala/org/apache/spark/sql/test/SharedSQLContext.scala
+++ b/core/src/test/scala/org/apache/spark/sql/test/SharedSQLContext.scala
@@ -103,7 +103,7 @@ trait SharedSQLContext extends SparkFunSuite with Eventually with BeforeAndAfter
 
   protected def generateData: Boolean = SharedSQLContext.generateData
 
-  protected def generateDataSeed: Long = SharedSQLContext.generateDataSeed
+  protected def generateDataSeed: Long = SharedSQLContext.generateDataSeed.get
 
   /**
    * The [[TestSparkSession]] to use for all tests in this suite.
@@ -403,7 +403,7 @@ object SharedSQLContext extends Logging {
       }
 
       if (generateData) {
-        logger.info(s"generate data is enabled and seed is $generateDataSeed")
+        logger.info(s"generate data is enabled and seed is ${generateDataSeed.get}")
       }
 
       if (isTidbConfigPropertiesInjectedToSparkEnabled) {

--- a/core/src/test/scala/org/apache/spark/sql/test/SharedSQLContext.scala
+++ b/core/src/test/scala/org/apache/spark/sql/test/SharedSQLContext.scala
@@ -400,10 +400,10 @@ object SharedSQLContext extends Logging {
           tmpSeed = System.currentTimeMillis()
         }
         generateDataSeed = Some(tmpSeed)
-      }
 
-      if (generateData) {
-        logger.info(s"generate data is enabled and seed is ${generateDataSeed.get}")
+        if (generateData) {
+          logger.info(s"generate data is enabled and seed is ${generateDataSeed.get}")
+        }
       }
 
       if (isTidbConfigPropertiesInjectedToSparkEnabled) {


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
close https://github.com/pingcap/tispark/issues/1042

random data generator seed should be unique, but now seed will be generated many times

### What is changed and how it works?
use a static variable to store the seed
