### PR TITLE
[DNM] fix distinct without alias bug

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/TiStrategy.scala
+++ b/core/src/main/scala/org/apache/spark/sql/TiStrategy.scala
@@ -456,19 +456,21 @@ case class TiStrategy(getOrCreateTiContext: SparkSession => TiContext)(sparkSess
       }.asInstanceOf[NamedExpression]
     }
 
-    aggregate.AggUtils.planAggregateWithoutDistinct(
+    val r1 = aggregate.AggUtils.planAggregateWithoutDistinct(
       groupingExpressions,
       residualAggregateExpressions,
       rewrittenResultExpressions,
       toCoprocessorRDD(source, output, dagReq)
     )
 
-//    aggregate.AggUtils.planAggregateWithoutDistinct(
-//      groupAttributes,
-//      residualAggregateExpressions,
-//      rewrittenResultExpressions,
-//      toCoprocessorRDD(source, output, dagReq)
-//    )
+    val r2 = aggregate.AggUtils.planAggregateWithoutDistinct(
+      groupAttributes,
+      residualAggregateExpressions,
+      rewrittenResultExpressions,
+      toCoprocessorRDD(source, output, dagReq)
+    )
+
+    r2
   }
 
   private def isValidAggregates(

--- a/core/src/test/scala/org/apache/spark/sql/BaseTiSparkTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/BaseTiSparkTest.scala
@@ -210,7 +210,7 @@ class BaseTiSparkTest extends QueryTest with SharedSQLContext {
   protected def judge(str: String, skipped: Boolean = false, checkLimit: Boolean = true): Unit =
     runTest(str, skipped = skipped, skipJDBC = true, checkLimit = checkLimit)
 
-  private def compSparkWithTiDB(sql: String, checkLimit: Boolean = true): Boolean =
+  protected def compSparkWithTiDB(sql: String, checkLimit: Boolean = true): Boolean =
     compSqlResult(sql, queryViaTiSpark(sql), queryTiDBViaJDBC(sql), checkLimit)
 
   protected def checkSparkResult(sql: String,
@@ -418,10 +418,13 @@ class BaseTiSparkTest extends QueryTest with SharedSQLContext {
           result.toString
       }
 
-  protected def explainTestAndCollect(sql: String): Unit = {
+  protected def explainTestAndCollect(sql: String, extended: Boolean = false): Unit = {
     val df = spark.sql(sql)
-    df.explain
+    df.explain(extended)
     df.show
+    df.limit(20).explain
+    df.limit(20).collect.foreach(println)
+    println
     df.collect.foreach(println)
   }
 

--- a/core/src/test/scala/org/apache/spark/sql/BaseTiSparkTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/BaseTiSparkTest.scala
@@ -420,12 +420,12 @@ class BaseTiSparkTest extends QueryTest with SharedSQLContext {
 
   protected def explainTestAndCollect(sql: String, extended: Boolean = false): Unit = {
     val df = spark.sql(sql)
-    df.explain(extended)
-    df.show
-    df.limit(20).explain
+    //df.explain(extended)
+    //df.show
+    //df.limit(20).explain
     df.limit(20).collect.foreach(println)
     println
-    df.collect.foreach(println)
+    //df.collect.foreach(println)
   }
 
   protected def time[A](f: => A): A = {

--- a/core/src/test/scala/org/apache/spark/sql/bug/DistinctWithoutAlias.scala
+++ b/core/src/test/scala/org/apache/spark/sql/bug/DistinctWithoutAlias.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.bug
+
+import org.apache.spark.sql.BaseTiSparkTest
+
+class DistinctWithoutAlias extends BaseTiSparkTest {
+
+  test("Distinct without alias throws NullPointerException") {
+    tidbStmt.execute("drop table if exists t")
+    tidbStmt.execute("create table t(c1 bigint);")
+    tidbStmt.execute("insert into t values (2), (3), (2);")
+
+    val sqls = //"select distinct(c1) as d, 1 as w from t" ::
+      //"select c1 as d, 1 as w from t group by c1" ::
+      //"select c1, 1 as w from t group by c1" ::
+      "select distinct(c1), 1L as w from t" ::
+        Nil
+
+    for (sql <- sqls) {
+      explainTestAndCollect(sql, extended = true)
+      //compSparkWithTiDB(sql)
+    }
+  }
+
+  override def afterAll(): Unit =
+    try {
+      tidbStmt.execute("drop table if exists t")
+    } finally {
+      super.afterAll()
+    }
+}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '2.3'
 
 services:
   pd0:
-    image: pingcap/pd:latest
+    image: pingcap/pd:v3.0.2
     ports:
       - "2379:2379"
     volumes:
@@ -19,7 +19,7 @@ services:
       - --config=/pd.toml
     restart: on-failure
   tikv0:
-    image: pingcap/tikv:latest
+    image: pingcap/tikv:v3.0.2
     ports:
       - "20160:20160"
     volumes:
@@ -35,7 +35,7 @@ services:
       - "pd0"
     restart: on-failure
   tidb:
-    image: pingcap/tidb:latest
+    image: pingcap/tidb:v3.0.2
     ports:
       - "4000:4000"
       - "10080:10080"

--- a/tikv-client/src/main/java/com/pingcap/tikv/expression/visitor/ExpressionTypeCoercer.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/expression/visitor/ExpressionTypeCoercer.java
@@ -61,6 +61,7 @@ public class ExpressionTypeCoercer extends Visitor<Pair<DataType, Double>, DataT
 
   public void infer(List<? extends Expression> expressions) {
     requireNonNull(expressions, "expressions is null");
+    // ???
     expressions.forEach(expr -> expr.accept(this, null));
   }
 
@@ -152,6 +153,7 @@ public class ExpressionTypeCoercer extends Visitor<Pair<DataType, Double>, DataT
   @Override
   protected Pair<DataType, Double> visit(Constant node, DataType targetType) {
     if (targetType == null) {
+      typeMap.put(node, node.getType());
       return Pair.create(node.getType(), CONSTANT_CRED);
     } else {
       node.setType(targetType);

--- a/tikv-client/src/main/java/com/pingcap/tikv/meta/TiDAGRequest.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/meta/TiDAGRequest.java
@@ -258,14 +258,7 @@ public class TiDAGRequest implements Serializable {
 
   public DataType getExpressionType(Expression expression) {
     requireNonNull(typeMap, "request is not resolved");
-    // return typeMap.get(expression);
-    DataType t = typeMap.get(expression);
-    if (t == null) {
-      requireNonNull(t, "t should not be null");
-      return ((Constant) expression).getType();
-    } else {
-      return t;
-    }
+    return typeMap.get(expression);
   }
 
   public void resolve() {


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
close https://github.com/pingcap/tispark/issues/1039

Distinct without alias fails, e.g.
```
select distinct(c1), 1 as w from t;
```

### What is changed and how it works?
`Alias` should not exist in `Group By`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

