### PR TITLE
fix distinct without alias bug: disable pushdown aggregate with alias

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/TiStrategy.scala
+++ b/core/src/main/scala/org/apache/spark/sql/TiStrategy.scala
@@ -468,7 +468,8 @@ case class TiStrategy(getOrCreateTiContext: SparkSession => TiContext)(sparkSess
       filters.forall(TiUtil.isSupportedFilter(_, source, blacklist)) &&
       groupingExpressions.forall(TiUtil.isSupportedGroupingExpr(_, source, blacklist)) &&
       aggregateExpressions.forall(TiUtil.isSupportedAggregate(_, source, blacklist)) &&
-      !aggregateExpressions.exists(_.isDistinct)
+      !aggregateExpressions.exists(_.isDistinct) &&
+      !groupingExpressions.exists(_.isInstanceOf[Alias])
 
   // We do through similar logic with original Spark as in SparkStrategies.scala
   // Difference is we need to test if a sub-plan can be consumed all together by TiKV

--- a/core/src/main/scala/org/apache/spark/sql/TiStrategy.scala
+++ b/core/src/main/scala/org/apache/spark/sql/TiStrategy.scala
@@ -469,6 +469,7 @@ case class TiStrategy(getOrCreateTiContext: SparkSession => TiContext)(sparkSess
       groupingExpressions.forall(TiUtil.isSupportedGroupingExpr(_, source, blacklist)) &&
       aggregateExpressions.forall(TiUtil.isSupportedAggregate(_, source, blacklist)) &&
       !aggregateExpressions.exists(_.isDistinct) &&
+      // TODO: This is a temporary fix for the issue: https://github.com/pingcap/tispark/issues/1039
       !groupingExpressions.exists(_.isInstanceOf[Alias])
 
   // We do through similar logic with original Spark as in SparkStrategies.scala

--- a/core/src/test/scala/org/apache/spark/sql/BaseTiSparkTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/BaseTiSparkTest.scala
@@ -210,7 +210,7 @@ class BaseTiSparkTest extends QueryTest with SharedSQLContext {
   protected def judge(str: String, skipped: Boolean = false, checkLimit: Boolean = true): Unit =
     runTest(str, skipped = skipped, skipJDBC = true, checkLimit = checkLimit)
 
-  private def compSparkWithTiDB(sql: String, checkLimit: Boolean = true): Boolean =
+  protected def compSparkWithTiDB(sql: String, checkLimit: Boolean = true): Boolean =
     compSqlResult(sql, queryViaTiSpark(sql), queryTiDBViaJDBC(sql), checkLimit)
 
   protected def checkSparkResult(sql: String,

--- a/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
@@ -22,14 +22,14 @@ class IssueTestSuite extends BaseTiSparkTest {
 
   // https://github.com/pingcap/tispark/issues/1039
   test("Distinct without alias throws NullPointerException") {
-    tidbStmt.execute("drop table if exists t")
-    tidbStmt.execute("create table t(c1 bigint);")
-    tidbStmt.execute("insert into t values (2), (3), (2);")
+    tidbStmt.execute("drop table if exists t_distinct_alias")
+    tidbStmt.execute("create table t_distinct_alias(c1 bigint);")
+    tidbStmt.execute("insert into t_distinct_alias values (2), (3), (2);")
 
-    val sqls = "select distinct(c1) as d, 1 as w from t" ::
-      "select c1 as d, 1 as w from t group by c1" ::
-      "select c1, 1 as w from t group by c1" ::
-      "select distinct(c1), 1 as w from t" ::
+    val sqls = "select distinct(c1) as d, 1 as w from t_distinct_alias" ::
+      "select c1 as d, 1 as w from t_distinct_alias group by c1" ::
+      "select c1, 1 as w from t_distinct_alias group by c1" ::
+      "select distinct(c1), 1 as w from t_distinct_alias" ::
       Nil
 
     for (sql <- sqls) {


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
close https://github.com/pingcap/tispark/issues/1039

Distinct without alias fails, e.g.
```
select distinct(c1), 1 as w from t;
```

### What is changed and how it works?
disable pushdown aggregate with alias

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
