### PR TITLE
[cherry-pick] fix distinct without alias bug: disable pushdown aggregate with alias

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/TiStrategy.scala
+++ b/core/src/main/scala/org/apache/spark/sql/TiStrategy.scala
@@ -466,7 +466,9 @@ case class TiStrategy(getOrCreateTiContext: SparkSession => TiContext)(sparkSess
       filters.forall(TiUtil.isSupportedFilter(_, source, blacklist)) &&
       groupingExpressions.forall(TiUtil.isSupportedGroupingExpr(_, source, blacklist)) &&
       aggregateExpressions.forall(TiUtil.isSupportedAggregate(_, source, blacklist)) &&
-      !aggregateExpressions.exists(_.isDistinct)
+      !aggregateExpressions.exists(_.isDistinct) &&
+      // TODO: This is a temporary fix for the issue: https://github.com/pingcap/tispark/issues/1039
+      !groupingExpressions.exists(_.isInstanceOf[Alias])
 
   // We do through similar logic with original Spark as in SparkStrategies.scala
   // Difference is we need to test if a sub-plan can be consumed all together by TiKV

--- a/core/src/test/scala/org/apache/spark/sql/BaseTiSparkSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/BaseTiSparkSuite.scala
@@ -222,7 +222,9 @@ class BaseTiSparkSuite extends QueryTest with SharedSQLContext {
       explainSpark(str)
       judge(str, skipped)
     } catch {
-      case e: Throwable => fail(e)
+      case e: Throwable =>
+        e.printStackTrace()
+        fail(e)
     }
 
   protected def explainAndRunTest(qSpark: String,

--- a/core/src/test/scala/org/apache/spark/sql/BaseTiSparkSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/BaseTiSparkSuite.scala
@@ -193,7 +193,7 @@ class BaseTiSparkSuite extends QueryTest with SharedSQLContext {
   protected def judge(str: String, skipped: Boolean = false, checkLimit: Boolean = true): Unit =
     runTest(str, skipped = skipped, skipJDBC = true, checkLimit = checkLimit)
 
-  private def compSparkWithTiDB(sql: String, checkLimit: Boolean = true): Boolean =
+  protected def compSparkWithTiDB(sql: String, checkLimit: Boolean = true): Boolean =
     compSqlResult(sql, querySpark(sql), queryTiDB(sql), checkLimit)
 
   protected def checkSparkResult(sql: String,

--- a/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
@@ -19,6 +19,25 @@ import com.pingcap.tispark.TiConfigConst
 import org.apache.spark.sql.functions.{col, sum}
 
 class IssueTestSuite extends BaseTiSparkSuite {
+
+  // https://github.com/pingcap/tispark/issues/1039
+  test("Distinct without alias throws NullPointerException") {
+    tidbStmt.execute("drop table if exists t_distinct_alias")
+    tidbStmt.execute("create table t_distinct_alias(c1 bigint);")
+    tidbStmt.execute("insert into t_distinct_alias values (2), (3), (2);")
+
+    val sqls = "select distinct(c1) as d, 1 as w from t_distinct_alias" ::
+      "select c1 as d, 1 as w from t_distinct_alias group by c1" ::
+      "select c1, 1 as w from t_distinct_alias group by c1" ::
+      "select distinct(c1), 1 as w from t_distinct_alias" ::
+      Nil
+
+    for (sql <- sqls) {
+      explainAndTest(sql)
+      compSparkWithTiDB(sql)
+    }
+  }
+
   test("cannot resolve column name when specifying table.column") {
     spark.sql("select full_data_type_table.id_dt from full_data_type_table").explain(true)
     judge("select full_data_type_table.id_dt from full_data_type_table")

--- a/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
@@ -26,6 +26,8 @@ class IssueTestSuite extends BaseTiSparkSuite {
     tidbStmt.execute("create table t_distinct_alias(c1 bigint);")
     tidbStmt.execute("insert into t_distinct_alias values (2), (3), (2);")
 
+    refreshConnections()
+
     val sqls = "select distinct(c1) as d, 1 as w from t_distinct_alias" ::
       "select c1 as d, 1 as w from t_distinct_alias group by c1" ::
       "select c1, 1 as w from t_distinct_alias group by c1" ::


### PR DESCRIPTION
cherry-pick https://github.com/pingcap/tispark/pull/1054