### PR TITLE
using different table names in BaseDataSourceTest

### DIFF
--- a/core/src/main/scala/com/pingcap/tispark/TiBatchWrite.scala
+++ b/core/src/main/scala/com/pingcap/tispark/TiBatchWrite.scala
@@ -124,7 +124,8 @@ class TiBatchWrite(@transient val df: DataFrame,
 
     // initialize
     tiConf = tiContext.tiConf
-    tiSession = tiContext.tiSession
+    TiSession.clearCache()
+    tiSession = TiSession.getInstance(tiConf)
     tiTableRef = options.tiTableRef
     tiDBInfo = tiSession.getCatalog.getDatabase(tiTableRef.databaseName)
     tiTableInfo = tiSession.getCatalog.getTable(tiTableRef.databaseName, tiTableRef.tableName)

--- a/core/src/main/scala/com/pingcap/tispark/TiBatchWrite.scala
+++ b/core/src/main/scala/com/pingcap/tispark/TiBatchWrite.scala
@@ -18,7 +18,6 @@ package com.pingcap.tispark
 import java.util
 
 import com.pingcap.tikv.allocator.RowIDAllocator
-import com.pingcap.tikv.catalog.Catalog
 import com.pingcap.tikv.codec.{CodecDataOutput, KeyUtils, TableCodec}
 import com.pingcap.tikv.exception.TiBatchWriteException
 import com.pingcap.tikv.key.{IndexKey, Key, RowKey}
@@ -66,7 +65,6 @@ class TiBatchWrite(@transient val df: DataFrame,
 
   private var tiConf: TiConfiguration = _
   @transient private var tiSession: TiSession = _
-  @transient private var catalog: Catalog = _
 
   private var tiTableRef: TiTableReference = _
   private var tiDBInfo: TiDBInfo = _
@@ -124,12 +122,10 @@ class TiBatchWrite(@transient val df: DataFrame,
 
     // initialize
     tiConf = tiContext.tiConf
-    TiSession.clearCache()
-    tiSession = TiSession.getInstance(tiConf)
+    tiSession = tiContext.tiSession
     tiTableRef = options.tiTableRef
     tiDBInfo = tiSession.getCatalog.getDatabase(tiTableRef.databaseName)
     tiTableInfo = tiSession.getCatalog.getTable(tiTableRef.databaseName, tiTableRef.tableName)
-    catalog = TiSession.getInstance(tiConf).getCatalog
 
     if (tiTableInfo == null) {
       throw new NoSuchTableException(tiTableRef.databaseName, tiTableRef.tableName)

--- a/core/src/test/scala/com/pingcap/tispark/TiBatchWriteSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/TiBatchWriteSuite.scala
@@ -18,8 +18,7 @@ package com.pingcap.tispark
 import org.apache.spark.sql.BaseTiSparkTest
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException
 
-class     TiSession.clearCache()
-tiSession = TiSession.getInstance(tiConf)TiBatchWriteSuite extends BaseTiSparkTest {
+class TiBatchWriteSuite extends BaseTiSparkTest {
 
   private var database: String = _
 

--- a/core/src/test/scala/com/pingcap/tispark/TiBatchWriteSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/TiBatchWriteSuite.scala
@@ -18,7 +18,8 @@ package com.pingcap.tispark
 import org.apache.spark.sql.BaseTiSparkTest
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException
 
-class TiBatchWriteSuite extends BaseTiSparkTest {
+class     TiSession.clearCache()
+tiSession = TiSession.getInstance(tiConf)TiBatchWriteSuite extends BaseTiSparkTest {
 
   private var database: String = _
 

--- a/core/src/test/scala/com/pingcap/tispark/convert/ToBitSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/convert/ToBitSuite.scala
@@ -8,7 +8,7 @@ import org.apache.spark.sql.types.{StructField, _}
  * BIT type include:
  * 1. BIT
  */
-class ToBitSuite extends BaseDataSourceTest("test_data_type_convert_to_bit") {
+class ToBitSuite extends BaseDataSourceTest {
 
   private val readZero: java.lang.Long = 0L
   private val readOne: java.lang.Long = 1L
@@ -32,14 +32,13 @@ class ToBitSuite extends BaseDataSourceTest("test_data_type_convert_to_bit") {
     )
   )
 
-  private def createTable(): Unit =
-    jdbcUpdate(
-      s"create table $dbtable(i INT, c1 BIT(1), c2 BIT(8),  c3 BIT(64))"
-    )
+  val tableTemplate = "test_%s_to_bit"
+  val queryTemplate = "create table `%s`.`%s`(i INT, c1 BIT(1), c2 BIT(8),  c3 BIT(64))"
 
   test("Test Convert from java.lang.Boolean to BIT") {
     // success
     // java.lang.Boolean -> BIT
+    val table = tableTemplate.format("boolean")
     compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val a: java.lang.Boolean = true
@@ -66,14 +65,15 @@ class ToBitSuite extends BaseDataSourceTest("test_data_type_convert_to_bit") {
         val readRow4 = Row(4, readOne, readOne, readOne)
         val readRow5 = Row(5, readZero, readZero, readZero)
 
-        dropTable()
-        createTable()
+        dropTable(table)
+        createTable(queryTemplate, table)
 
         // insert rows
-        writeFunc(List(row1, row2, row3, row4, row5), schema, None)
+        writeFunc(List(row1, row2, row3, row4, row5), schema, table, None)
         compareTiDBSelectWithJDBC(
           Seq(readRow1, readRow2, readRow3, readRow4, readRow5),
-          readSchema
+          readSchema,
+          table
         )
     }
   }
@@ -81,6 +81,7 @@ class ToBitSuite extends BaseDataSourceTest("test_data_type_convert_to_bit") {
   test("Test Convert from java.lang.Byte to BIT") {
     // success
     // java.lang.Byte -> BIT
+    val table = tableTemplate.format("boolean")
     compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val zero: java.lang.Byte = java.lang.Byte.valueOf("0")
@@ -105,18 +106,19 @@ class ToBitSuite extends BaseDataSourceTest("test_data_type_convert_to_bit") {
           )
         )
 
-        dropTable()
-        createTable()
+        dropTable(table)
+        createTable(queryTemplate, table)
 
         // insert rows
-        writeFunc(List(row1, row2, row3, row4, row5), schema, None)
-        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5), schema)
+        writeFunc(List(row1, row2, row3, row4, row5), schema, table, None)
+        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5), schema, table)
     }
   }
 
   test("Test Convert from java.lang.Short to BIT") {
     // success
     // java.lang.Short -> BIT
+    val table = tableTemplate.format("boolean")
     compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val zero: java.lang.Short = java.lang.Short.valueOf("0")
@@ -141,18 +143,19 @@ class ToBitSuite extends BaseDataSourceTest("test_data_type_convert_to_bit") {
           )
         )
 
-        dropTable()
-        createTable()
+        dropTable(table)
+        createTable(queryTemplate, table)
 
         // insert rows
-        writeFunc(List(row1, row2, row3, row4, row5), schema, None)
-        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5), schema)
+        writeFunc(List(row1, row2, row3, row4, row5), schema, table, None)
+        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5), schema, table)
     }
   }
 
   test("Test Convert from java.lang.Integer to BIT") {
     // success
     // java.lang.Integer -> BIT
+    val table = tableTemplate.format("boolean")
     compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val zero: java.lang.Integer = java.lang.Integer.valueOf("0")
@@ -177,18 +180,19 @@ class ToBitSuite extends BaseDataSourceTest("test_data_type_convert_to_bit") {
           )
         )
 
-        dropTable()
-        createTable()
+        dropTable(table)
+        createTable(queryTemplate, table)
 
         // insert rows
-        writeFunc(List(row1, row2, row3, row4, row5), schema, None)
-        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5), schema)
+        writeFunc(List(row1, row2, row3, row4, row5), schema, table, None)
+        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5), schema, table)
     }
   }
 
   test("Test Convert from java.lang.Long to BIT") {
     // success
     // java.lang.Long -> BIT
+    val table = tableTemplate.format("boolean")
     compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val zero: java.lang.Long = java.lang.Long.valueOf("0")
@@ -213,18 +217,19 @@ class ToBitSuite extends BaseDataSourceTest("test_data_type_convert_to_bit") {
           )
         )
 
-        dropTable()
-        createTable()
+        dropTable(table)
+        createTable(queryTemplate, table)
 
         // insert rows
-        writeFunc(List(row1, row2, row3, row4, row5), schema, None)
-        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5), schema)
+        writeFunc(List(row1, row2, row3, row4, row5), schema, table, None)
+        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5), schema, table)
     }
   }
 
   test("Test Convert from java.lang.Float to BIT") {
     // success
     // java.lang.Float -> BIT
+    val table = tableTemplate.format("boolean")
     compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val zero: java.lang.Float = 0f
@@ -249,18 +254,23 @@ class ToBitSuite extends BaseDataSourceTest("test_data_type_convert_to_bit") {
           )
         )
 
-        dropTable()
-        createTable()
+        dropTable(table)
+        createTable(queryTemplate, table)
 
         // insert rows
-        writeFunc(List(row1, row2, row3, row4, row5), schema, None)
-        compareTiDBSelectWithJDBC(Seq(readRow1, readRow2, readRow3, readRow4, readRow5), readSchema)
+        writeFunc(List(row1, row2, row3, row4, row5), schema, table, None)
+        compareTiDBSelectWithJDBC(
+          Seq(readRow1, readRow2, readRow3, readRow4, readRow5),
+          readSchema,
+          table
+        )
     }
   }
 
   test("Test Convert from java.lang.Double to BIT") {
     // success
     // java.lang.Double -> BIT
+    val table = tableTemplate.format("boolean")
     compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val zero: java.lang.Double = 0d
@@ -307,12 +317,16 @@ class ToBitSuite extends BaseDataSourceTest("test_data_type_convert_to_bit") {
           )
         )
 
-        dropTable()
-        createTable()
+        dropTable(table)
+        createTable(queryTemplate, table)
 
         // insert rows
-        writeFunc(List(row1, row2, row3, row4, row5), schema, None)
-        compareTiDBSelectWithJDBC(Seq(readRow1, readRow2, readRow3, readRow4, readRow5), readSchema)
+        writeFunc(List(row1, row2, row3, row4, row5), schema, table, None)
+        compareTiDBSelectWithJDBC(
+          Seq(readRow1, readRow2, readRow3, readRow4, readRow5),
+          readSchema,
+          table
+        )
     }
   }
 
@@ -325,11 +339,4 @@ class ToBitSuite extends BaseDataSourceTest("test_data_type_convert_to_bit") {
   // scala.collection.Seq
   // scala.collection.Map
   // org.apache.spark.sql.Row
-
-  override def afterAll(): Unit =
-    try {
-      dropTable()
-    } finally {
-      super.afterAll()
-    }
 }

--- a/core/src/test/scala/com/pingcap/tispark/convert/ToBytesSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/convert/ToBytesSuite.scala
@@ -13,16 +13,15 @@ import org.apache.spark.sql.types.{StructField, _}
  * 5. MEDIUMBLOB
  * 6. LONGBLOB
  */
-class ToBytesSuite extends BaseDataSourceTest("test_data_type_convert_to_bytes") {
-
-  private def createTable(): Unit =
-    jdbcUpdate(
-      s"create table $dbtable(i INT, c1 BINARY(5), c2 VARBINARY(255), c3 TINYBLOB, c4 BLOB, c5 MEDIUMBLOB, c6 LONGBLOB)"
-    )
+class ToBytesSuite extends BaseDataSourceTest {
+  private val tableTemplate = "test_%s_to_bytes"
+  val queryTemplate: String =
+    "create table `%s`.`%s`(i INT, c1 BINARY(5), c2 VARBINARY(255), c3 TINYBLOB, c4 BLOB, c5 MEDIUMBLOB, c6 LONGBLOB)"
 
   test("Test Convert from java.lang.Boolean to BYTES") {
     // success
     // java.lang.Boolean -> BYTES
+    val table = tableTemplate.format("boolean")
     compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val a: java.lang.Boolean = true
@@ -70,15 +69,16 @@ class ToBytesSuite extends BaseDataSourceTest("test_data_type_convert_to_bytes")
           )
         )
 
-        dropTable()
-        createTable()
+        dropTable(table)
+        createTable(queryTemplate, table)
 
         // insert rows
         // TODO: skipTiDBAndExpectedAnswerCheck because spark returns WrappedArray Type
-        writeFunc(List(row1, row2, row3, row4, row5), schema, None)
+        writeFunc(List(row1, row2, row3, row4, row5), schema, table, None)
         compareTiDBSelectWithJDBC(
           Seq(readRow1, readRow2, readRow3, readRow4, readRow5),
           readSchema,
+          table,
           skipTiDBAndExpectedAnswerCheck = true
         )
     }
@@ -87,6 +87,7 @@ class ToBytesSuite extends BaseDataSourceTest("test_data_type_convert_to_bytes")
   test("Test Convert from java.lang.Byte to BYTES") {
     // success
     // java.lang.Byte -> BYTES
+    val table = tableTemplate.format("byte")
     compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val a: java.lang.Byte = java.lang.Byte.valueOf("11")
@@ -134,15 +135,16 @@ class ToBytesSuite extends BaseDataSourceTest("test_data_type_convert_to_bytes")
           )
         )
 
-        dropTable()
-        createTable()
+        dropTable(table)
+        createTable(queryTemplate, table)
 
         // insert rows
         // TODO: skipTiDBAndExpectedAnswerCheck because spark returns WrappedArray Type
-        writeFunc(List(row1, row2, row3, row4, row5), schema, None)
+        writeFunc(List(row1, row2, row3, row4, row5), schema, table, None)
         compareTiDBSelectWithJDBC(
           Seq(readRow1, readRow2, readRow3, readRow4, readRow5),
           readSchema,
+          table,
           skipTiDBAndExpectedAnswerCheck = true
         )
     }
@@ -151,6 +153,7 @@ class ToBytesSuite extends BaseDataSourceTest("test_data_type_convert_to_bytes")
   test("Test Convert from java.lang.Short to BYTES") {
     // success
     // java.lang.Short -> BYTES
+    val table = tableTemplate.format("short")
     compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val a: java.lang.Short = java.lang.Short.valueOf("11")
@@ -198,15 +201,16 @@ class ToBytesSuite extends BaseDataSourceTest("test_data_type_convert_to_bytes")
           )
         )
 
-        dropTable()
-        createTable()
+        dropTable(table)
+        createTable(queryTemplate, table)
 
         // insert rows
         // TODO: skipTiDBAndExpectedAnswerCheck because spark returns WrappedArray Type
-        writeFunc(List(row1, row2, row3, row4, row5), schema, None)
+        writeFunc(List(row1, row2, row3, row4, row5), schema, table, None)
         compareTiDBSelectWithJDBC(
           Seq(readRow1, readRow2, readRow3, readRow4, readRow5),
           readSchema,
+          table,
           skipTiDBAndExpectedAnswerCheck = true
         )
     }
@@ -215,6 +219,7 @@ class ToBytesSuite extends BaseDataSourceTest("test_data_type_convert_to_bytes")
   test("Test Convert from java.lang.Integer to BYTES") {
     // success
     // java.lang.Integer -> BYTES
+    val table = tableTemplate.format("int")
     compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val a: java.lang.Integer = java.lang.Integer.valueOf("11")
@@ -262,15 +267,16 @@ class ToBytesSuite extends BaseDataSourceTest("test_data_type_convert_to_bytes")
           )
         )
 
-        dropTable()
-        createTable()
+        dropTable(table)
+        createTable(queryTemplate, table)
 
         // insert rows
         // TODO: skipTiDBAndExpectedAnswerCheck because spark returns WrappedArray Type
-        writeFunc(List(row1, row2, row3, row4, row5), schema, None)
+        writeFunc(List(row1, row2, row3, row4, row5), schema, table, None)
         compareTiDBSelectWithJDBC(
           Seq(readRow1, readRow2, readRow3, readRow4, readRow5),
           readSchema,
+          table,
           skipTiDBAndExpectedAnswerCheck = true
         )
     }
@@ -279,6 +285,7 @@ class ToBytesSuite extends BaseDataSourceTest("test_data_type_convert_to_bytes")
   test("Test Convert from java.lang.Long to BYTES") {
     // success
     // java.lang.Long -> BYTES
+    val table = tableTemplate.format("long")
     compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val a: java.lang.Long = java.lang.Long.valueOf("11")
@@ -326,15 +333,16 @@ class ToBytesSuite extends BaseDataSourceTest("test_data_type_convert_to_bytes")
           )
         )
 
-        dropTable()
-        createTable()
+        dropTable(table)
+        createTable(queryTemplate, table)
 
         // insert rows
         // TODO: skipTiDBAndExpectedAnswerCheck because spark returns WrappedArray Type
-        writeFunc(List(row1, row2, row3, row4, row5), schema, None)
+        writeFunc(List(row1, row2, row3, row4, row5), schema, table, None)
         compareTiDBSelectWithJDBC(
           Seq(readRow1, readRow2, readRow3, readRow4, readRow5),
           readSchema,
+          table,
           skipTiDBAndExpectedAnswerCheck = true
         )
     }
@@ -343,6 +351,7 @@ class ToBytesSuite extends BaseDataSourceTest("test_data_type_convert_to_bytes")
   test("Test Convert from String to BYTES") {
     // success
     // java.lang.String -> BYTES
+    val table = tableTemplate.format("str")
     compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val a: java.lang.String = new java.lang.String("11")
@@ -390,15 +399,16 @@ class ToBytesSuite extends BaseDataSourceTest("test_data_type_convert_to_bytes")
           )
         )
 
-        dropTable()
-        createTable()
+        dropTable(table)
+        createTable(queryTemplate, table)
 
         // insert rows
         // TODO: skipTiDBAndExpectedAnswerCheck because spark returns WrappedArray Type
-        writeFunc(List(row1, row2, row3, row4, row5), schema, None)
+        writeFunc(List(row1, row2, row3, row4, row5), schema, table, None)
         compareTiDBSelectWithJDBC(
           Seq(readRow1, readRow2, readRow3, readRow4, readRow5),
           readSchema,
+          table,
           skipTiDBAndExpectedAnswerCheck = true
         )
     }
@@ -414,11 +424,4 @@ class ToBytesSuite extends BaseDataSourceTest("test_data_type_convert_to_bytes")
   // scala.collection.Seq
   // scala.collection.Map
   // org.apache.spark.sql.Row
-
-  override def afterAll(): Unit =
-    try {
-      dropTable()
-    } finally {
-      super.afterAll()
-    }
 }

--- a/core/src/test/scala/com/pingcap/tispark/convert/ToDateSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/convert/ToDateSuite.scala
@@ -8,7 +8,7 @@ import org.apache.spark.sql.types._
  * DATE type include:
  * 1. DATE
  */
-class ToDateSuite extends BaseDataSourceTest("test_data_type_convert_to_date") {
+class ToDateSuite extends BaseDataSourceTest {
 
   private var readRow1: Row = _
   private var readRow2: Row = _
@@ -22,8 +22,8 @@ class ToDateSuite extends BaseDataSourceTest("test_data_type_convert_to_date") {
     )
   )
 
-  private def createTable(): Unit =
-    jdbcUpdate(s"create table $dbtable(i INT, c1 DATE, c2 DATE)")
+  val tableTemplate: String = "test_%s_to_date"
+  val queryTemplate: String = "create table `%s`.`%s`(i INT, c1 DATE, c2 DATE)"
 
   override def beforeAll(): Unit = {
     super.beforeAll()
@@ -38,6 +38,7 @@ class ToDateSuite extends BaseDataSourceTest("test_data_type_convert_to_date") {
   test("Test Convert from java.lang.Long to DATE") {
     // success
     // java.lang.Long -> DATE
+    val table = tableTemplate.format("long")
     compareTiDBWriteWithJDBC {
       case (writeFunc, "tidbWrite") =>
         val a: java.lang.Long = java.sql.Date.valueOf("2019-11-11").getTime
@@ -54,12 +55,12 @@ class ToDateSuite extends BaseDataSourceTest("test_data_type_convert_to_date") {
           )
         )
 
-        dropTable()
-        createTable()
+        dropTable(table)
+        createTable(queryTemplate, table)
 
         // insert rows
-        writeFunc(List(row1, row2), schema, None)
-        compareTiDBSelectWithJDBC(Seq(readRow1, readRow2), readSchema)
+        writeFunc(List(row1, row2), schema, table, None)
+        compareTiDBSelectWithJDBC(Seq(readRow1, readRow2), readSchema, table)
       case (writeFunc, "jdbcWrite") =>
       //ignored, because of this error
       //java.sql.BatchUpdateException: Data truncation: invalid time format: '34'
@@ -69,6 +70,7 @@ class ToDateSuite extends BaseDataSourceTest("test_data_type_convert_to_date") {
   test("Test Convert from String to DATE") {
     // success
     // String -> DATE
+    val table = tableTemplate.format("str")
     compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val a: java.lang.String = "2019-11-11"
@@ -85,18 +87,19 @@ class ToDateSuite extends BaseDataSourceTest("test_data_type_convert_to_date") {
           )
         )
 
-        dropTable()
-        createTable()
+        dropTable(table)
+        createTable(queryTemplate, table)
 
         // insert rows
-        writeFunc(List(row1, row2), schema, None)
-        compareTiDBSelectWithJDBC(Seq(readRow1, readRow2), readSchema)
+        writeFunc(List(row1, row2), schema, table, None)
+        compareTiDBSelectWithJDBC(Seq(readRow1, readRow2), readSchema, table)
     }
   }
 
   test("Test Convert from java.sql.Date to DATE") {
     // success
     // java.sql.Date -> DATE
+    val table = tableTemplate.format("date")
     compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val a: java.sql.Date = java.sql.Date.valueOf("2019-11-11")
@@ -113,18 +116,19 @@ class ToDateSuite extends BaseDataSourceTest("test_data_type_convert_to_date") {
           )
         )
 
-        dropTable()
-        createTable()
+        dropTable(table)
+        createTable(queryTemplate, table)
 
         // insert rows
-        writeFunc(List(row1, row2), schema, None)
-        compareTiDBSelectWithJDBC(Seq(row1, row2), schema)
+        writeFunc(List(row1, row2), schema, table, None)
+        compareTiDBSelectWithJDBC(Seq(row1, row2), schema, table)
     }
   }
 
   test("Test Convert from java.sql.Timestamp to DATE") {
     // success
     // java.sql.Timestamp -> DATE
+    val table = tableTemplate.format("long")
     compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val a: java.sql.Timestamp = java.sql.Timestamp.valueOf("2019-11-11 11:11:11")
@@ -141,12 +145,12 @@ class ToDateSuite extends BaseDataSourceTest("test_data_type_convert_to_date") {
           )
         )
 
-        dropTable()
-        createTable()
+        dropTable(table)
+        createTable(queryTemplate, table)
 
         // insert rows
-        writeFunc(List(row1, row2), schema, None)
-        compareTiDBSelectWithJDBC(Seq(readRow1, readRow2), readSchema)
+        writeFunc(List(row1, row2), schema, table, None)
+        compareTiDBSelectWithJDBC(Seq(readRow1, readRow2), readSchema, table)
     }
   }
 
@@ -162,11 +166,4 @@ class ToDateSuite extends BaseDataSourceTest("test_data_type_convert_to_date") {
   // scala.collection.Seq
   // scala.collection.Map
   // org.apache.spark.sql.Row
-
-  override def afterAll(): Unit =
-    try {
-      dropTable()
-    } finally {
-      super.afterAll()
-    }
 }

--- a/core/src/test/scala/com/pingcap/tispark/convert/ToDateTimeSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/convert/ToDateTimeSuite.scala
@@ -8,7 +8,7 @@ import org.apache.spark.sql.types._
  * DATETIME type include:
  * 1. DATETIME
  */
-class ToDateTimeSuite extends BaseDataSourceTest("test_data_type_convert_to_datetime") {
+class ToDateTimeSuite extends BaseDataSourceTest {
 
   private var readRow1: Row = _
   private var readRow2: Row = _
@@ -22,8 +22,9 @@ class ToDateTimeSuite extends BaseDataSourceTest("test_data_type_convert_to_date
     )
   )
 
-  private def createTable(): Unit =
-    jdbcUpdate(s"create table $dbtable(i INT, c1 DATETIME(0), c2 DATETIME(3), c3 DATETIME(6))")
+  val queryTemplate: String =
+    "create table `%s`.`%s`(i INT, c1 DATETIME(0), c2 DATETIME(3), c3 DATETIME(6))"
+  val tableTemplate: String = "test_%s_to_datetime"
 
   override def beforeAll(): Unit = {
     super.beforeAll()
@@ -39,6 +40,7 @@ class ToDateTimeSuite extends BaseDataSourceTest("test_data_type_convert_to_date
   test("Test Convert from String to DATETIME") {
     // success
     // String -> DATETIME
+    val table = tableTemplate.format("str")
     compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val row1 = Row(1, null, null, null)
@@ -54,18 +56,19 @@ class ToDateTimeSuite extends BaseDataSourceTest("test_data_type_convert_to_date
           )
         )
 
-        dropTable()
-        createTable()
+        dropTable(table)
+        createTable(queryTemplate, table)
 
         // insert rows
-        writeFunc(List(row1, row2), schema, None)
-        compareTiDBSelectWithJDBC(Seq(readRow1, readRow2), readSchema)
+        writeFunc(List(row1, row2), schema, table, None)
+        compareTiDBSelectWithJDBC(Seq(readRow1, readRow2), readSchema, table)
     }
   }
 
   test("Test Convert from java.sql.Date to DATETIME") {
     // success
     // java.sql.Date -> DATETIME
+    val table = tableTemplate.format("date")
     compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val a: java.sql.Date = java.sql.Date.valueOf("2019-11-11")
@@ -84,18 +87,19 @@ class ToDateTimeSuite extends BaseDataSourceTest("test_data_type_convert_to_date
           )
         )
 
-        dropTable()
-        createTable()
+        dropTable(table)
+        createTable(queryTemplate, table)
 
         // insert rows
-        writeFunc(List(row1, row2), schema, None)
-        compareTiDBSelectWithJDBC(Seq(row1, row2), schema)
+        writeFunc(List(row1, row2), schema, table, None)
+        compareTiDBSelectWithJDBC(Seq(row1, row2), schema, table)
     }
   }
 
   test("Test Convert from java.sql.Timestamp to DATETIME") {
     // success
     // java.sql.Timestamp -> DATETIME
+    val table = tableTemplate.format("ts")
     compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val a: java.sql.Timestamp = java.sql.Timestamp.valueOf("2019-11-11 11:11:11")
@@ -114,12 +118,12 @@ class ToDateTimeSuite extends BaseDataSourceTest("test_data_type_convert_to_date
           )
         )
 
-        dropTable()
-        createTable()
+        dropTable(table)
+        createTable(queryTemplate, table)
 
         // insert rows
-        writeFunc(List(row1, row2), schema, None)
-        compareTiDBSelectWithJDBC(Seq(row1, row2), schema)
+        writeFunc(List(row1, row2), schema, table, None)
+        compareTiDBSelectWithJDBC(Seq(row1, row2), schema, table)
     }
   }
 
@@ -138,11 +142,4 @@ class ToDateTimeSuite extends BaseDataSourceTest("test_data_type_convert_to_date
   // scala.collection.Seq
   // scala.collection.Map
   // org.apache.spark.sql.Row
-
-  override def afterAll(): Unit =
-    try {
-      dropTable()
-    } finally {
-      super.afterAll()
-    }
 }

--- a/core/src/test/scala/com/pingcap/tispark/convert/ToDecimalSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/convert/ToDecimalSuite.scala
@@ -8,7 +8,7 @@ import org.apache.spark.sql.types.{StructField, _}
  * DECIMAL type include:
  * 1. DECIMAL
  */
-class ToDecimalSuite extends BaseDataSourceTest("test_data_type_convert_to_decimal") {
+class ToDecimalSuite extends BaseDataSourceTest {
 
   private val readSchema = StructType(
     List(
@@ -22,20 +22,21 @@ class ToDecimalSuite extends BaseDataSourceTest("test_data_type_convert_to_decim
     )
   )
 
-  private def createTable(): Unit =
-    jdbcUpdate(
-      s"""create table $dbtable(i INT,
-         |c1 DECIMAL(38, 1),
-         |c2 DECIMAL(38, 2),
-         |c3 DECIMAL(38, 3),
-         |c4 DECIMAL(38, 4),
-         |c5 DECIMAL(38, 5),
-         |c6 DECIMAL(38, 6))""".stripMargin
-    )
+  val queryTemplate: String =
+    """create table `%s`.`%s`(i INT,
+      |c1 DECIMAL(38, 1),
+      |c2 DECIMAL(38, 2),
+      |c3 DECIMAL(38, 3),
+      |c4 DECIMAL(38, 4),
+      |c5 DECIMAL(38, 5),
+      |c6 DECIMAL(38, 6))""".stripMargin
+
+  val tableTemplate: String = "test_%s_to_decimal"
 
   test("Test Convert from java.lang.Boolean to DECIMAL") {
     // success
     // java.lang.Boolean -> DECIMAL
+    val table = tableTemplate.format("boolean")
     compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val a: java.lang.Boolean = true
@@ -78,18 +79,23 @@ class ToDecimalSuite extends BaseDataSourceTest("test_data_type_convert_to_decim
         val readRow4 = Row(4, readA1, readA2, readA3, readA4, readA5, readA6)
         val readRow5 = Row(5, readB1, readB2, readB3, readB4, readB5, readB6)
 
-        dropTable()
-        createTable()
+        dropTable(table)
+        createTable(queryTemplate, table)
 
         // insert rows
-        writeFunc(List(row1, row2, row3, row4, row5), schema, None)
-        compareTiDBSelectWithJDBC(Seq(readRow1, readRow2, readRow3, readRow4, readRow5), readSchema)
+        writeFunc(List(row1, row2, row3, row4, row5), schema, table, None)
+        compareTiDBSelectWithJDBC(
+          Seq(readRow1, readRow2, readRow3, readRow4, readRow5),
+          readSchema,
+          table
+        )
     }
   }
 
   test("Test Convert from java.lang.Byte to DECIMAL") {
     // success
     // java.lang.Byte -> DECIMAL
+    val table = tableTemplate.format("byte")
     compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val a: java.lang.Byte = java.lang.Byte.valueOf("11")
@@ -115,18 +121,19 @@ class ToDecimalSuite extends BaseDataSourceTest("test_data_type_convert_to_decim
           )
         )
 
-        dropTable()
-        createTable()
+        dropTable(table)
+        createTable(queryTemplate, table)
 
         // insert rows
-        writeFunc(List(row1, row2, row3, row4, row5), schema, None)
-        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5), schema)
+        writeFunc(List(row1, row2, row3, row4, row5), schema, table, None)
+        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5), schema, table)
     }
   }
 
   test("Test Convert from java.lang.Short to DECIMAL") {
     // success
     // java.lang.Short -> DECIMAL
+    val table = tableTemplate.format("short")
     compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val a: java.lang.Short = java.lang.Short.valueOf("11")
@@ -152,18 +159,19 @@ class ToDecimalSuite extends BaseDataSourceTest("test_data_type_convert_to_decim
           )
         )
 
-        dropTable()
-        createTable()
+        dropTable(table)
+        createTable(queryTemplate, table)
 
         // insert rows
-        writeFunc(List(row1, row2, row3, row4, row5), schema, None)
-        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5), schema)
+        writeFunc(List(row1, row2, row3, row4, row5), schema, table, None)
+        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5), schema, table)
     }
   }
 
   test("Test Convert from java.lang.Integer to DECIMAL") {
     // success
     // java.lang.Integer -> DECIMAL
+    val table = tableTemplate.format("int")
     compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val a: java.lang.Integer = java.lang.Integer.valueOf("11")
@@ -189,18 +197,19 @@ class ToDecimalSuite extends BaseDataSourceTest("test_data_type_convert_to_decim
           )
         )
 
-        dropTable()
-        createTable()
+        dropTable(table)
+        createTable(queryTemplate, table)
 
         // insert rows
-        writeFunc(List(row1, row2, row3, row4, row5), schema, None)
-        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5), schema)
+        writeFunc(List(row1, row2, row3, row4, row5), schema, table, None)
+        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5), schema, table)
     }
   }
 
   test("Test Convert from java.lang.Long to DECIMAL") {
     // success
     // java.lang.Long -> DECIMAL
+    val table = tableTemplate.format("long")
     compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val a: java.lang.Long = java.lang.Long.valueOf("11")
@@ -226,18 +235,19 @@ class ToDecimalSuite extends BaseDataSourceTest("test_data_type_convert_to_decim
           )
         )
 
-        dropTable()
-        createTable()
+        dropTable(table)
+        createTable(queryTemplate, table)
 
         // insert rows
-        writeFunc(List(row1, row2, row3, row4, row5), schema, None)
-        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5), schema)
+        writeFunc(List(row1, row2, row3, row4, row5), schema, table, None)
+        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5), schema, table)
     }
   }
 
   test("Test Convert from java.lang.Float to DECIMAL") {
     // success
     // java.lang.Float -> DECIMAL
+    val table = tableTemplate.format("float")
     compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val a1: java.lang.Float = 1.1f
@@ -272,18 +282,19 @@ class ToDecimalSuite extends BaseDataSourceTest("test_data_type_convert_to_decim
         val readRow1 = Row(1, null, null, null, null, null, null)
         val readRow2 = Row(2, readA1, readA2, readA3, readA4, readA5, readA6)
 
-        dropTable()
-        createTable()
+        dropTable(table)
+        createTable(queryTemplate, table)
 
         // insert rows
-        writeFunc(List(row1, row2), schema, None)
-        compareTiDBSelectWithJDBC(Seq(readRow1, readRow2), readSchema)
+        writeFunc(List(row1, row2), schema, table, None)
+        compareTiDBSelectWithJDBC(Seq(readRow1, readRow2), readSchema, table)
     }
   }
 
   test("Test Convert from java.lang.Double to DECIMAL") {
     // success
     // java.lang.Double -> DECIMAL
+    val table = tableTemplate.format("double")
     compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val a1: java.lang.Double = 1.1d
@@ -317,18 +328,19 @@ class ToDecimalSuite extends BaseDataSourceTest("test_data_type_convert_to_decim
 
         val readRow1 = Row(1, null, null, null, null, null, null)
         val readRow2 = Row(2, readA1, readA2, readA3, readA4, readA5, readA6)
-        dropTable()
-        createTable()
+        dropTable(table)
+        createTable(queryTemplate, table)
 
         // insert rows
-        writeFunc(List(row1, row2), schema, None)
-        compareTiDBSelectWithJDBC(Seq(readRow1, readRow2), readSchema)
+        writeFunc(List(row1, row2), schema, table, None)
+        compareTiDBSelectWithJDBC(Seq(readRow1, readRow2), readSchema, table)
     }
   }
 
   test("Test Convert from String to DECIMAL") {
     // success
     // java.lang.String -> DECIMAL
+    val table = tableTemplate.format("str")
     compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val a: java.lang.String = new java.lang.String("1.1")
@@ -359,18 +371,19 @@ class ToDecimalSuite extends BaseDataSourceTest("test_data_type_convert_to_decim
         val readRow1 = Row(1, null, null, null, null, null, null)
         val readRow2 = Row(2, readA1, readB2, readA3, readB4, readA5, readB6)
 
-        dropTable()
-        createTable()
+        dropTable(table)
+        createTable(queryTemplate, table)
 
         // insert rows
-        writeFunc(List(row1, row2), schema, None)
-        compareTiDBSelectWithJDBC(Seq(readRow1, readRow2), readSchema)
+        writeFunc(List(row1, row2), schema, table, None)
+        compareTiDBSelectWithJDBC(Seq(readRow1, readRow2), readSchema, table)
     }
   }
 
   test("Test Convert from java.math.BigDecimal to DECIMAL") {
     // failure
     // java.math.BigDecimal -> DECIMAL
+    val table = tableTemplate.format("bigdecimal")
     compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val a: java.math.BigDecimal = java.math.BigDecimal.ONE
@@ -396,12 +409,12 @@ class ToDecimalSuite extends BaseDataSourceTest("test_data_type_convert_to_decim
           )
         )
 
-        dropTable()
-        createTable()
+        dropTable(table)
+        createTable(queryTemplate, table)
 
         // insert rows
-        writeFunc(List(row1, row2, row3, row4, row5), schema, None)
-        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5), schema)
+        writeFunc(List(row1, row2, row3, row4, row5), schema, table, None)
+        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5), schema, table)
     }
   }
 
@@ -412,11 +425,4 @@ class ToDecimalSuite extends BaseDataSourceTest("test_data_type_convert_to_decim
   // scala.collection.Seq
   // scala.collection.Map
   // org.apache.spark.sql.Row
-
-  override def afterAll(): Unit =
-    try {
-      dropTable()
-    } finally {
-      super.afterAll()
-    }
 }

--- a/core/src/test/scala/com/pingcap/tispark/convert/ToEnumSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/convert/ToEnumSuite.scala
@@ -8,7 +8,7 @@ import org.apache.spark.sql.types.{StructField, _}
  * ENUM type include:
  * 1. ENUM
  */
-class ToEnumSuite extends BaseDataSourceTest("test_data_type_convert_to_enum") {
+class ToEnumSuite extends BaseDataSourceTest {
 
   private val readOne: java.lang.String = java.lang.String.valueOf("male")
   private val readTwo: java.lang.String = java.lang.String.valueOf("female")
@@ -35,19 +35,22 @@ class ToEnumSuite extends BaseDataSourceTest("test_data_type_convert_to_enum") {
     )
   )
 
-  private def createTable(): Unit =
-    jdbcUpdate(s"""create table $dbtable(i INT,
-                  |c1 ENUM('male', 'female', 'both', 'unknown'),
-                  |c2 ENUM('male', 'female', 'both', 'unknown'),
-                  |c3 ENUM('male', 'female', 'both', 'unknown'),
-                  |c4 ENUM('male', 'female', 'both', 'unknown'),
-                  |c5 ENUM('male', 'female', 'both', 'unknown'),
-                  |c6 ENUM('male', 'female', 'both', 'unknown')
-                  |)""".stripMargin)
+  val queryTemplate =
+    s"""create table `%s`.`%s`(i INT,
+       |c1 ENUM('male', 'female', 'both', 'unknown'),
+       |c2 ENUM('male', 'female', 'both', 'unknown'),
+       |c3 ENUM('male', 'female', 'both', 'unknown'),
+       |c4 ENUM('male', 'female', 'both', 'unknown'),
+       |c5 ENUM('male', 'female', 'both', 'unknown'),
+       |c6 ENUM('male', 'female', 'both', 'unknown')
+       |)""".stripMargin
+
+  val tableTemplate = "test_%s_to_enum"
 
   test("Test Convert from java.lang.Boolean to ENUM") {
     // success
     // java.lang.Boolean -> ENUM
+    val table = tableTemplate.format("boolean")
     compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val row1 = Row(1, null, null, null, null, null, null)
@@ -74,18 +77,23 @@ class ToEnumSuite extends BaseDataSourceTest("test_data_type_convert_to_enum") {
         val readRow4 = Row(4, "male", "male", "male", "male", "male", "male")
         val readRow5 = Row(5, "male", "male", "male", "male", "male", "male")
 
-        dropTable()
-        createTable()
+        dropTable(table)
+        createTable(queryTemplate, table)
 
         // insert rows
-        writeFunc(List(row1, row2, row3, row4, row5), schema, None)
-        compareTiDBSelectWithJDBC(Seq(readRow1, readRow2, readRow3, readRow4, readRow5), readSchema)
+        writeFunc(List(row1, row2, row3, row4, row5), schema, table, None)
+        compareTiDBSelectWithJDBC(
+          Seq(readRow1, readRow2, readRow3, readRow4, readRow5),
+          readSchema,
+          table
+        )
     }
   }
 
   test("Test Convert from java.lang.Byte to ENUM") {
     // success
     // java.lang.Byte -> ENUM
+    val table = tableTemplate.format("byte")
     compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val one: java.lang.Byte = java.lang.Byte.valueOf("1")
@@ -113,18 +121,23 @@ class ToEnumSuite extends BaseDataSourceTest("test_data_type_convert_to_enum") {
           )
         )
 
-        dropTable()
-        createTable()
+        dropTable(table)
+        createTable(queryTemplate, table)
 
         // insert rows
-        writeFunc(List(row1, row2, row3, row4, row5), schema, None)
-        compareTiDBSelectWithJDBC(Seq(readRow1, readRow2, readRow3, readRow4, readRow5), readSchema)
+        writeFunc(List(row1, row2, row3, row4, row5), schema, table, None)
+        compareTiDBSelectWithJDBC(
+          Seq(readRow1, readRow2, readRow3, readRow4, readRow5),
+          readSchema,
+          table
+        )
     }
   }
 
   test("Test Convert from java.lang.Short to ENUM") {
     // success
     // java.lang.Short -> ENUM
+    val table = tableTemplate.format("short")
     compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val one: java.lang.Short = java.lang.Short.valueOf("1")
@@ -152,18 +165,23 @@ class ToEnumSuite extends BaseDataSourceTest("test_data_type_convert_to_enum") {
           )
         )
 
-        dropTable()
-        createTable()
+        dropTable(table)
+        createTable(queryTemplate, table)
 
         // insert rows
-        writeFunc(List(row1, row2, row3, row4, row5), schema, None)
-        compareTiDBSelectWithJDBC(Seq(readRow1, readRow2, readRow3, readRow4, readRow5), readSchema)
+        writeFunc(List(row1, row2, row3, row4, row5), schema, table, None)
+        compareTiDBSelectWithJDBC(
+          Seq(readRow1, readRow2, readRow3, readRow4, readRow5),
+          readSchema,
+          table
+        )
     }
   }
 
   test("Test Convert from java.lang.Integer to ENUM") {
     // success
     // java.lang.Integer -> ENUM
+    val table = tableTemplate.format("int")
     compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val one: java.lang.Integer = java.lang.Integer.valueOf("1")
@@ -191,18 +209,23 @@ class ToEnumSuite extends BaseDataSourceTest("test_data_type_convert_to_enum") {
           )
         )
 
-        dropTable()
-        createTable()
+        dropTable(table)
+        createTable(queryTemplate, table)
 
         // insert rows
-        writeFunc(List(row1, row2, row3, row4, row5), schema, None)
-        compareTiDBSelectWithJDBC(Seq(readRow1, readRow2, readRow3, readRow4, readRow5), readSchema)
+        writeFunc(List(row1, row2, row3, row4, row5), schema, table, None)
+        compareTiDBSelectWithJDBC(
+          Seq(readRow1, readRow2, readRow3, readRow4, readRow5),
+          readSchema,
+          table
+        )
     }
   }
 
   test("Test Convert from java.lang.Long to ENUM") {
     // success
     // java.lang.Long -> ENUM
+    val table = tableTemplate.format("long")
     compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val one: java.lang.Long = java.lang.Long.valueOf("1")
@@ -230,18 +253,23 @@ class ToEnumSuite extends BaseDataSourceTest("test_data_type_convert_to_enum") {
           )
         )
 
-        dropTable()
-        createTable()
+        dropTable(table)
+        createTable(queryTemplate, table)
 
         // insert rows
-        writeFunc(List(row1, row2, row3, row4, row5), schema, None)
-        compareTiDBSelectWithJDBC(Seq(readRow1, readRow2, readRow3, readRow4, readRow5), readSchema)
+        writeFunc(List(row1, row2, row3, row4, row5), schema, table, None)
+        compareTiDBSelectWithJDBC(
+          Seq(readRow1, readRow2, readRow3, readRow4, readRow5),
+          readSchema,
+          table
+        )
     }
   }
 
   test("Test Convert from java.lang.Float to ENUM") {
     // success
     // java.lang.Float -> ENUM
+    val table = tableTemplate.format("float")
     compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val one: java.lang.Float = new java.lang.Float("1")
@@ -269,18 +297,23 @@ class ToEnumSuite extends BaseDataSourceTest("test_data_type_convert_to_enum") {
           )
         )
 
-        dropTable()
-        createTable()
+        dropTable(table)
+        createTable(queryTemplate, table)
 
         // insert rows
-        writeFunc(List(row1, row2, row3, row4, row5), schema, None)
-        compareTiDBSelectWithJDBC(Seq(readRow1, readRow2, readRow3, readRow4, readRow5), readSchema)
+        writeFunc(List(row1, row2, row3, row4, row5), schema, table, None)
+        compareTiDBSelectWithJDBC(
+          Seq(readRow1, readRow2, readRow3, readRow4, readRow5),
+          readSchema,
+          table
+        )
     }
   }
 
   test("Test Convert from java.lang.Double to ENUM") {
     // success
     // java.lang.Double -> ENUM
+    val table = tableTemplate.format("double")
     compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val one: java.lang.Double = new java.lang.Double("1")
@@ -308,18 +341,23 @@ class ToEnumSuite extends BaseDataSourceTest("test_data_type_convert_to_enum") {
           )
         )
 
-        dropTable()
-        createTable()
+        dropTable(table)
+        createTable(queryTemplate, table)
 
         // insert rows
-        writeFunc(List(row1, row2, row3, row4, row5), schema, None)
-        compareTiDBSelectWithJDBC(Seq(readRow1, readRow2, readRow3, readRow4, readRow5), readSchema)
+        writeFunc(List(row1, row2, row3, row4, row5), schema, table, None)
+        compareTiDBSelectWithJDBC(
+          Seq(readRow1, readRow2, readRow3, readRow4, readRow5),
+          readSchema,
+          table
+        )
     }
   }
 
   test("Test Convert from String to ENUM") {
     // success
     // java.lang.String -> ENUM
+    val table = tableTemplate.format("str")
     compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val one: java.lang.String = new java.lang.String("1")
@@ -347,12 +385,16 @@ class ToEnumSuite extends BaseDataSourceTest("test_data_type_convert_to_enum") {
           )
         )
 
-        dropTable()
-        createTable()
+        dropTable(table)
+        createTable(queryTemplate, table)
 
         // insert rows
-        writeFunc(List(row1, row2, row3, row4, row5), schema, None)
-        compareTiDBSelectWithJDBC(Seq(readRow1, readRow2, readRow3, readRow4, readRow5), readSchema)
+        writeFunc(List(row1, row2, row3, row4, row5), schema, table, None)
+        compareTiDBSelectWithJDBC(
+          Seq(readRow1, readRow2, readRow3, readRow4, readRow5),
+          readSchema,
+          table
+        )
     }
   }
 
@@ -364,11 +406,4 @@ class ToEnumSuite extends BaseDataSourceTest("test_data_type_convert_to_enum") {
   // scala.collection.Seq
   // scala.collection.Map
   // org.apache.spark.sql.Row
-
-  override def afterAll(): Unit =
-    try {
-      dropTable()
-    } finally {
-      super.afterAll()
-    }
 }

--- a/core/src/test/scala/com/pingcap/tispark/convert/ToRealSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/convert/ToRealSuite.scala
@@ -25,13 +25,14 @@ class ToRealSuite extends BaseDataSourceTest("test_data_type_convert_to_real") {
     )
   )
 
-  private def createTable(): Unit =
-    jdbcUpdate(s"create table $dbtable(i INT, c1 FLOAT, c2 DOUBLE)")
+  val queryTemplate = "create table `%s`.`%s`(i INT, c1 FLOAT, c2 DOUBLE)"
+  val tableTemplate = "test_%s_to_real"
 
   test("Test Convert from java.lang.Boolean to REAL") {
     // success
     // java.lang.Boolean -> FLOAT
     // java.lang.Boolean -> DOUBLE
+    val table = tableTemplate.format("boolean")
     compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val row1 = Row(1, null, null)
@@ -52,12 +53,12 @@ class ToRealSuite extends BaseDataSourceTest("test_data_type_convert_to_real") {
         val readRow3 = Row(3, 0f, 1d)
         val readRow4 = Row(4, 1f, 1d)
 
-        dropTable()
-        createTable()
+        dropTable(table)
+        createTable(queryTemplate, table)
 
         // insert rows
-        writeFunc(List(row1, row2, row3, row4), schema, None)
-        compareTiDBSelectWithJDBC(Seq(readRow1, readRow2, readRow3, readRow4), readSchema)
+        writeFunc(List(row1, row2, row3, row4), schema, table, None)
+        compareTiDBSelectWithJDBC(Seq(readRow1, readRow2, readRow3, readRow4), readSchema, table)
     }
   }
 
@@ -65,6 +66,7 @@ class ToRealSuite extends BaseDataSourceTest("test_data_type_convert_to_real") {
     // success
     // java.lang.Byte -> FLOAT
     // java.lang.Byte -> DOUBLE
+    val table = tableTemplate.format("byte")
     compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val a: java.lang.Byte = java.lang.Byte.valueOf("11")
@@ -83,12 +85,12 @@ class ToRealSuite extends BaseDataSourceTest("test_data_type_convert_to_real") {
           )
         )
 
-        dropTable()
-        createTable()
+        dropTable(table)
+        createTable(queryTemplate, table)
 
         // insert rows
-        writeFunc(List(row1, row2, row3, row4), schema, None)
-        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4), schema)
+        writeFunc(List(row1, row2, row3, row4), schema, table, None)
+        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4), schema, table)
     }
   }
 
@@ -96,6 +98,7 @@ class ToRealSuite extends BaseDataSourceTest("test_data_type_convert_to_real") {
     // success
     // java.lang.Short -> FLOAT
     // java.lang.Short -> DOUBLE
+    val table = tableTemplate.format("short")
     compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val a: java.lang.Short = java.lang.Short.valueOf("11")
@@ -114,12 +117,12 @@ class ToRealSuite extends BaseDataSourceTest("test_data_type_convert_to_real") {
           )
         )
 
-        dropTable()
-        createTable()
+        dropTable(table)
+        createTable(queryTemplate, table)
 
         // insert rows
-        writeFunc(List(row1, row2, row3, row4), schema, None)
-        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4), schema)
+        writeFunc(List(row1, row2, row3, row4), schema, table, None)
+        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4), schema, table)
     }
   }
 
@@ -127,6 +130,7 @@ class ToRealSuite extends BaseDataSourceTest("test_data_type_convert_to_real") {
     // success
     // java.lang.Integer -> FLOAT
     // java.lang.Integer -> DOUBLE
+    val table = tableTemplate.format("int")
     compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val row1 = Row(1, null, null)
@@ -148,12 +152,12 @@ class ToRealSuite extends BaseDataSourceTest("test_data_type_convert_to_real") {
           Row(3, java.lang.Integer.MAX_VALUE.toFloat, java.lang.Integer.MIN_VALUE.toDouble)
         val readRow4 = Row(4, java.lang.Integer.MIN_VALUE.toFloat, java.lang.Integer.MAX_VALUE)
 
-        dropTable()
-        createTable()
+        dropTable(table)
+        createTable(queryTemplate, table)
 
         // insert rows
-        writeFunc(List(row1, row2, row3, row4), schema, None)
-        compareTiDBSelectWithJDBC(Seq(readRow1, readRow2, readRow3, readRow4), readSchema)
+        writeFunc(List(row1, row2, row3, row4), schema, table, None)
+        compareTiDBSelectWithJDBC(Seq(readRow1, readRow2, readRow3, readRow4), readSchema, table)
     }
   }
 
@@ -161,6 +165,7 @@ class ToRealSuite extends BaseDataSourceTest("test_data_type_convert_to_real") {
     // success
     // java.lang.Long -> FLOAT
     // java.lang.Long -> DOUBLE
+    val table = tableTemplate.format("long")
     compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val row1 = Row(1, null, null)
@@ -176,12 +181,12 @@ class ToRealSuite extends BaseDataSourceTest("test_data_type_convert_to_real") {
           )
         )
 
-        dropTable()
-        createTable()
+        dropTable(table)
+        createTable(queryTemplate, table)
 
         // insert rows
-        writeFunc(List(row1, row2, row3, row4), schema, None)
-        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4), schema)
+        writeFunc(List(row1, row2, row3, row4), schema, table, None)
+        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4), schema, table)
     }
   }
 
@@ -189,6 +194,7 @@ class ToRealSuite extends BaseDataSourceTest("test_data_type_convert_to_real") {
     // success
     // java.lang.Float -> FLOAT
     // java.lang.Float -> DOUBLE
+    val table = tableTemplate.format("float")
     compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val row1 = Row(1, null, null)
@@ -213,17 +219,18 @@ class ToRealSuite extends BaseDataSourceTest("test_data_type_convert_to_real") {
         val readRow5 = Row(5, -maxFloat, (-maxFloat).toDouble)
         val readRow6 = Row(6, -minFloat, (-minFloat).toDouble)
 
-        dropTable()
-        createTable()
+        dropTable(table)
+        createTable(queryTemplate, table)
 
         // insert rows
-        writeFunc(List(row1, row2, row3, row4, row5, row6), schema, None)
+        writeFunc(List(row1, row2, row3, row4, row5, row6), schema, table, None)
 
         // TODO: TiSpark transforms FLOAT to Double, which will cause precision problem,
         //  so we just set skipTiDBAndExpectedAnswerCheck = true
         compareTiDBSelectWithJDBC(
           Seq(readRow1, readRow2, readRow3, readRow4, readRow5, readRow6),
           readSchema,
+          table,
           skipTiDBAndExpectedAnswerCheck = true
         )
     }
@@ -233,6 +240,7 @@ class ToRealSuite extends BaseDataSourceTest("test_data_type_convert_to_real") {
     // success
     // java.lang.Double -> FLOAT
     // java.lang.Double -> DOUBLE
+    val table = tableTemplate.format("double")
     compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         //  + 1.0E-40f because of this issue: https://github.com/pingcap/tidb/issues/10587
@@ -258,14 +266,15 @@ class ToRealSuite extends BaseDataSourceTest("test_data_type_convert_to_real") {
         val readRow5 = Row(5, -maxFloat, -maxDouble)
         val readRow6 = Row(6, -minFloat, -minDouble)
 
-        dropTable()
-        createTable()
+        dropTable(table)
+        createTable(queryTemplate, table)
 
         // insert rows
-        writeFunc(List(row1, row2, row3, row4, row5, row6), schema, None)
+        writeFunc(List(row1, row2, row3, row4, row5, row6), schema, table, None)
         compareTiDBSelectWithJDBC(
           Seq(readRow1, readRow2, readRow3, readRow4, readRow5, readRow6),
-          readSchema
+          readSchema,
+          table
         )
     }
   }
@@ -274,6 +283,7 @@ class ToRealSuite extends BaseDataSourceTest("test_data_type_convert_to_real") {
     // success
     // String -> FLOAT
     // String -> DOUBLE
+    val table = tableTemplate.format("str")
     compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val row1 = Row(1, null, null)
@@ -298,14 +308,15 @@ class ToRealSuite extends BaseDataSourceTest("test_data_type_convert_to_real") {
         val readRow5 = Row(5, -minFloat, -minDouble)
         val readRow6 = Row(6, -maxFloat, -maxDouble)
 
-        dropTable()
-        createTable()
+        dropTable(table)
+        createTable(queryTemplate, table)
 
         // insert rows
-        writeFunc(List(row1, row2, row3, row4, row5, row6), schema, None)
+        writeFunc(List(row1, row2, row3, row4, row5, row6), schema, table, None)
         compareTiDBSelectWithJDBC(
           Seq(readRow1, readRow2, readRow3, readRow4, readRow5, readRow6),
-          readSchema
+          readSchema,
+          table
         )
     }
   }
@@ -318,11 +329,4 @@ class ToRealSuite extends BaseDataSourceTest("test_data_type_convert_to_real") {
   // scala.collection.Seq
   // scala.collection.Map
   // org.apache.spark.sql.Row
-
-  override def afterAll(): Unit =
-    try {
-      dropTable()
-    } finally {
-      super.afterAll()
-    }
 }

--- a/core/src/test/scala/com/pingcap/tispark/convert/ToSignedSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/convert/ToSignedSuite.scala
@@ -13,7 +13,7 @@ import org.apache.spark.sql.types._
  * 5. BIGINT SINGED
  * 6. BOOLEAN
  */
-class ToSignedSuite extends BaseDataSourceTest("test_data_type_convert_to_signed") {
+class ToSignedSuite extends BaseDataSourceTest {
 
   private val readSchema = StructType(
     List(
@@ -27,14 +27,14 @@ class ToSignedSuite extends BaseDataSourceTest("test_data_type_convert_to_signed
     )
   )
 
-  private def createTable(): Unit =
-    jdbcUpdate(
-      s"create table $dbtable(i INT, c1 TINYINT, c2 SMALLINT, c3 MEDIUMINT, c4 INT, c5 BIGINT, c6 BOOLEAN)"
-    )
+  val queryTemplate =
+    "create table `%s`.`%s`(i INT, c1 TINYINT, c2 SMALLINT, c3 MEDIUMINT, c4 INT, c5 BIGINT, c6 BOOLEAN)"
+  val tableTemplate = "test_%s_to_signed"
 
   test("Test Convert from java.lang.Boolean to SINGED") {
     // success
     // java.lang.Boolean -> {TINYINT SMALLINT MEDIUMINT INT BIGINT} SIGNED BOOLEAN
+    val table = tableTemplate.format("boolean")
     compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val row1 = Row(1, null, null, null, null, null, null)
@@ -63,14 +63,15 @@ class ToSignedSuite extends BaseDataSourceTest("test_data_type_convert_to_signed
         val readRow5 = Row(5, 1L, 0L, 0L, null, 1L, 0L)
         val readRow6 = Row(6, 1L, 0L, 1L, 0L, null, null)
 
-        dropTable()
-        createTable()
+        dropTable(table)
+        createTable(queryTemplate, table)
 
         // insert rows
-        writeFunc(List(row1, row2, row3, row4, row5, row6), schema, None)
+        writeFunc(List(row1, row2, row3, row4, row5, row6), schema, table, None)
         compareTiDBSelectWithJDBC(
           Seq(readRow1, readRow2, readRow3, readRow4, readRow5, readRow6),
-          readSchema
+          readSchema,
+          table
         )
     }
   }
@@ -78,6 +79,7 @@ class ToSignedSuite extends BaseDataSourceTest("test_data_type_convert_to_signed
   test("Test Convert from java.lang.Byte to SIGNED") {
     // success
     // java.lang.Byte -> {TINYINT SMALLINT MEDIUMINT INT BIGINT} SIGNED BOOLEAN
+    val table = tableTemplate.format("byte")
     compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val zero: java.lang.Byte = java.lang.Byte.valueOf("0")
@@ -106,18 +108,19 @@ class ToSignedSuite extends BaseDataSourceTest("test_data_type_convert_to_signed
           )
         )
 
-        dropTable()
-        createTable()
+        dropTable(table)
+        createTable(queryTemplate, table)
 
         // insert rows
-        writeFunc(List(row1, row2, row3, row4, row5, row6), schema, None)
-        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
+        writeFunc(List(row1, row2, row3, row4, row5, row6), schema, table, None)
+        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema, table)
     }
   }
 
   test("Test Convert from java.lang.Short to SIGNED") {
     // success
     // java.lang.Short -> {TINYINT SMALLINT MEDIUMINT INT BIGINT} SIGNED BOOLEAN
+    val table = tableTemplate.format("short")
     compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val one: java.lang.Short = java.lang.Short.valueOf("1")
@@ -149,18 +152,19 @@ class ToSignedSuite extends BaseDataSourceTest("test_data_type_convert_to_signed
           )
         )
 
-        dropTable()
-        createTable()
+        dropTable(table)
+        createTable(queryTemplate, table)
 
         // insert rows
-        writeFunc(List(row1, row2, row3, row4, row5, row6), schema, None)
-        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
+        writeFunc(List(row1, row2, row3, row4, row5, row6), schema, table, None)
+        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema, table)
     }
   }
 
   test("Test Convert from java.lang.Integer to SIGNED") {
     // success
     // java.lang.Integer -> {TINYINT SMALLINT MEDIUMINT INT BIGINT} SIGNED BOOLEAN
+    val table = tableTemplate.format("int")
     compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val one: java.lang.Integer = java.lang.Integer.valueOf("1")
@@ -194,18 +198,19 @@ class ToSignedSuite extends BaseDataSourceTest("test_data_type_convert_to_signed
           )
         )
 
-        dropTable()
-        createTable()
+        dropTable(table)
+        createTable(queryTemplate, table)
 
         // insert rows
-        writeFunc(List(row1, row2, row3, row4, row5, row6), schema, None)
-        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
+        writeFunc(List(row1, row2, row3, row4, row5, row6), schema, table, None)
+        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema, table)
     }
   }
 
   test("Test Convert from java.lang.Long to SIGNED") {
     // success
     // java.lang.Long -> {TINYINT SMALLINT MEDIUMINT INT BIGINT} SIGNED BOOLEAN
+    val table = tableTemplate.format("long")
     compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val one: java.lang.Long = java.lang.Long.valueOf("1")
@@ -241,18 +246,19 @@ class ToSignedSuite extends BaseDataSourceTest("test_data_type_convert_to_signed
           )
         )
 
-        dropTable()
-        createTable()
+        dropTable(table)
+        createTable(queryTemplate, table)
 
         // insert rows
-        writeFunc(List(row1, row2, row3, row4, row5, row6), schema, None)
-        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
+        writeFunc(List(row1, row2, row3, row4, row5, row6), schema, table, None)
+        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema, table)
     }
   }
 
   test("Test Convert from java.lang.Float to SIGNED") {
     // success
     // java.lang.Float -> {TINYINT SMALLINT MEDIUMINT INT BIGINT} SIGNED BOOLEAN
+    val table = tableTemplate.format("float")
     compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val one: java.lang.Float = java.lang.Float.valueOf("1")
@@ -289,18 +295,19 @@ class ToSignedSuite extends BaseDataSourceTest("test_data_type_convert_to_signed
           )
         )
 
-        dropTable()
-        createTable()
+        dropTable(table)
+        createTable(queryTemplate, table)
 
         // insert rows
-        writeFunc(List(row1, row2, row3, row4, row5, row6), schema, None)
-        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
+        writeFunc(List(row1, row2, row3, row4, row5, row6), schema, table, None)
+        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema, table)
     }
   }
 
   test("Test Convert from java.lang.Double to SIGNED") {
     // success
     // java.lang.Double -> {TINYINT SMALLINT MEDIUMINT INT BIGINT} SIGNED BOOLEAN
+    val table = tableTemplate.format("double")
     compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val one: java.lang.Double = java.lang.Double.valueOf("1")
@@ -334,18 +341,19 @@ class ToSignedSuite extends BaseDataSourceTest("test_data_type_convert_to_signed
           )
         )
 
-        dropTable()
-        createTable()
+        dropTable(table)
+        createTable(queryTemplate, table)
 
         // insert rows
-        writeFunc(List(row1, row2, row3, row4, row5, row6), schema, None)
-        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
+        writeFunc(List(row1, row2, row3, row4, row5, row6), schema, table, None)
+        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema, table)
     }
   }
 
   test("Test Convert from String to SIGNED") {
     // success
     // String -> {TINYINT SMALLINT MEDIUMINT INT BIGINT} SIGNED BOOLEAN
+    val table = tableTemplate.format("str")
     compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val a: java.lang.String = "11"
@@ -396,14 +404,15 @@ class ToSignedSuite extends BaseDataSourceTest("test_data_type_convert_to_signed
         val readRow5 = Row(5, bRead, bRead, bRead, aRead, aRead, 0L)
         val readRow6 = Row(6, bRead, bRead, null, aRead, null, null)
 
-        dropTable()
-        createTable()
+        dropTable(table)
+        createTable(queryTemplate, table)
 
         // insert rows
-        writeFunc(List(row1, row2, row3, row4, row5, row6), schema, None)
+        writeFunc(List(row1, row2, row3, row4, row5, row6), schema, table, None)
         compareTiDBSelectWithJDBC(
           Seq(readRow1, readRow2, readRow3, readRow4, readRow5, readRow6),
-          readSchema
+          readSchema,
+          table
         )
     }
   }
@@ -416,11 +425,4 @@ class ToSignedSuite extends BaseDataSourceTest("test_data_type_convert_to_signed
   // scala.collection.Seq
   // scala.collection.Map
   // org.apache.spark.sql.Row
-
-  override def afterAll(): Unit =
-    try {
-      dropTable()
-    } finally {
-      super.afterAll()
-    }
 }

--- a/core/src/test/scala/com/pingcap/tispark/convert/ToStringSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/convert/ToStringSuite.scala
@@ -13,7 +13,7 @@ import org.apache.spark.sql.types.{StructField, _}
  * 5. MEDIUMTEXT
  * 6. LONGTEXT
  */
-class ToStringSuite extends BaseDataSourceTest("test_data_type_convert_to_string") {
+class ToStringSuite extends BaseDataSourceTest {
 
   private val readSchema = StructType(
     List(
@@ -27,14 +27,14 @@ class ToStringSuite extends BaseDataSourceTest("test_data_type_convert_to_string
     )
   )
 
-  private def createTable(): Unit =
-    jdbcUpdate(
-      s"create table $dbtable(i INT, c1 CHAR(255), c2 VARCHAR(255), c3 TINYTEXT, c4 TEXT, c5 MEDIUMTEXT, c6 LONGTEXT)"
-    )
+  val queryTemplate =
+    "create table `%s`.`%s`(i INT, c1 CHAR(255), c2 VARCHAR(255), c3 TINYTEXT, c4 TEXT, c5 MEDIUMTEXT, c6 LONGTEXT)"
+  val tableTemplate = "test_%s_to_str"
 
   test("Test Convert from java.lang.Boolean to STRING") {
     // success
     // java.lang.Boolean -> STRING
+    val table = tableTemplate.format("boolean")
     compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val a: java.lang.Boolean = true
@@ -67,18 +67,22 @@ class ToStringSuite extends BaseDataSourceTest("test_data_type_convert_to_string
         val readRow4 = Row(4, readA, readA, readA, readA, readA, readA)
         val readRow5 = Row(5, readB, readB, readB, readB, readB, readB)
 
-        dropTable()
-        createTable()
-
+        dropTable(table)
+        createTable(queryTemplate, table)
         // insert rows
-        writeFunc(List(row1, row2, row3, row4, row5), schema, None)
-        compareTiDBSelectWithJDBC(Seq(readRow1, readRow2, readRow3, readRow4, readRow5), readSchema)
+        writeFunc(List(row1, row2, row3, row4, row5), schema, table, None)
+        compareTiDBSelectWithJDBC(
+          Seq(readRow1, readRow2, readRow3, readRow4, readRow5),
+          readSchema,
+          table
+        )
     }
   }
 
   test("Test Convert from java.lang.Byte to STRING") {
     // success
     // java.lang.Byte -> STRING
+    val table = tableTemplate.format("byte")
     compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val a: java.lang.Byte = java.lang.Byte.valueOf("11")
@@ -115,18 +119,23 @@ class ToStringSuite extends BaseDataSourceTest("test_data_type_convert_to_string
         val readRow4 = Row(4, readC, readD, readC, readD, readC, readD)
         val readRow5 = Row(5, readD, readC, readD, readC, readD, readC)
 
-        dropTable()
-        createTable()
+        dropTable(table)
+        createTable(queryTemplate, table)
 
         // insert rows
-        writeFunc(List(row1, row2, row3, row4, row5), schema, None)
-        compareTiDBSelectWithJDBC(Seq(readRow1, readRow2, readRow3, readRow4, readRow5), readSchema)
+        writeFunc(List(row1, row2, row3, row4, row5), schema, table, None)
+        compareTiDBSelectWithJDBC(
+          Seq(readRow1, readRow2, readRow3, readRow4, readRow5),
+          readSchema,
+          table
+        )
     }
   }
 
   test("Test Convert from java.lang.Short to STRING") {
     // success
     // java.lang.Short -> STRING
+    val table = tableTemplate.format("short")
     compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val a: java.lang.Short = java.lang.Short.valueOf("11")
@@ -163,18 +172,23 @@ class ToStringSuite extends BaseDataSourceTest("test_data_type_convert_to_string
         val readRow4 = Row(4, readC, readD, readC, readD, readC, readD)
         val readRow5 = Row(5, readD, readC, readD, readC, readD, readC)
 
-        dropTable()
-        createTable()
+        dropTable(table)
+        createTable(queryTemplate, table)
 
         // insert rows
-        writeFunc(List(row1, row2, row3, row4, row5), schema, None)
-        compareTiDBSelectWithJDBC(Seq(readRow1, readRow2, readRow3, readRow4, readRow5), readSchema)
+        writeFunc(List(row1, row2, row3, row4, row5), schema, table, None)
+        compareTiDBSelectWithJDBC(
+          Seq(readRow1, readRow2, readRow3, readRow4, readRow5),
+          readSchema,
+          table
+        )
     }
   }
 
   test("Test Convert from java.lang.Integer to STRING") {
     // success
     // java.lang.Integer -> STRING
+    val table = tableTemplate.format("int")
     compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val a: java.lang.Integer = java.lang.Integer.valueOf("11")
@@ -211,18 +225,23 @@ class ToStringSuite extends BaseDataSourceTest("test_data_type_convert_to_string
         val readRow4 = Row(4, readC, readD, readC, readD, readC, readD)
         val readRow5 = Row(5, readD, readC, readD, readC, readD, readC)
 
-        dropTable()
-        createTable()
+        dropTable(table)
+        createTable(queryTemplate, table)
 
         // insert rows
-        writeFunc(List(row1, row2, row3, row4, row5), schema, None)
-        compareTiDBSelectWithJDBC(Seq(readRow1, readRow2, readRow3, readRow4, readRow5), readSchema)
+        writeFunc(List(row1, row2, row3, row4, row5), schema, table, None)
+        compareTiDBSelectWithJDBC(
+          Seq(readRow1, readRow2, readRow3, readRow4, readRow5),
+          readSchema,
+          table
+        )
     }
   }
 
   test("Test Convert from java.lang.Long to STRING") {
     // success
     // java.lang.Long -> STRING
+    val table = tableTemplate.format("long")
     compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val a: java.lang.Long = java.lang.Long.valueOf("11")
@@ -259,12 +278,15 @@ class ToStringSuite extends BaseDataSourceTest("test_data_type_convert_to_string
         val readRow4 = Row(4, readC, readD, readC, readD, readC, readD)
         val readRow5 = Row(5, readD, readC, readD, readC, readD, readC)
 
-        dropTable()
-        createTable()
-
+        dropTable(table)
+        createTable(queryTemplate, table)
         // insert rows
-        writeFunc(List(row1, row2, row3, row4, row5), schema, None)
-        compareTiDBSelectWithJDBC(Seq(readRow1, readRow2, readRow3, readRow4, readRow5), readSchema)
+        writeFunc(List(row1, row2, row3, row4, row5), schema, table, None)
+        compareTiDBSelectWithJDBC(
+          Seq(readRow1, readRow2, readRow3, readRow4, readRow5),
+          readSchema,
+          table
+        )
     }
   }
 
@@ -273,6 +295,7 @@ class ToStringSuite extends BaseDataSourceTest("test_data_type_convert_to_string
   ignore("Test Convert from java.lang.Float to STRING") {
     // success
     // java.lang.Float -> STRING
+    val table = tableTemplate.format("float")
     compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val a: java.lang.Float = java.lang.Float.valueOf("1.1")
@@ -309,16 +332,17 @@ class ToStringSuite extends BaseDataSourceTest("test_data_type_convert_to_string
         val readRow4 = Row(4, readC, readD, readC, readD, readC, readD)
         val readRow5 = Row(5, readD, readC, readD, readC, readD, readC)
 
-        dropTable()
-        createTable()
+        dropTable(table)
+        createTable(queryTemplate, table)
 
         // insert rows
         // TODO: TiSpark transforms FLOAT to Double, which will cause precision problem,
         //  so we just set skipTiDBAndExpectedAnswerCheck = true
-        writeFunc(List(row1, row2, row3, row4, row5), schema, None)
+        writeFunc(List(row1, row2, row3, row4, row5), schema, table, None)
         compareTiDBSelectWithJDBC(
           Seq(readRow1, readRow2, readRow3, readRow4, readRow5),
           readSchema,
+          table,
           skipTiDBAndExpectedAnswerCheck = true
         )
     }
@@ -328,6 +352,7 @@ class ToStringSuite extends BaseDataSourceTest("test_data_type_convert_to_string
   ignore("Test Convert from java.lang.Double to STRING") {
     // success
     // java.lang.Double -> STRING
+    val table = tableTemplate.format("double")
     compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val a: java.lang.Double = java.lang.Double.valueOf("1.1")
@@ -353,18 +378,19 @@ class ToStringSuite extends BaseDataSourceTest("test_data_type_convert_to_string
           )
         )
 
-        dropTable()
-        createTable()
+        dropTable(table)
+        createTable(queryTemplate, table)
 
         // insert rows
-        writeFunc(List(row1, row2, row3, row4, row5), schema, None)
-        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5), schema)
+        writeFunc(List(row1, row2, row3, row4, row5), schema, table, None)
+        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5), schema, table)
     }
   }
 
   test("Test Convert from String to STRING") {
     // success
     // java.lang.String -> STRING
+    val table = tableTemplate.format("str")
     compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val a: java.lang.String = new java.lang.String("1.1")
@@ -390,18 +416,19 @@ class ToStringSuite extends BaseDataSourceTest("test_data_type_convert_to_string
           )
         )
 
-        dropTable()
-        createTable()
+        dropTable(table)
+        createTable(queryTemplate, table)
 
         // insert rows
-        writeFunc(List(row1, row2, row3, row4, row5), schema, None)
-        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5), schema)
+        writeFunc(List(row1, row2, row3, row4, row5), schema, table, None)
+        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5), schema, table)
     }
   }
 
   test("Test Convert from java.math.BigDecimal to STRING") {
     // failure
     // java.math.BigDecimal -> STRING
+    val table = tableTemplate.format("bigdecimal")
     compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val a: java.math.BigDecimal = java.math.BigDecimal.ONE
@@ -438,18 +465,23 @@ class ToStringSuite extends BaseDataSourceTest("test_data_type_convert_to_string
         val readRow4 = Row(4, readC, readD, readC, readD, readC, readD)
         val readRow5 = Row(5, readD, readC, readD, readC, readD, readC)
 
-        dropTable()
-        createTable()
+        dropTable(table)
+        createTable(queryTemplate, table)
 
         // insert rows
-        writeFunc(List(row1, row2, row3, row4, row5), schema, None)
-        compareTiDBSelectWithJDBC(Seq(readRow1, readRow2, readRow3, readRow4, readRow5), readSchema)
+        writeFunc(List(row1, row2, row3, row4, row5), schema, table, None)
+        compareTiDBSelectWithJDBC(
+          Seq(readRow1, readRow2, readRow3, readRow4, readRow5),
+          readSchema,
+          table
+        )
     }
   }
 
   test("Test Convert from java.sql.Date to STRING") {
     // failure
     // java.sql.Date -> STRING
+    val table = tableTemplate.format("date")
     compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val a: java.sql.Date = java.sql.Date.valueOf("2019-01-01")
@@ -486,18 +518,23 @@ class ToStringSuite extends BaseDataSourceTest("test_data_type_convert_to_string
         val readRow4 = Row(4, readC, readD, readC, readD, readC, readD)
         val readRow5 = Row(5, readD, readC, readD, readC, readD, readC)
 
-        dropTable()
-        createTable()
+        dropTable(table)
+        createTable(queryTemplate, table)
 
         // insert rows
-        writeFunc(List(row1, row2, row3, row4, row5), schema, None)
-        compareTiDBSelectWithJDBC(Seq(readRow1, readRow2, readRow3, readRow4, readRow5), readSchema)
+        writeFunc(List(row1, row2, row3, row4, row5), schema, table, None)
+        compareTiDBSelectWithJDBC(
+          Seq(readRow1, readRow2, readRow3, readRow4, readRow5),
+          readSchema,
+          table
+        )
     }
   }
 
   test("Test Convert from java.sql.Timestamp to STRING") {
     // success
     // java.sql.Timestamp -> STRING
+    val table = tableTemplate.format("ts")
     compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val a: java.sql.Timestamp = java.sql.Timestamp.valueOf("2019-01-01 01:01:01")
@@ -534,12 +571,16 @@ class ToStringSuite extends BaseDataSourceTest("test_data_type_convert_to_string
         val readRow4 = Row(4, readC, readD, readC, readD, readC, readD)
         val readRow5 = Row(5, readD, readC, readD, readC, readD, readC)
 
-        dropTable()
-        createTable()
+        dropTable(table)
+        createTable(queryTemplate, table)
 
         // insert rows
-        writeFunc(List(row1, row2, row3, row4, row5), schema, None)
-        compareTiDBSelectWithJDBC(Seq(readRow1, readRow2, readRow3, readRow4, readRow5), readSchema)
+        writeFunc(List(row1, row2, row3, row4, row5), schema, table, None)
+        compareTiDBSelectWithJDBC(
+          Seq(readRow1, readRow2, readRow3, readRow4, readRow5),
+          readSchema,
+          table
+        )
     }
   }
 
@@ -548,11 +589,4 @@ class ToStringSuite extends BaseDataSourceTest("test_data_type_convert_to_string
   // scala.collection.Seq
   // scala.collection.Map
   // org.apache.spark.sql.Row
-
-  override def afterAll(): Unit =
-    try {
-      dropTable()
-    } finally {
-      super.afterAll()
-    }
 }

--- a/core/src/test/scala/com/pingcap/tispark/convert/ToUnsignedSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/convert/ToUnsignedSuite.scala
@@ -1,8 +1,5 @@
 package com.pingcap.tispark.convert
 
-import com.pingcap.tikv.TiSession
-import com.pingcap.tikv.allocator.RowIDAllocator
-import com.pingcap.tispark.TiDBUtils
 import com.pingcap.tispark.datasource.BaseDataSourceTest
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types._
@@ -15,7 +12,8 @@ import org.apache.spark.sql.types._
  * 4. INT UNSIGNED
  * 5. BIGINT UNSIGNED
  */
-class ToUnsignedSuite extends BaseDataSourceTest("test_data_type_convert_to_unsigned") {
+class ToUnsignedSuite extends BaseDataSourceTest {
+  private val tableTemplate = "test_%s_to_unsigned"
   private val readSchema = StructType(
     List(
       StructField("i", IntegerType),
@@ -27,19 +25,17 @@ class ToUnsignedSuite extends BaseDataSourceTest("test_data_type_convert_to_unsi
     )
   )
 
-  private def createTable(): Unit =
-    jdbcUpdate(
-      s"""create table $dbtable(i INT,
-         | c1 TINYINT UNSIGNED,
-         | c2 SMALLINT UNSIGNED,
-         | c3 MEDIUMINT UNSIGNED,
-         | c4 INT UNSIGNED,
-         | c5 BIGINT UNSIGNED)""".stripMargin
-    )
+  val queryTemplate: String = s"""create table `%s`.`%s`(i INT,
+                                 | c1 TINYINT UNSIGNED,
+                                 | c2 SMALLINT UNSIGNED,
+                                 | c3 MEDIUMINT UNSIGNED,
+                                 | c4 INT UNSIGNED,
+                                 | c5 BIGINT UNSIGNED)""".stripMargin
 
   test("Test Convert from java.lang.Boolean to UNSIGNED") {
     // success
     // java.lang.Boolean -> {TINYINT SMALLINT MEDIUMINT INT BIGINT} UNSIGNED
+    val table = tableTemplate.format("boolean")
     compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val row1 = Row(1, null, null, null, null, null)
@@ -67,14 +63,15 @@ class ToUnsignedSuite extends BaseDataSourceTest("test_data_type_convert_to_unsi
         val readRow5 = Row(5, 1L, 0L, 0L, null, 1L)
         val readRow6 = Row(6, 1L, 0L, 1L, 0L, null)
 
-        dropTable()
-        createTable()
+        dropTable(table)
+        createTable(queryTemplate, table)
 
         // insert rows
-        writeFunc(List(row1, row2, row3, row4, row5, row6), schema, None)
+        writeFunc(List(row1, row2, row3, row4, row5, row6), schema, table, None)
         compareTiDBSelectWithJDBC(
           Seq(readRow1, readRow2, readRow3, readRow4, readRow5, readRow6),
-          readSchema
+          readSchema,
+          table
         )
     }
   }
@@ -82,6 +79,7 @@ class ToUnsignedSuite extends BaseDataSourceTest("test_data_type_convert_to_unsi
   test("Test Convert from java.lang.Byte to UNSIGNED") {
     // success
     // java.lang.Byte -> {TINYINT SMALLINT MEDIUMINT INT BIGINT} UNSIGNED
+    val table = tableTemplate.format("byte")
     compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val a: java.lang.Byte = java.lang.Byte.valueOf("11")
@@ -107,18 +105,20 @@ class ToUnsignedSuite extends BaseDataSourceTest("test_data_type_convert_to_unsi
           )
         )
 
-        dropTable()
-        createTable()
+        dropTable(table)
+        createTable(queryTemplate, table)
 
         // insert rows
-        writeFunc(List(row1, row2, row3, row4, row5, row6), schema, None)
-        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
+        writeFunc(List(row1, row2, row3, row4, row5, row6), schema, table, None)
+        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema, table)
     }
   }
 
   test("Test Convert from java.lang.Short to UNSIGNED") {
     // success
     // java.lang.Short -> {TINYINT SMALLINT MEDIUMINT INT BIGINT} UNSIGNED
+
+    val table = tableTemplate.format("short")
     compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val a: java.lang.Short = java.lang.Short.valueOf("11")
@@ -146,18 +146,19 @@ class ToUnsignedSuite extends BaseDataSourceTest("test_data_type_convert_to_unsi
           )
         )
 
-        dropTable()
-        createTable()
+        dropTable(table)
+        createTable(queryTemplate, table)
 
         // insert rows
-        writeFunc(List(row1, row2, row3, row4, row5, row6), schema, None)
-        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
+        writeFunc(List(row1, row2, row3, row4, row5, row6), schema, table, None)
+        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema, table)
     }
   }
 
   test("Test Convert from java.lang.Integer to UNSIGNED") {
     // success
     // java.lang.Integer -> {TINYINT SMALLINT MEDIUMINT INT BIGINT} UNSIGNED
+    val table = tableTemplate.format("int")
     compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val a: java.lang.Integer = java.lang.Integer.valueOf("11")
@@ -186,18 +187,19 @@ class ToUnsignedSuite extends BaseDataSourceTest("test_data_type_convert_to_unsi
           )
         )
 
-        dropTable()
-        createTable()
+        dropTable(table)
+        createTable(queryTemplate, table)
 
         // insert rows
-        writeFunc(List(row1, row2, row3, row4, row5, row6), schema, None)
-        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
+        writeFunc(List(row1, row2, row3, row4, row5, row6), schema, table, None)
+        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema, table)
     }
   }
 
   test("Test Convert from java.lang.Long to UNSIGNED") {
     // success
     // java.lang.Long -> {TINYINT SMALLINT MEDIUMINT INT BIGINT} UNSIGNED
+    val table = tableTemplate.format("long")
     compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val a: java.lang.Long = java.lang.Long.valueOf("11")
@@ -227,18 +229,18 @@ class ToUnsignedSuite extends BaseDataSourceTest("test_data_type_convert_to_unsi
           )
         )
 
-        dropTable()
-        createTable()
-
+        dropTable(table)
+        createTable(queryTemplate, table)
         // insert rows
-        writeFunc(List(row1, row2, row3, row4, row5, row6), schema, None)
-        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
+        writeFunc(List(row1, row2, row3, row4, row5, row6), schema, table, None)
+        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema, table)
     }
   }
 
   test("Test Convert from java.lang.Float to UNSIGNED") {
     // success
     // java.lang.Float -> {TINYINT SMALLINT MEDIUMINT INT BIGINT} UNSIGNED
+    val table = tableTemplate.format("float")
     compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val a: java.lang.Float = java.lang.Float.valueOf("11.1")
@@ -283,14 +285,15 @@ class ToUnsignedSuite extends BaseDataSourceTest("test_data_type_convert_to_unsi
         val readRow5 = Row(5, readB, readB, readB, readA, readA)
         val readRow6 = Row(6, readB, readB, null, readA, null)
 
-        dropTable()
-        createTable()
+        dropTable(table)
+        createTable(queryTemplate, table)
 
         // insert rows
-        writeFunc(List(row1, row2, row3, row4, row5, row6), schema, None)
+        writeFunc(List(row1, row2, row3, row4, row5, row6), schema, table, None)
         compareTiDBSelectWithJDBC(
           Seq(readRow1, readRow2, readRow3, readRow4, readRow5, readRow6),
-          readSchema
+          readSchema,
+          table
         )
     }
   }
@@ -298,6 +301,7 @@ class ToUnsignedSuite extends BaseDataSourceTest("test_data_type_convert_to_unsi
   test("Test Convert from java.lang.Double to UNSIGNED") {
     // success
     // java.lang.Double -> {TINYINT SMALLINT MEDIUMINT INT BIGINT} UNSIGNED
+    val table = tableTemplate.format("double")
     compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val a: java.lang.Double = java.lang.Double.valueOf("11.1")
@@ -341,14 +345,15 @@ class ToUnsignedSuite extends BaseDataSourceTest("test_data_type_convert_to_unsi
         val readRow5 = Row(5, readB, readB, readB, readA, readA)
         val readRow6 = Row(6, readB, readB, null, readA, null)
 
-        dropTable()
-        createTable()
+        dropTable(table)
+        createTable(queryTemplate, table)
 
         // insert rows
-        writeFunc(List(row1, row2, row3, row4, row5, row6), schema, None)
+        writeFunc(List(row1, row2, row3, row4, row5, row6), schema, table, None)
         compareTiDBSelectWithJDBC(
           Seq(readRow1, readRow2, readRow3, readRow4, readRow5, readRow6),
-          readSchema
+          readSchema,
+          table
         )
     }
   }
@@ -356,6 +361,7 @@ class ToUnsignedSuite extends BaseDataSourceTest("test_data_type_convert_to_unsi
   test("Test Convert from String to UNSIGNED") {
     // success
     // String -> {TINYINT SMALLINT MEDIUMINT INT BIGINT} UNSIGNED
+    val table = tableTemplate.format("str")
     compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
         val a: String = "11"
@@ -399,14 +405,15 @@ class ToUnsignedSuite extends BaseDataSourceTest("test_data_type_convert_to_unsi
         val readRow5 = Row(5, readB, readB, readB, readA, readA)
         val readRow6 = Row(6, readB, readB, null, readA, null)
 
-        dropTable()
-        createTable()
+        dropTable(table)
+        createTable(queryTemplate, table)
 
         // insert rows
-        writeFunc(List(row1, row2, row3, row4, row5, row6), schema, None)
+        writeFunc(List(row1, row2, row3, row4, row5, row6), schema, table, None)
         compareTiDBSelectWithJDBC(
           Seq(readRow1, readRow2, readRow3, readRow4, readRow5, readRow6),
-          readSchema
+          readSchema,
+          table
         )
     }
   }
@@ -419,11 +426,4 @@ class ToUnsignedSuite extends BaseDataSourceTest("test_data_type_convert_to_unsi
   // scala.collection.Seq
   // scala.collection.Map
   // org.apache.spark.sql.Row
-
-  override def afterAll(): Unit =
-    try {
-      dropTable()
-    } finally {
-      super.afterAll()
-    }
 }

--- a/core/src/test/scala/com/pingcap/tispark/datasource/AddingIndexInsertSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/AddingIndexInsertSuite.scala
@@ -5,7 +5,7 @@ import org.apache.spark.sql.Row
 import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
 
 // TODO: once exception message is stable, we need also check the exception's message.
-class AddingIndexInsertSuite extends BaseDataSourceTest("adding_index_insert") {
+class AddingIndexInsertSuite extends BaseDataSourceTest {
   private val row1 = Row(1, 1, "Hello")
   private val row2 = Row(2, 2, "TiDB")
   private val row3 = Row(3, 3, "Spark")
@@ -21,99 +21,97 @@ class AddingIndexInsertSuite extends BaseDataSourceTest("adding_index_insert") {
   )
 
   test("test column type can be truncated") {
-    dropTable()
+    val table = "test_col_tp"
+    dropTable(table)
     jdbcUpdate(
-      s"create table $dbtable(pk int, i int, s varchar(128), unique index(s(2)))"
+      s"create table `$database`.`$table`(pk int, i int, s varchar(128), unique index(s(2)))"
     )
     jdbcUpdate(
-      s"insert into $dbtable values(1, 1, 'Hello')"
+      s"insert into `$database`.`$table` values(1, 1, 'Hello')"
     )
     // insert row2 row3
-    tidbWrite(List(row2, row3), schema)
-    testTiDBSelect(Seq(row1, row2, row3))
+    tidbWriteWithTable(List(row2, row3), schema, table)
+    testTiDBSelectWithTable(Seq(row1, row2, row3), tableName = table)
 
     intercept[TiBatchWriteException] {
       // insert row2 row4
-      tidbWrite(List(row2, row4), schema)
+      tidbWriteWithTable(List(row2, row4), schema, table)
     }
   }
 
   test("no pk, no unique index case") {
-    dropTable()
+    val table = "no_pk_no_idx"
+    dropTable(table)
     jdbcUpdate(
-      s"create table $dbtable(pk int, i int, s varchar(128), index(i))"
+      s"create table `$database`.`$table`(pk int, i int, s varchar(128), index(i))"
     )
     jdbcUpdate(
-      s"insert into $dbtable values(1, 1, 'Hello')"
+      s"insert into `$database`.`$table` values(1, 1, 'Hello')"
     )
     // insert row2 row3
-    tidbWrite(List(row2, row3), schema)
-    testTiDBSelect(Seq(row1, row2, row3))
+    tidbWriteWithTable(List(row2, row3), schema, table)
+    testTiDBSelectWithTable(Seq(row1, row2, row3), tableName = table)
 
-    tidbWrite(List(row2, row4), schema)
-    testTiDBSelect(Seq(row1, row2, row2, row3, row4))
+    tidbWriteWithTable(List(row2, row4), schema, table)
+    testTiDBSelectWithTable(Seq(row1, row2, row2, row3, row4), tableName = table)
 
-    tidbWrite(List(row4, row4), schema)
-    testTiDBSelect(Seq(row1, row2, row2, row3, row4, row4, row4))
+    tidbWriteWithTable(List(row4, row4), schema, table)
+    testTiDBSelectWithTable(Seq(row1, row2, row2, row3, row4, row4, row4), tableName = table)
   }
 
   test("pk is not handle adding unique index") {
-    dropTable()
+    val table = "pk_is_not_handle"
+    dropTable(table)
     jdbcUpdate(
-      s"create table $dbtable(pk int, i int, s varchar(128), unique index(i), primary key(s))"
+      s"create table `$database`.`$table`(pk int, i int, s varchar(128), unique index(i), primary key(s))"
     )
     jdbcUpdate(
-      s"insert into $dbtable values(1, 1, 'Hello')"
+      s"insert into `$database`.`$table` values(1, 1, 'Hello')"
     )
     // insert row2 row3
-    tidbWrite(List(row2, row3), schema)
-    testTiDBSelect(Seq(row1, row2, row3))
+    tidbWriteWithTable(List(row2, row3), schema, table)
+    testTiDBSelectWithTable(Seq(row1, row2, row3), tableName = table)
 
     intercept[TiBatchWriteException] {
       // insert row2 row4
-      tidbWrite(List(row2, row4), schema)
+      tidbWriteWithTable(List(row2, row4), schema, table)
     }
   }
 
   test("pk is handle adding unique index") {
-    dropTable()
+    val table = "pk_is_handle"
+    dropTable(table)
     jdbcUpdate(
-      s"create table $dbtable(pk int, i int, s varchar(128), unique index(i), primary key(pk))"
+      s"create table `$database`.`$table`(pk int, i int, s varchar(128), unique index(i), primary key(pk))"
     )
     jdbcUpdate(
-      s"insert into $dbtable values(1, 1, 'Hello')"
+      s"insert into `$database`.`$table` values(1, 1, 'Hello')"
     )
     // insert row2 row3
-    tidbWrite(List(row2, row3), schema)
-    testTiDBSelect(Seq(row1, row2, row3))
+    tidbWriteWithTable(List(row2, row3), schema, table)
+    testTiDBSelectWithTable(Seq(row1, row2, row3), tableName = table)
 
     intercept[TiBatchWriteException] {
       // insert row2 row4
-      tidbWrite(List(row2, row4), schema)
+      tidbWriteWithTable(List(row2, row4), schema, table)
     }
   }
 
   test("Test no pk adding unique index") {
-    dropTable()
-    jdbcUpdate(s"create table $dbtable(pk int, i int, s varchar(128), unique index(i))")
+    val table = "no_pk"
+    dropTable(table)
+    jdbcUpdate(s"create table `$database`.`$table`(pk int, i int, s varchar(128), unique index(i))")
     jdbcUpdate(
-      s"insert into $dbtable values(1, 1, 'Hello')"
+      s"insert into `$database`.`$table` values(1, 1, 'Hello')"
     )
 
     // insert row2 row3
-    tidbWrite(List(row2, row3), schema)
-    testTiDBSelect(Seq(row1, row2, row3))
+    tidbWriteWithTable(List(row2, row3), schema, table)
+    testTiDBSelectWithTable(Seq(row1, row2, row3), tableName = table)
 
     intercept[TiBatchWriteException] {
       // insert row2 row4
-      tidbWrite(List(row2, row4), schema)
+      tidbWriteWithTable(List(row2, row4), schema, table)
     }
   }
-
-  override def afterAll(): Unit =
-    try {
-      dropTable()
-    } finally {
-      super.afterAll()
-    }
 }

--- a/core/src/test/scala/com/pingcap/tispark/datasource/BasicSQLSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/BasicSQLSuite.scala
@@ -5,19 +5,21 @@ import org.apache.spark.sql.Row
 
 import scala.util.Random
 
-class BasicSQLSuite extends BaseDataSourceTest("test_datasource_sql") {
+class BasicSQLSuite extends BaseDataSourceTest {
   private val row1 = Row(null, "Hello")
   private val row2 = Row(2, "TiDB")
   private val row3 = Row(3, "Spark")
   private val row4 = Row(4, null)
 
+  val table = "test_datasource_sql"
   override def beforeAll(): Unit = {
     super.beforeAll()
 
-    dropTable()
-    jdbcUpdate(s"create table $dbtable(i int, s varchar(128))")
+    dropTable(table)
+    createTable(s"create table `%s`.`%s`(i int, s varchar(128))", table)
     jdbcUpdate(
-      s"insert into $dbtable values(null, 'Hello'), (2, 'TiDB')"
+      s"insert into `%s`.`%s` values(null, 'Hello'), (2, 'TiDB')",
+      table
     )
   }
 
@@ -97,7 +99,7 @@ class BasicSQLSuite extends BaseDataSourceTest("test_datasource_sql") {
 
   override def afterAll(): Unit =
     try {
-      dropTable()
+      dropTable(table)
     } finally {
       super.afterAll()
     }

--- a/core/src/test/scala/com/pingcap/tispark/datasource/EdgeConditionSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/EdgeConditionSuite.scala
@@ -3,8 +3,7 @@ package com.pingcap.tispark.datasource
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types._
 
-class EdgeConditionSuite extends BaseDataSourceTest("test_datasource_edge_condition") {
-
+class EdgeConditionSuite extends BaseDataSourceTest {
   private val TEST_LARGE_DATA_SIZE = 102400
 
   private val TEST_LARGE_COLUMN_SIZE = 512
@@ -13,6 +12,7 @@ class EdgeConditionSuite extends BaseDataSourceTest("test_datasource_edge_condit
     super.beforeAll()
 
   test("Write to table with one column (primary key long type)") {
+    val table = "table_with_on_col_pk_is_long"
     val row1 = Row(1L)
     val row2 = Row(2L)
     val row3 = Row(3L)
@@ -24,19 +24,22 @@ class EdgeConditionSuite extends BaseDataSourceTest("test_datasource_edge_condit
       )
     )
 
-    dropTable()
+    dropTable(table)
 
-    jdbcUpdate(
-      s"create table $dbtable(i int, primary key (i))"
+    createTable(
+      "create table `%s`.`%s`(i int, primary key (i))",
+      table
     )
     jdbcUpdate(
-      s"insert into $dbtable values(1)"
+      "insert into `%s`.`%s` values(1)",
+      table
     )
-    tidbWrite(List(row2, row3, row4), schema)
-    testTiDBSelect(Seq(row1, row2, row3, row4))
+    tidbWriteWithTable(List(row2, row3, row4), schema, table)
+    testTiDBSelectWithTable(Seq(row1, row2, row3, row4), tableName = table)
   }
 
   test("Write to table with one column (primary key int type)") {
+    val table = "table_with_on_col_pk_is_int"
     val row1 = Row(1)
     val row2 = Row(2)
     val row3 = Row(3)
@@ -48,19 +51,22 @@ class EdgeConditionSuite extends BaseDataSourceTest("test_datasource_edge_condit
       )
     )
 
-    dropTable()
+    dropTable(table)
 
-    jdbcUpdate(
-      s"create table $dbtable(i int, primary key (i))"
+    createTable(
+      "create table `%s`.`%s`(i int, primary key (i))",
+      table
     )
     jdbcUpdate(
-      s"insert into $dbtable values(1)"
+      "insert into `%s`.`%s` values(1)",
+      table
     )
-    tidbWrite(List(row2, row3, row4), schema)
-    testTiDBSelect(Seq(row1, row2, row3, row4))
+    tidbWriteWithTable(List(row2, row3, row4), schema, table)
+    testTiDBSelectWithTable(Seq(row1, row2, row3, row4), tableName = table)
   }
 
   test("Write to table with one column (primary key + auto increase)") {
+    val table = "table_with_on_col_pk_and_auto"
     val row1 = Row(1L)
     val row2 = Row(2L)
     val row3 = Row(3L)
@@ -72,19 +78,22 @@ class EdgeConditionSuite extends BaseDataSourceTest("test_datasource_edge_condit
       )
     )
 
-    dropTable()
+    dropTable(table)
 
-    jdbcUpdate(
-      s"create table $dbtable(i int NOT NULL AUTO_INCREMENT, primary key (i))"
+    createTable(
+      "create table `%s`.`%s`(i int NOT NULL AUTO_INCREMENT, primary key (i))",
+      table
     )
     jdbcUpdate(
-      s"insert into $dbtable values(1)"
+      "insert into `%s`.`%s` values(1)",
+      table
     )
-    tidbWrite(List(row2, row3, row4), schema)
-    testTiDBSelect(Seq(row1, row2, row3, row4))
+    tidbWriteWithTable(List(row2, row3, row4), schema, table)
+    testTiDBSelectWithTable(Seq(row1, row2, row3, row4), tableName = table)
   }
 
   test("Write to table with one column (no primary key)") {
+    val table = "table_with_on_col_no_pk"
     val row1 = Row(null)
     val row2 = Row("Hello")
     val row3 = Row("Spark")
@@ -96,19 +105,22 @@ class EdgeConditionSuite extends BaseDataSourceTest("test_datasource_edge_condit
       )
     )
 
-    dropTable()
+    dropTable(table)
 
-    jdbcUpdate(
-      s"create table $dbtable(i varchar(128))"
+    createTable(
+      "create table `%s`.`%s`(i varchar(128))",
+      table
     )
     jdbcUpdate(
-      s"insert into $dbtable values('Hello')"
+      "insert into `%s`.`%s` values('Hello')",
+      table
     )
-    tidbWrite(List(row1, row3, row4), schema)
-    testTiDBSelect(Seq(row1, row2, row3, row4))
+    tidbWriteWithTable(List(row1, row3, row4), schema, table)
+    testTiDBSelectWithTable(Seq(row1, row2, row3, row4), tableName = table)
   }
 
   test("Write to table with many columns") {
+    val table = "table_with_many_cols"
     val types = ("int", LongType) :: ("varchar(128)", StringType) :: Nil
     val data1 = 1L :: "TiDB" :: Nil
     val data2 = 2L :: "Spark" :: Nil
@@ -138,17 +150,19 @@ class EdgeConditionSuite extends BaseDataSourceTest("test_datasource_edge_condit
       }
       .mkString(", ")
 
-    dropTable()
+    dropTable(table)
 
-    jdbcUpdate(
-      s"create table $dbtable($createTableSchemaStr)"
+    createTable(
+      s"create table `%s`.`%s`($createTableSchemaStr)",
+      table
     )
 
-    tidbWrite(List(row1, row2), schema)
-    testTiDBSelect(Seq(row1, row2), "c0")
+    tidbWriteWithTable(List(row1, row2), schema, table)
+    testTiDBSelectWithTable(Seq(row1, row2), "c0", tableName = table)
   }
 
   test("Write Empty data") {
+    val table = "write_empty_data"
     val row1 = Row(1L)
 
     val schema = StructType(
@@ -157,19 +171,22 @@ class EdgeConditionSuite extends BaseDataSourceTest("test_datasource_edge_condit
       )
     )
 
-    dropTable()
+    dropTable(table)
 
-    jdbcUpdate(
-      s"create table $dbtable(i int, primary key (i))"
+    createTable(
+      "create table `%s`.`%s`(i int, primary key (i))",
+      table
     )
     jdbcUpdate(
-      s"insert into $dbtable values(1)"
+      "insert into `%s`.`%s` values(1)",
+      table
     )
-    tidbWrite(List(), schema)
-    testTiDBSelect(Seq(row1))
+    tidbWriteWithTable(List(), schema, table)
+    testTiDBSelectWithTable(Seq(row1), tableName = table)
   }
 
   test("Write large amount of data") {
+    val table = "write_large_amount_data"
     var list: List[Row] = Nil
     for (i <- 0 until TEST_LARGE_DATA_SIZE) {
       list = Row(i.toLong) :: list
@@ -182,13 +199,14 @@ class EdgeConditionSuite extends BaseDataSourceTest("test_datasource_edge_condit
       )
     )
 
-    dropTable()
+    dropTable(table)
 
-    jdbcUpdate(
-      s"create table $dbtable(i int, primary key (i))"
+    createTable(
+      "create table `%s`.`%s`(i int, primary key (i))",
+      table
     )
-    tidbWrite(list, schema)
-    testTiDBSelect(list)
+    tidbWriteWithTable(list, schema, table)
+    testTiDBSelectWithTable(list, tableName = table)
 
     var list2: List[Row] = Nil
     for (i <- TEST_LARGE_DATA_SIZE until TEST_LARGE_DATA_SIZE * 2) {
@@ -196,14 +214,7 @@ class EdgeConditionSuite extends BaseDataSourceTest("test_datasource_edge_condit
     }
     list2 = list2.reverse
 
-    tidbWrite(list2, schema)
-    testTiDBSelect(list ::: list2)
+    tidbWriteWithTable(list2, schema, table)
+    testTiDBSelectWithTable(list ::: list2, tableName = table)
   }
-
-  override def afterAll(): Unit =
-    try {
-      dropTable()
-    } finally {
-      super.afterAll()
-    }
 }

--- a/core/src/test/scala/com/pingcap/tispark/datasource/ExceptionTestSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/ExceptionTestSuite.scala
@@ -4,12 +4,10 @@ import com.pingcap.tikv.exception.TiBatchWriteException
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types.{LongType, StringType, StructField, StructType}
 
-class ExceptionTestSuite extends BaseDataSourceTest("test_datasource_exception_test") {
-
-  override def beforeAll(): Unit =
-    super.beforeAll()
+class ExceptionTestSuite extends BaseDataSourceTest {
 
   test("Test write to table does not exist") {
+    val table = "write_to_table_does_not_exist"
     val row1 = Row(null, "Hello")
     val row2 = Row(2L, "TiDB")
 
@@ -20,15 +18,17 @@ class ExceptionTestSuite extends BaseDataSourceTest("test_datasource_exception_t
       )
     )
 
-    dropTable()
+    dropTable(table)
 
+    val errMsg = s"table `$database`.`$table` does not exists!"
     val caught = intercept[TiBatchWriteException] {
-      tidbWrite(List(row1, row2), schema)
+      tidbWriteWithTable(List(row1, row2), schema, table)
     }
-    assert(caught.getMessage.equals(s"table $dbtable does not exists!"))
+    assert(caught.getMessage.equals(errMsg))
   }
 
   test("Test column does not exist") {
+    val table = "col_not_exist"
     val row1 = Row(2L, 3L)
 
     val schema = StructType(
@@ -38,13 +38,13 @@ class ExceptionTestSuite extends BaseDataSourceTest("test_datasource_exception_t
       )
     )
 
-    dropTable()
+    dropTable(table)
 
-    jdbcUpdate(s"create table $dbtable(i int)")
+    createTable(s"create table `%s`.`%s`(i int)", table)
 
     {
       val caught = intercept[TiBatchWriteException] {
-        tidbWrite(List(row1), schema)
+        tidbWriteWithTable(List(row1), schema, table)
       }
       assert(
         caught.getMessage
@@ -56,6 +56,7 @@ class ExceptionTestSuite extends BaseDataSourceTest("test_datasource_exception_t
   }
 
   test("Missing insert column") {
+    val table = "missing_insert_column"
     val row1 = Row(2L, 3L)
 
     val schema = StructType(
@@ -65,13 +66,13 @@ class ExceptionTestSuite extends BaseDataSourceTest("test_datasource_exception_t
       )
     )
 
-    dropTable()
+    dropTable(table)
 
-    jdbcUpdate(s"create table $dbtable(i int, i2 int, i3 int)")
+    createTable("create table `%s`.`%s`(i int, i2 int, i3 int)", table)
 
     {
       val caught = intercept[TiBatchWriteException] {
-        tidbWrite(List(row1), schema)
+        tidbWriteWithTable(List(row1), schema, table)
       }
       assert(
         caught.getMessage
@@ -83,6 +84,7 @@ class ExceptionTestSuite extends BaseDataSourceTest("test_datasource_exception_t
   }
 
   test("Insert null value to Not Null Column") {
+    val table = "insert_null_to_not_null_col"
     val row1 = Row(null, 3L)
     val row2 = Row(4L, null)
 
@@ -93,13 +95,13 @@ class ExceptionTestSuite extends BaseDataSourceTest("test_datasource_exception_t
       )
     )
 
-    dropTable()
+    dropTable(table)
 
-    jdbcUpdate(s"create table $dbtable(i int, i2 int NOT NULL)")
+    createTable("create table `%s`.`%s`(i int, i2 int NOT NULL)", table)
 
     {
       val caught = intercept[TiBatchWriteException] {
-        tidbWrite(List(row1, row2), schema)
+        tidbWriteWithTable(List(row1, row2), schema, table)
       }
       assert(
         caught.getMessage
@@ -109,11 +111,4 @@ class ExceptionTestSuite extends BaseDataSourceTest("test_datasource_exception_t
       )
     }
   }
-
-  override def afterAll(): Unit =
-    try {
-      dropTable()
-    } finally {
-      super.afterAll()
-    }
 }

--- a/core/src/test/scala/com/pingcap/tispark/datasource/FilterPushdownSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/FilterPushdownSuite.scala
@@ -2,48 +2,43 @@ package com.pingcap.tispark.datasource
 
 import org.apache.spark.sql.Row
 
-class FilterPushdownSuite extends BaseDataSourceTest("test_datasource_filter_pushdown") {
+class FilterPushdownSuite extends BaseDataSourceTest {
   private val row1 = Row(null, "Hello")
   private val row2 = Row(2, "TiDB")
   private val row3 = Row(3, "Spark")
   private val row4 = Row(4, null)
+  val table = "test_datasource_filter_pushdown"
 
   override def beforeAll(): Unit = {
     super.beforeAll()
 
-    dropTable()
-    jdbcUpdate(s"create table $dbtable(i int, s varchar(128))")
+    dropTable(table)
+    createTable("create table `%s`.`%s`(i int, s varchar(128))", table)
     jdbcUpdate(
-      s"insert into $dbtable values(null, 'Hello'), (2, 'TiDB'), (3, 'Spark'), (4, null)"
+      "insert into `%s`.`%s` values(null, 'Hello'), (2, 'TiDB'), (3, 'Spark'), (4, null)",
+      table
     )
   }
 
   test("Test Simple Comparisons") {
-    testTiDBSelectFilter("s = 'Hello'", Seq(row1))
-    testTiDBSelectFilter("i > 2", Seq(row3, row4))
-    testTiDBSelectFilter("i < 3", Seq(row2))
+    testTiDBSelectFilter(table, "s = 'Hello'", Seq(row1))
+    testTiDBSelectFilter(table, "i > 2", Seq(row3, row4))
+    testTiDBSelectFilter(table, "i < 3", Seq(row2))
   }
 
   test("Test >= and <=") {
-    testTiDBSelectFilter("i >= 2", Seq(row2, row3, row4))
-    testTiDBSelectFilter("i <= 3", Seq(row2, row3))
+    testTiDBSelectFilter(table, "i >= 2", Seq(row2, row3, row4))
+    testTiDBSelectFilter(table, "i <= 3", Seq(row2, row3))
   }
 
   test("Test logical operators") {
-    testTiDBSelectFilter("i >= 2 AND i <= 3", Seq(row2, row3))
-    testTiDBSelectFilter("NOT i = 3", Seq(row2, row4))
-    testTiDBSelectFilter("NOT i = 3 OR i IS NULL", Seq(row1, row2, row4))
-    testTiDBSelectFilter("i IS NULL OR i > 2 AND s IS NOT NULL", Seq(row1, row3))
+    testTiDBSelectFilter(table, "i >= 2 AND i <= 3", Seq(row2, row3))
+    testTiDBSelectFilter(table, "NOT i = 3", Seq(row2, row4))
+    testTiDBSelectFilter(table, "NOT i = 3 OR i IS NULL", Seq(row1, row2, row4))
+    testTiDBSelectFilter(table, "i IS NULL OR i > 2 AND s IS NOT NULL", Seq(row1, row3))
   }
 
   test("Test IN") {
-    testTiDBSelectFilter("i IN ( 2, 3)", Seq(row2, row3))
+    testTiDBSelectFilter(table, "i IN ( 2, 3)", Seq(row2, row3))
   }
-
-  override def afterAll(): Unit =
-    try {
-      dropTable()
-    } finally {
-      super.afterAll()
-    }
 }

--- a/core/src/test/scala/com/pingcap/tispark/datasource/InsertSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/InsertSuite.scala
@@ -6,7 +6,7 @@ import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructT
 
 import scala.collection.mutable.ArrayBuffer
 
-class InsertSuite extends BaseDataSourceTest("test.datasource_insert") {
+class InsertSuite extends BaseDataSourceTest {
   private val row1 = Row(null, "Hello")
   private val row5 = Row(5, "Duplicate")
 
@@ -37,165 +37,178 @@ class InsertSuite extends BaseDataSourceTest("test.datasource_insert") {
   }
 
   test("Test insert to table without primary key") {
-    dropTable()
-    jdbcUpdate(s"create table $dbtable(i int, s varchar(128))")
+    val table = "pk_wo_pk"
+    dropTable(table)
+    createTable(s"create table `%s`.`%s`(i int, s varchar(128))", table)
     jdbcUpdate(
-      s"insert into $dbtable values(null, 'Hello')"
+      s"insert into `%s`.`%s` values(null, 'Hello')",
+      table
     )
 
     var data = List(row1)
     // insert 2 rows
     var insert = generateData(2, 2)
     data = data ::: insert
-    tidbWrite(insert, schema)
-    testTiDBSelect(data)
+    tidbWriteWithTable(insert, schema, table)
+    testTiDBSelectWithTable(data, tableName = table)
 
     // insert duplicate row
     insert = generateData(2, 2)
     data = data ::: insert
     // sort the data
     data = data.sortWith(compareRow)
-    tidbWrite(insert, schema)
-    testTiDBSelect(data)
+    tidbWriteWithTable(insert, schema, table)
+    testTiDBSelectWithTable(data, tableName = table)
 
     // insert ~100 rows
     insert = generateData(5, 95)
     data = data ::: insert
-    tidbWrite(insert, schema)
-    testTiDBSelect(data)
+    tidbWriteWithTable(insert, schema, table)
+    testTiDBSelectWithTable(data, tableName = table)
 
     // insert ~1000 rows
     insert = generateData(101, 900)
     data = data ::: insert
-    tidbWrite(insert, schema)
-    testTiDBSelect(data)
+    tidbWriteWithTable(insert, schema, table)
+    testTiDBSelectWithTable(data, tableName = table)
   }
 
   test("Test insert to table with primary key (primary key is handle)") {
-    dropTable()
-    jdbcUpdate(s"create table $dbtable(i int primary key, s varchar(128))")
+    val table = "tbl_pk_is_handle"
+    dropTable(table)
+    createTable(s"create table `%s`.`%s`(i int primary key, s varchar(128))", table)
     jdbcUpdate(
-      s"insert into $dbtable values(2, 'TiDB')"
+      s"insert into `%s`.`%s` values(2, 'TiDB')",
+      table
     )
 
     var data = List(Row(2, "TiDB"))
     // insert 2 rows
     var insert = generateData(3, 2)
     data = data ::: insert
-    tidbWrite(insert, schema)
-    testTiDBSelect(data)
+    tidbWriteWithTable(insert, schema, table)
+    testTiDBSelectWithTable(data, tableName = table)
 
     // insert duplicate row
     insert = generateData(4, 2)
     intercept[TiBatchWriteException] {
-      tidbWrite(insert, schema)
+      tidbWriteWithTable(insert, schema, table)
     }
 
     // insert ~100 rows
     insert = generateData(5, 95)
     data = data ::: insert
-    tidbWrite(insert, schema)
-    testTiDBSelect(data)
+    tidbWriteWithTable(insert, schema, table)
+    testTiDBSelectWithTable(data, tableName = table)
 
     // insert ~1000 rows
     insert = generateData(101, 900)
     data = data ::: insert
-    tidbWrite(insert, schema)
-    testTiDBSelect(data)
+    tidbWriteWithTable(insert, schema, table)
+    testTiDBSelectWithTable(data, tableName = table)
   }
 
   test("Test insert to table with primary key with tiny int") {
-    dropTable()
-    jdbcUpdate(s"create table $dbtable(i tinyint primary key, s varchar(128))")
+    val table = "tbl_pk_is_tiny_int"
+    dropTable(table)
+    createTable(s"create table `%s`.`%s`(i tinyint primary key, s varchar(128))", table)
     jdbcUpdate(
-      s"insert into $dbtable values(2, 'TiDB')"
+      s"insert into `%s`.`%s` values(2, 'TiDB')",
+      table
     )
 
     var data = List(Row(2, "TiDB"))
     // insert 2 rows
     val insert = generateData(3, 100)
     data = data ::: insert
-    tidbWrite(insert, schema)
-    testTiDBSelect(data)
+    tidbWriteWithTable(insert, schema, table)
+    testTiDBSelectWithTable(data, tableName = table)
   }
 
   test("Test insert to table with primary key with small int") {
-    dropTable()
-    jdbcUpdate(s"create table $dbtable(i smallint primary key, s varchar(128))")
+    val table = "tbl_pk_is_small_int"
+    dropTable(table)
+    createTable(s"create table `%s`.`%s`(i smallint primary key, s varchar(128))", table)
     jdbcUpdate(
-      s"insert into $dbtable values(2, 'TiDB')"
+      s"insert into `%s`.`%s` values(2, 'TiDB')",
+      table
     )
 
     var data = List(Row(2, "TiDB"))
     // insert 2 rows
     val insert = generateData(3, 100)
     data = data ::: insert
-    tidbWrite(insert, schema)
-    testTiDBSelect(data)
+    tidbWriteWithTable(insert, schema, table)
+    testTiDBSelectWithTable(data, tableName = table)
   }
 
   test("Test insert to table with primary key with medium int") {
-    dropTable()
-    jdbcUpdate(s"create table $dbtable(i mediumint primary key, s varchar(128))")
+    val table = "tbl_pk_is_medium_int"
+    dropTable(table)
+    createTable(s"create table `%s`.`%s`(i mediumint primary key, s varchar(128))", table)
     jdbcUpdate(
-      s"insert into $dbtable values(2, 'TiDB')"
+      s"insert into `%s`.`%s` values(2, 'TiDB')",
+      table
     )
 
     var data = List(Row(2, "TiDB"))
     // insert 2 rows
     val insert = generateData(3, 100)
     data = data ::: insert
-    tidbWrite(insert, schema)
-    testTiDBSelect(data)
+    tidbWriteWithTable(insert, schema, table)
+    testTiDBSelectWithTable(data, tableName = table)
   }
 
   test("Test insert to table with primary key (auto increase case 1)") {
-    dropTable()
-    jdbcUpdate(s"create table $dbtable(i int primary key AUTO_INCREMENT, s varchar(128))")
+    val table = "tbl_pk_is_handle_auto"
+    dropTable(table)
+    createTable("create table `%s`.`%s`(i int primary key AUTO_INCREMENT, s varchar(128))", table)
     jdbcUpdate(
-      s"insert into $dbtable values(2, 'TiDB')"
+      "insert into `%s`.`%s` values(2, 'TiDB')",
+      table
     )
 
     var data = List(Row(2, "TiDB"))
     // insert 2 rows
     var insert = generateData(3, 2)
     data = data ::: insert
-    tidbWrite(insert, schema)
-    testTiDBSelect(data)
+    tidbWriteWithTable(insert, schema, table)
+    testTiDBSelectWithTable(data, tableName = table)
 
     // when provide auto id column value but say not provide them in options
     // an exception will be thrown.
     // duplicate pk
     intercept[TiBatchWriteException] {
-      tidbWrite(List(row2_v2, row5), schema)
+      tidbWriteWithTable(List(row2_v2, row5), schema, table)
     }
 
     // when not provide auto id but say provide them in options
     // and exception will be thrown.
     // null pk
     intercept[TiBatchWriteException] {
-      tidbWrite(List(Row(null, "abc")), schema)
+      tidbWriteWithTable(List(Row(null, "abc")), schema, table)
     }
 
     //insert ~100 rows
     insert = generateData(5, 95)
     data = data ::: insert
-    tidbWrite(insert, schema)
-    testTiDBSelect(data)
+    tidbWriteWithTable(insert, schema, table)
+    testTiDBSelectWithTable(data, tableName = table)
 
     //insert ~1000 rows
     insert = generateData(101, 900)
     data = data ::: insert
-    tidbWrite(insert, schema)
-    testTiDBSelect(data)
+    tidbWriteWithTable(insert, schema, table)
+    testTiDBSelectWithTable(data, tableName = table)
   }
 
   test("Test insert to table with primary key (auto increase case 2)") {
-
-    dropTable()
-    jdbcUpdate(s"create table $dbtable(i int primary key AUTO_INCREMENT, s varchar(128))")
+    val table = "tbl_pk_is_handle_auto_case_2"
+    dropTable(table)
+    createTable(s"create table `%s`.`%s`(i int primary key AUTO_INCREMENT, s varchar(128))", table)
     jdbcUpdate(
-      s"insert into $dbtable(s) values('Hello')"
+      s"insert into `%s`.`%s`(s) values('Hello')",
+      table
     )
 
     val withOutIDSchema = StructType(
@@ -207,28 +220,21 @@ class InsertSuite extends BaseDataSourceTest("test.datasource_insert") {
     var data = List(Row("Hello"))
 
     // insert 2 rows
-    var insert = generateData(30000, 2, true)
+    var insert = generateData(30000, 2, skipFirstCol = true)
     data = data ::: insert
-    tidbWrite(insert, withOutIDSchema)
-    testTiDBSelect(data, "i", "s")
+    tidbWriteWithTable(insert, withOutIDSchema, table)
+    testTiDBSelectWithTable(data, "i", "s", tableName = table)
 
     // insert ~100 rows
-    insert = generateData(30002, 98, true)
+    insert = generateData(30002, 98, skipFirstCol = true)
     data = data ::: insert
-    tidbWrite(insert, withOutIDSchema)
-    testTiDBSelect(data, "i", "s")
+    tidbWriteWithTable(insert, withOutIDSchema, table)
+    testTiDBSelectWithTable(data, "i", "s", tableName = table)
 
     // insert ~1000 rows
-    insert = generateData(30100, 900, true)
+    insert = generateData(30100, 900, skipFirstCol = true)
     data = data ::: insert
-    tidbWrite(insert, withOutIDSchema)
-    testTiDBSelect(data, "i", "s")
+    tidbWriteWithTable(insert, withOutIDSchema, table)
+    testTiDBSelectWithTable(data, "i", "s", tableName = table)
   }
-
-  override def afterAll(): Unit =
-    try {
-      dropTable()
-    } finally {
-      super.afterAll()
-    }
 }

--- a/core/src/test/scala/com/pingcap/tispark/datasource/MissingParameterSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/MissingParameterSuite.scala
@@ -4,7 +4,7 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
 
-class MissingParameterSuite extends BaseDataSourceTest("test_datasource_missing_parameter") {
+class MissingParameterSuite extends BaseDataSourceTest {
   private val row1 = Row(null, "Hello")
 
   private val schema = StructType(
@@ -15,8 +15,9 @@ class MissingParameterSuite extends BaseDataSourceTest("test_datasource_missing_
   )
 
   test("Missing parameter: database") {
-    dropTable()
-    jdbcUpdate(s"create table $dbtable(i int, s varchar(128))")
+    val table = "tbl_missing_db"
+    dropTable(table)
+    createTable(s"create table `%s`.`%s`(i int, s varchar(128))", table)
 
     val caught = intercept[IllegalArgumentException] {
       val rows = row1 :: Nil
@@ -36,11 +37,4 @@ class MissingParameterSuite extends BaseDataSourceTest("test_datasource_missing_
         )
     )
   }
-
-  override def afterAll(): Unit =
-    try {
-      dropTable()
-    } finally {
-      super.afterAll()
-    }
 }

--- a/core/src/test/scala/com/pingcap/tispark/datasource/ShardRowIDBitsSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/ShardRowIDBitsSuite.scala
@@ -3,7 +3,7 @@ package com.pingcap.tispark.datasource
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types.{IntegerType, StructField, StructType}
 
-class ShardRowIDBitsSuite extends BaseDataSourceTest("test_shard_row_id_bits") {
+class ShardRowIDBitsSuite extends BaseDataSourceTest {
   private val row1 = Row(1)
   private val row2 = Row(2)
   private val row3 = Row(3)
@@ -14,16 +14,19 @@ class ShardRowIDBitsSuite extends BaseDataSourceTest("test_shard_row_id_bits") {
   )
 
   test("reading and writing a table with shard_row_id_bits") {
-    dropTable()
-    jdbcUpdate(
-      s"CREATE TABLE  $dbtable ( `a` int(11))  SHARD_ROW_ID_BITS = 4"
+    val table = "show_row_id_bits_test"
+    dropTable(table)
+    createTable(
+      s"CREATE TABLE  `%s`.`%s` ( `a` int(11))  SHARD_ROW_ID_BITS = 4",
+      table
     )
 
     jdbcUpdate(
-      s"insert into $dbtable values(null)"
+      s"insert into `%s`.`%s` values(null)",
+      table
     )
 
-    tidbWrite(List(row1, row2, row3), schema)
-    testTiDBSelect(List(Row(null), row1, row2, row3), sortCol = "a")
+    tidbWriteWithTable(List(row1, row2, row3), schema, table)
+    testTiDBSelectWithTable(List(Row(null), row1, row2, row3), sortCol = "a", tableName = table)
   }
 }

--- a/core/src/test/scala/com/pingcap/tispark/datasource/TiSparkTypeSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/TiSparkTypeSuite.scala
@@ -3,7 +3,7 @@ package com.pingcap.tispark.datasource
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types.{LongType, StringType, StructField, StructType}
 
-class TiSparkTypeSuite extends BaseDataSourceTest("type_test") {
+class TiSparkTypeSuite extends BaseDataSourceTest {
   private val row1 = Row(null, "Hello")
   private val row2 = Row(2L, "TiDB")
   private val row3 = Row(3L, "Spark")
@@ -16,13 +16,15 @@ class TiSparkTypeSuite extends BaseDataSourceTest("type_test") {
     )
   )
   test("bigint test") {
-    dropTable()
-    jdbcUpdate(s"create table $dbtable(i bigint, s varchar(128))")
+    val table = "big_int_test"
+    dropTable(table)
+    createTable(s"create table `%s`.`%s`(i bigint, s varchar(128))", table)
     jdbcUpdate(
-      s"insert into $dbtable values(null, 'Hello'), (2, 'TiDB')"
+      "insert into `%s`.`%s` values(null, 'Hello'), (2, 'TiDB')",
+      table
     )
 
-    tidbWrite(List(row3, row5), schema)
-    testTiDBSelect(List(row1, row2, row3, row5))
+    tidbWriteWithTable(List(row3, row5), schema, table)
+    testTiDBSelectWithTable(List(row1, row2, row3, row5), tableName = table)
   }
 }

--- a/core/src/test/scala/com/pingcap/tispark/datasource/UpperCaseColumnNameSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/UpperCaseColumnNameSuite.scala
@@ -4,8 +4,7 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types.{IntegerType, StructField, StructType}
 
-class UpperCaseColumnNameSuite
-    extends BaseDataSourceTest("test_datasource_uppser_case_column_name") {
+class UpperCaseColumnNameSuite extends BaseDataSourceTest {
 
   private val row1 = Row(1, 2)
 
@@ -16,17 +15,16 @@ class UpperCaseColumnNameSuite
     )
   )
 
-  override def beforeAll(): Unit = {
-    super.beforeAll()
-
-    dropTable()
-    jdbcUpdate(s"""
-                  |CREATE TABLE $dbtable (O_ORDERKEY INTEGER NOT NULL,
-                  |                       O_CUSTKEY INTEGER NOT NULL);
-       """.stripMargin)
-  }
-
   test("Test insert upper case column name") {
+    val table = "upper_case_col_name"
+    dropTable(table)
+    createTable(
+      """
+        |CREATE TABLE `%s`.`%s` (O_ORDERKEY INTEGER NOT NULL,
+        |                       O_CUSTKEY INTEGER NOT NULL);
+       """.stripMargin,
+      table
+    )
     val data: RDD[Row] = sc.makeRDD(List(row1))
     val df = sqlContext.createDataFrame(data, schema)
     df.write
@@ -37,11 +35,4 @@ class UpperCaseColumnNameSuite
       .mode("append")
       .save()
   }
-
-  override def afterAll(): Unit =
-    try {
-      dropTable()
-    } finally {
-      super.afterAll()
-    }
 }

--- a/core/src/test/scala/com/pingcap/tispark/datatype/DataTypeSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datatype/DataTypeSuite.scala
@@ -8,82 +8,88 @@ import com.pingcap.tispark.datasource.BaseDataSourceTest
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types._
 
-class DataTypeSuite extends BaseDataSourceTest("test_data_type", "test") {
+class DataTypeSuite extends BaseDataSourceTest("test") {
 
   test("Test Read different types") {
+    val table = "read_different_types"
+    dropTable(table)
+    createTable(
+      s"""
+         |create table `%s`.`%s`(
+         |i INT,
+         |c1 BIT(1),
+         |c2 BIT(8),
+         |c3 TINYINT,
+         |c4 BOOLEAN,
+         |c5 SMALLINT,
+         |c6 MEDIUMINT,
+         |c7 INTEGER,
+         |c8 BIGINT,
+         |c9 FLOAT,
+         |c10 DOUBLE,
+         |c11 DECIMAL,
+         |c12 DATE,
+         |c13 DATETIME,
+         |c14 TIMESTAMP,
+         |c15 TIME,
+         |c16 YEAR,
+         |c17 CHAR(64),
+         |c18 VARCHAR(64),
+         |c19 BINARY(64),
+         |c20 VARBINARY(64),
+         |c21 TINYBLOB,
+         |c22 TINYTEXT,
+         |c23 BLOB,
+         |c24 TEXT,
+         |c25 MEDIUMBLOB,
+         |c26 MEDIUMTEXT,
+         |c27 LONGBLOB,
+         |c28 LONGTEXT,
+         |c29 ENUM('male' , 'female' , 'both' , 'unknow'),
+         |c30 SET('a', 'b', 'c')
+         |)
+      """.stripMargin,
+      table
+    )
 
-    dropTable()
-    jdbcUpdate(s"""
-                  |create table $dbtable(
-                  |i INT,
-                  |c1 BIT(1),
-                  |c2 BIT(8),
-                  |c3 TINYINT,
-                  |c4 BOOLEAN,
-                  |c5 SMALLINT,
-                  |c6 MEDIUMINT,
-                  |c7 INTEGER,
-                  |c8 BIGINT,
-                  |c9 FLOAT,
-                  |c10 DOUBLE,
-                  |c11 DECIMAL,
-                  |c12 DATE,
-                  |c13 DATETIME,
-                  |c14 TIMESTAMP,
-                  |c15 TIME,
-                  |c16 YEAR,
-                  |c17 CHAR(64),
-                  |c18 VARCHAR(64),
-                  |c19 BINARY(64),
-                  |c20 VARBINARY(64),
-                  |c21 TINYBLOB,
-                  |c22 TINYTEXT,
-                  |c23 BLOB,
-                  |c24 TEXT,
-                  |c25 MEDIUMBLOB,
-                  |c26 MEDIUMTEXT,
-                  |c27 LONGBLOB,
-                  |c28 LONGTEXT,
-                  |c29 ENUM('male' , 'female' , 'both' , 'unknow'),
-                  |c30 SET('a', 'b', 'c')
-                  |)
-      """.stripMargin)
-
-    jdbcUpdate(s"""
-                  |insert into $dbtable values(
-                  |1,
-                  |B'1',
-                  |B'01111100',
-                  |29,
-                  |1,
-                  |29,
-                  |29,
-                  |29,
-                  |29,
-                  |29.9,
-                  |29.9,
-                  |29.9,
-                  |'2019-01-01',
-                  |'2019-01-01 11:11:11',
-                  |'2019-01-01 11:11:11',
-                  |'11:11:11',
-                  |'2019',
-                  |'char test',
-                  |'varchar test',
-                  |'binary test',
-                  |'varbinary test',
-                  |'tinyblob test',
-                  |'tinytext test',
-                  |'blob test',
-                  |'text test',
-                  |'mediumblob test',
-                  |'mediumtext test',
-                  |'longblob test',
-                  |'longtext test',
-                  |'male',
-                  |'a,b'
-                  |)
-       """.stripMargin)
+    jdbcUpdate(
+      """
+        |insert into `%s`.`%s` values(
+        |1,
+        |B'1',
+        |B'01111100',
+        |29,
+        |1,
+        |29,
+        |29,
+        |29,
+        |29,
+        |29.9,
+        |29.9,
+        |29.9,
+        |'2019-01-01',
+        |'2019-01-01 11:11:11',
+        |'2019-01-01 11:11:11',
+        |'11:11:11',
+        |'2019',
+        |'char test',
+        |'varchar test',
+        |'binary test',
+        |'varbinary test',
+        |'tinyblob test',
+        |'tinytext test',
+        |'blob test',
+        |'text test',
+        |'mediumblob test',
+        |'mediumtext test',
+        |'longblob test',
+        |'longtext test',
+        |'male',
+        |'a,b'
+        |)
+       """.stripMargin,
+      table
+    )
 
     val tiTableInfo = getTableInfo(database, table)
     for (i <- 0 until tiTableInfo.getColumns.size()) {
@@ -93,38 +99,42 @@ class DataTypeSuite extends BaseDataSourceTest("test_data_type", "test") {
 
   //todo support TIME/YEAR/BINARY/SET
   test("Test different data type") {
-    dropTable()
-    jdbcUpdate(s"""
-                  |create table $dbtable(
-                  |i INT primary key,
-                  |c1 BIT(1),
-                  |c2 BIT(8),
-                  |c3 TINYINT,
-                  |c4 BOOLEAN,
-                  |c5 SMALLINT,
-                  |c6 MEDIUMINT,
-                  |c7 INTEGER,
-                  |c8 BIGINT,
-                  |c9 FLOAT,
-                  |c10 DOUBLE,
-                  |c11 DECIMAL(38,18),
-                  |c12 DATE,
-                  |c13 DATETIME,
-                  |c14 TIMESTAMP,
-                  |c17 CHAR(64),
-                  |c18 VARCHAR(64),
-                  |c20 VARBINARY(64),
-                  |c21 TINYBLOB,
-                  |c22 TINYTEXT,
-                  |c23 BLOB,
-                  |c24 TEXT,
-                  |c25 MEDIUMBLOB,
-                  |c26 MEDIUMTEXT,
-                  |c27 LONGBLOB,
-                  |c28 LONGTEXT,
-                  |c29 ENUM('male' , 'female' , 'both' , 'unknown')
-                  |)
-      """.stripMargin)
+    val table = "different_data_type"
+    dropTable(table)
+    createTable(
+      """
+        |create table `%s`.`%s`(
+        |i INT primary key,
+        |c1 BIT(1),
+        |c2 BIT(8),
+        |c3 TINYINT,
+        |c4 BOOLEAN,
+        |c5 SMALLINT,
+        |c6 MEDIUMINT,
+        |c7 INTEGER,
+        |c8 BIGINT,
+        |c9 FLOAT,
+        |c10 DOUBLE,
+        |c11 DECIMAL(38,18),
+        |c12 DATE,
+        |c13 DATETIME,
+        |c14 TIMESTAMP,
+        |c17 CHAR(64),
+        |c18 VARCHAR(64),
+        |c20 VARBINARY(64),
+        |c21 TINYBLOB,
+        |c22 TINYTEXT,
+        |c23 BLOB,
+        |c24 TEXT,
+        |c25 MEDIUMBLOB,
+        |c26 MEDIUMTEXT,
+        |c27 LONGBLOB,
+        |c28 LONGTEXT,
+        |c29 ENUM('male' , 'female' , 'both' , 'unknown')
+        |)
+      """.stripMargin,
+      table
+    )
     val schema = StructType(
       List(
         StructField("i", IntegerType),
@@ -220,7 +230,7 @@ class DataTypeSuite extends BaseDataSourceTest("test_data_type", "test") {
       "female"
     )
     val data = List(row1, row2)
-    tidbWrite(data, schema)
+    tidbWriteWithTable(data, schema, table)
     val row3 = Row(
       1,
       0.toByte,
@@ -280,18 +290,22 @@ class DataTypeSuite extends BaseDataSourceTest("test_data_type", "test") {
       "female"
     )
     val ref = List(row3, row4)
-    testTiDBSelect(ref)
+    testTiDBSelectWithTable(ref, tableName = table)
   }
 
   test("Test integer pk") {
     // integer pk
-    dropTable()
-    jdbcUpdate(s"""
-                  |create table $dbtable(
-                  |i INT primary key,
-                  |c1 varchar(64)
-                  |)
-      """.stripMargin)
+    val table = "int_pk_table"
+    dropTable(table)
+    createTable(
+      """
+        |create table `%s`.`%s`(
+        |i INT primary key,
+        |c1 varchar(64)
+        |)
+      """.stripMargin,
+      table
+    )
     val schema = StructType(
       List(
         StructField("i", IntegerType),
@@ -301,25 +315,29 @@ class DataTypeSuite extends BaseDataSourceTest("test_data_type", "test") {
     val row1 = Row(1, "test")
     val row2 = Row(2, "spark")
     var data = List(row1, row2)
-    tidbWrite(data, schema)
-    testTiDBSelect(data)
+    tidbWriteWithTable(data, schema, table)
+    testTiDBSelectWithTable(data, tableName = table)
 
     val row3 = Row(1, "spark")
     data = List(row1, row3)
     intercept[TiBatchWriteException] {
-      tidbWrite(data, schema)
+      tidbWriteWithTable(data, schema, table)
     }
   }
 
   test("Test decimal pk") {
     // decimal pk
-    dropTable()
-    jdbcUpdate(s"""
-                  |create table $dbtable(
-                  |i decimal(3,2) primary key,
-                  |c1 varchar(64)
-                  |)
-      """.stripMargin)
+    val table = "decimal_pk_tbl"
+    dropTable(table)
+    createTable(
+      """
+        |create table `%s`.`%s`(
+        |i decimal(3,2) primary key,
+        |c1 varchar(64)
+        |)
+      """.stripMargin,
+      table
+    )
     val schema = StructType(
       List(
         StructField("i", DecimalType(3, 2)),
@@ -329,25 +347,26 @@ class DataTypeSuite extends BaseDataSourceTest("test_data_type", "test") {
     val row1 = Row(BigDecimal(1.23), "test")
     val row2 = Row(BigDecimal(1.24), "spark")
     var data = List(row1, row2)
-    tidbWrite(data, schema)
-    testTiDBSelect(data)
+    tidbWriteWithTable(data, schema, table)
+    testTiDBSelectWithTable(data, tableName = table)
 
     val row3 = Row(BigDecimal(1.23), "spark")
     data = List(row1, row3)
     intercept[TiBatchWriteException] {
-      tidbWrite(data, schema)
+      tidbWriteWithTable(data, schema, table)
     }
   }
 
   test("Test char pk") {
     // char pk
-    dropTable()
-    jdbcUpdate(s"""
-                  |create table $dbtable(
+    val table = "char_pk_tbl"
+    dropTable(table)
+    createTable(s"""
+                  |create table `%s`.`%s`(
                   |i char(4) primary key,
                   |c1 varchar(64)
                   |)
-      """.stripMargin)
+      """.stripMargin, table)
     val schema = StructType(
       List(
         StructField("i", StringType),
@@ -357,25 +376,29 @@ class DataTypeSuite extends BaseDataSourceTest("test_data_type", "test") {
     val row1 = Row("row1", "test")
     val row2 = Row("row2", "spark")
     var data = List(row1, row2)
-    tidbWrite(data, schema)
-    testTiDBSelect(data)
+    tidbWriteWithTable(data, schema, table)
+    testTiDBSelectWithTable(data, tableName = table)
 
     val row3 = Row("row1", "spark")
     data = List(row1, row3)
     intercept[TiBatchWriteException] {
-      tidbWrite(data, schema)
+      tidbWriteWithTable(data, schema, table)
     }
   }
 
   test("Test varchar pk") {
     // char pk
-    dropTable()
-    jdbcUpdate(s"""
-                  |create table $dbtable(
-                  |i varchar(4) primary key,
-                  |c1 varchar(64)
-                  |)
-      """.stripMargin)
+    val table = "varchat_pk_tbl"
+    dropTable(table)
+    createTable(
+      """
+        |create table `%s`.`%s`(
+        |i varchar(4) primary key,
+        |c1 varchar(64)
+        |)
+      """.stripMargin,
+      table
+    )
     val schema = StructType(
       List(
         StructField("i", StringType),
@@ -385,25 +408,29 @@ class DataTypeSuite extends BaseDataSourceTest("test_data_type", "test") {
     val row1 = Row("r1", "test")
     val row2 = Row("r2", "spark")
     var data = List(row1, row2)
-    tidbWrite(data, schema)
-    testTiDBSelect(data)
+    tidbWriteWithTable(data, schema, table)
+    testTiDBSelectWithTable(data, tableName = table)
 
     val row3 = Row("r1", "spark")
     data = List(row1, row3)
     intercept[TiBatchWriteException] {
-      tidbWrite(data, schema)
+      tidbWriteWithTable(data, schema, table)
     }
   }
 
   test("Test date pk") {
     // char pk
-    dropTable()
-    jdbcUpdate(s"""
-                  |create table $dbtable(
-                  |i date primary key,
-                  |c1 varchar(64)
-                  |)
-      """.stripMargin)
+    val table = "date_pk_tbl"
+    dropTable(table)
+    createTable(
+      """
+        |create table `%s`.`%s`(
+        |i date primary key,
+        |c1 varchar(64)
+        |)
+      """.stripMargin,
+      table
+    )
     val schema = StructType(
       List(
         StructField("i", StringType),
@@ -415,25 +442,29 @@ class DataTypeSuite extends BaseDataSourceTest("test_data_type", "test") {
     var data = List(row1, row2)
     val ref =
       List(Row(Date.valueOf("2019-06-10"), "test"), Row(Date.valueOf("2019-06-11"), "spark"))
-    tidbWrite(data, schema)
-    testTiDBSelect(ref)
+    tidbWriteWithTable(data, schema, table)
+    testTiDBSelectWithTable(ref, tableName = table)
 
     val row3 = Row("2019-06-10", "spark")
     data = List(row1, row3)
     intercept[TiBatchWriteException] {
-      tidbWrite(data, schema)
+      tidbWriteWithTable(data, schema, table)
     }
   }
 
   test("Test datetime pk") {
     // datetime pk
-    dropTable()
-    jdbcUpdate(s"""
-                  |create table $dbtable(
-                  |i DATETIME primary key,
-                  |c1 varchar(64)
-                  |)
-      """.stripMargin)
+    val table = "datetime_pk_tbl"
+    dropTable(table)
+    createTable(
+      """
+        |create table `%s`.`%s`(
+        |i DATETIME primary key,
+        |c1 varchar(64)
+        |)
+      """.stripMargin,
+      table
+    )
     val schema = StructType(
       List(
         StructField("i", TimestampType),
@@ -445,25 +476,29 @@ class DataTypeSuite extends BaseDataSourceTest("test_data_type", "test") {
     val row1 = Row(new Timestamp(timeInLong), "test")
     val row2 = Row(new Timestamp(timeInLong1), "spark")
     var data = List(row1, row2)
-    tidbWrite(data, schema)
-    testTiDBSelect(data)
+    tidbWriteWithTable(data, schema, table)
+    testTiDBSelectWithTable(data, tableName = table)
 
     val row3 = Row(new Timestamp(timeInLong), "spark")
     data = List(row1, row3)
     intercept[TiBatchWriteException] {
-      tidbWrite(data, schema)
+      tidbWriteWithTable(data, schema, table)
     }
   }
 
   test("Test timestamp pk") {
     // timestamp pk
-    dropTable()
-    jdbcUpdate(s"""
-                  |create table $dbtable(
-                  |i timestamp primary key,
-                  |c1 varchar(64)
-                  |)
-      """.stripMargin)
+    val table = "ts_pk_tbl"
+    dropTable(table)
+    createTable(
+      s"""
+         |create table `%s`.`%s`(
+         |i timestamp primary key,
+         |c1 varchar(64)
+         |)
+      """.stripMargin,
+      table
+    )
     val schema = StructType(
       List(
         StructField("i", TimestampType),
@@ -475,26 +510,30 @@ class DataTypeSuite extends BaseDataSourceTest("test_data_type", "test") {
     val row1 = Row(new Timestamp(timeInLong), "test")
     val row2 = Row(new Timestamp(timeInLong1), "spark")
     var data = List(row1, row2)
-    tidbWrite(data, schema)
-    testTiDBSelect(data)
+    tidbWriteWithTable(data, schema, table)
+    testTiDBSelectWithTable(data, tableName = table)
 
     val row3 = Row(new Timestamp(timeInLong), "spark")
     data = List(row1, row3)
     intercept[TiBatchWriteException] {
-      tidbWrite(data, schema)
+      tidbWriteWithTable(data, schema, table)
     }
   }
 
   test("Test text pk") {
-    // timestamp pk
-    dropTable()
-    jdbcUpdate(s"""
-                  |create table $dbtable(
-                  |i text,
-                  |c1 varchar(64),
-                  |primary key(i(128))
-                  |)
-      """.stripMargin)
+    // text pk
+    val table = "text_pk_tbl"
+    dropTable(table)
+    createTable(
+      """
+        |create table `%s`.`%s`(
+        |i text,
+        |c1 varchar(64),
+        |primary key(i(128))
+        |)
+      """.stripMargin,
+      table
+    )
     val schema = StructType(
       List(
         StructField("i", StringType),
@@ -504,26 +543,30 @@ class DataTypeSuite extends BaseDataSourceTest("test_data_type", "test") {
     val row1 = Row("row1", "test")
     val row2 = Row("row2", "spark")
     var data = List(row1, row2)
-    tidbWrite(data, schema)
-    testTiDBSelect(data)
+    tidbWriteWithTable(data, schema, table)
+    testTiDBSelectWithTable(data, tableName = table)
 
     val row3 = Row("row1", "spark")
     data = List(row1, row3)
     intercept[TiBatchWriteException] {
-      tidbWrite(data, schema)
+      tidbWriteWithTable(data, schema, table)
     }
   }
 
   test("Test blob pk") {
     // blob pk
-    dropTable()
-    jdbcUpdate(s"""
-                  |create table $dbtable(
-                  |i blob,
-                  |c1 varchar(64),
-                  |primary key(i(128))
-                  |)
-      """.stripMargin)
+    val table = "blob_pk_tbl"
+    dropTable(table)
+    createTable(
+      """
+        |create table `%s`.`%s`(
+        |i blob,
+        |c1 varchar(64),
+        |primary key(i(128))
+        |)
+      """.stripMargin,
+      table
+    )
     val schema = StructType(
       List(
         StructField("i", StringType),
@@ -534,25 +577,29 @@ class DataTypeSuite extends BaseDataSourceTest("test_data_type", "test") {
     val row2 = Row("row2", "spark")
     var data = List(row1, row2)
     val ref = List(Row("row1".toArray, "test"), Row("row2".toArray, "spark"))
-    tidbWrite(data, schema)
-    testTiDBSelect(ref)
+    tidbWriteWithTable(data, schema, table)
+    testTiDBSelectWithTable(ref, tableName = table)
 
     val row3 = Row("row1", "spark")
     data = List(row1, row3)
     intercept[TiBatchWriteException] {
-      tidbWrite(data, schema)
+      tidbWriteWithTable(data, schema, table)
     }
   }
 
   test("Test enum pk") {
     // enum pk
-    dropTable()
-    jdbcUpdate(s"""
-                  |create table $dbtable(
-                  |i ENUM('male','female','both','unknown') primary key,
-                  |c1 varchar(64)
-                  |)
-      """.stripMargin)
+    val table = "enum_pk_tbl"
+    dropTable(table)
+    createTable(
+      """
+        |create table `%s`.`%s`(
+        |i ENUM('male','female','both','unknown') primary key,
+        |c1 varchar(64)
+        |)
+      """.stripMargin,
+      table
+    )
     val schema = StructType(
       List(
         StructField("i", StringType),
@@ -562,27 +609,31 @@ class DataTypeSuite extends BaseDataSourceTest("test_data_type", "test") {
     val row1 = Row("male", "test")
     val row2 = Row("female", "spark")
     var data = List(row2, row1)
-    tidbWrite(data, schema)
-    testTiDBSelect(data)
+    tidbWriteWithTable(data, schema, table)
+    testTiDBSelectWithTable(data, tableName = table)
 
     val row3 = Row("male", "spark")
     data = List(row1, row3)
     intercept[TiBatchWriteException] {
-      tidbWrite(data, schema)
+      tidbWriteWithTable(data, schema, table)
     }
   }
 
   test("Test composite pk") {
     // enum pk
-    dropTable()
-    jdbcUpdate(s"""
-                  |create table $dbtable(
-                  |i int,
-                  |i1 int,
-                  |c1 varchar(64),
-                  |primary key(i,i1)
-                  |)
-      """.stripMargin)
+    val table = "composite_pk_tbl"
+    dropTable(table)
+    createTable(
+      """
+        |create table `%s`.`%s`(
+        |i int,
+        |i1 int,
+        |c1 varchar(64),
+        |primary key(i,i1)
+        |)
+      """.stripMargin,
+      table
+    )
     val schema = StructType(
       List(
         StructField("i", IntegerType),
@@ -593,20 +644,13 @@ class DataTypeSuite extends BaseDataSourceTest("test_data_type", "test") {
     val row1 = Row(1, 2, "test")
     val row2 = Row(2, 2, "tispark")
     var data = List(row1, row2)
-    tidbWrite(data, schema)
-    testTiDBSelect(data)
+    tidbWriteWithTable(data, schema, table)
+    testTiDBSelectWithTable(data, tableName = table)
 
     val row3 = Row(1, 2, "spark")
     data = List(row1, row3)
     intercept[TiBatchWriteException] {
-      tidbWrite(data, schema)
+      tidbWriteWithTable(data, schema, table)
     }
   }
-
-  override def afterAll(): Unit =
-    try {
-      dropTable()
-    } finally {
-      super.afterAll()
-    }
 }

--- a/core/src/test/scala/com/pingcap/tispark/datatype/DataTypeSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datatype/DataTypeSuite.scala
@@ -361,12 +361,15 @@ class DataTypeSuite extends BaseDataSourceTest("test") {
     // char pk
     val table = "char_pk_tbl"
     dropTable(table)
-    createTable(s"""
-                  |create table `%s`.`%s`(
-                  |i char(4) primary key,
-                  |c1 varchar(64)
-                  |)
-      """.stripMargin, table)
+    createTable(
+      s"""
+         |create table `%s`.`%s`(
+         |i char(4) primary key,
+         |c1 varchar(64)
+         |)
+      """.stripMargin,
+      table
+    )
     val schema = StructType(
       List(
         StructField("i", StringType),

--- a/core/src/test/scala/com/pingcap/tispark/overflow/BitOverflowSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/overflow/BitOverflowSuite.scala
@@ -8,25 +8,23 @@ import org.apache.spark.sql.types._
  * BIT type include:
  * 1. BIT
  */
-class BitOverflowSuite extends BaseDataSourceTest("test_data_type_bit_overflow") {
+class BitOverflowSuite extends BaseDataSourceTest {
 
   test("Test BIT(1) Upper bound Overflow") {
-    testBit1UpperBound(false)
+    testBit1UpperBound(testKey = false, "bit1_upper_bound_overflow")
   }
   test("Test BIT(1) as key Upper bound Overflow") {
-    testBit1UpperBound(true)
+    testBit1UpperBound(testKey = true, "key_bit1_upper_bound_overflow")
   }
 
-  private def testBit1UpperBound(testKey: Boolean): Unit = {
-
-    dropTable()
+  private def testBit1UpperBound(testKey: Boolean, table: String): Unit = {
+    dropTable(table)
     if (testKey) {
-      jdbcUpdate(
-        s"create table $dbtable(c1 BIT(1) primary key)"
-      )
+      createTable("create table `%s`.`%s`(c1 BIT(1) primary key)", table)
     } else {
-      jdbcUpdate(
-        s"create table $dbtable(c1 BIT(1))"
+      createTable(
+        "create table `%s`.`%s`(c1 BIT(1))",
+        table
       )
     }
 
@@ -44,6 +42,7 @@ class BitOverflowSuite extends BaseDataSourceTest("test_data_type_bit_overflow")
     compareTiDBWriteFailureWithJDBC(
       List(row),
       schema,
+      table,
       jdbcErrorClass,
       jdbcErrorMsg,
       tidbErrorClass,
@@ -53,23 +52,24 @@ class BitOverflowSuite extends BaseDataSourceTest("test_data_type_bit_overflow")
   }
 
   test("Test BIT(1) Lower bound Overflow") {
-    testBit1LowerBound(false)
+    testBit1LowerBound(testKey = false, "bit1_lower_bound_overflow")
   }
 
   test("Test BIT(1) as key Lower bound Overflow") {
-    testBit1LowerBound(true)
+    testBit1LowerBound(testKey = true, "key_bit1_lower_bound_overflow")
   }
 
-  private def testBit1LowerBound(testKey: Boolean): Unit = {
-
-    dropTable()
+  private def testBit1LowerBound(testKey: Boolean, table: String): Unit = {
+    dropTable(table)
     if (testKey) {
-      jdbcUpdate(
-        s"create table $dbtable(c1 BIT(1) primary key)"
+      createTable(
+        "create table `%s`.`%s`(c1 BIT(1) primary key)",
+        table
       )
     } else {
-      jdbcUpdate(
-        s"create table $dbtable(c1 BIT(1))"
+      createTable(
+        "create table `%s`.`%s`(c1 BIT(1))",
+        table
       )
     }
 
@@ -87,6 +87,7 @@ class BitOverflowSuite extends BaseDataSourceTest("test_data_type_bit_overflow")
     compareTiDBWriteFailureWithJDBC(
       List(row),
       schema,
+      table,
       jdbcErrorClass,
       jdbcErrorMsg,
       tidbErrorClass,
@@ -96,22 +97,24 @@ class BitOverflowSuite extends BaseDataSourceTest("test_data_type_bit_overflow")
   }
 
   test("Test BIT(4) Upper bound Overflow") {
-    testBit4UpperBound(false)
+    testBit4UpperBound(testKey = false, "bit4_upper_bound_overflow")
   }
 
   test("Test BIT(4) as key Upper bound Overflow") {
-    testBit4UpperBound(true)
+    testBit4UpperBound(testKey = true, "key_bit4_upper_bound_overflow")
   }
 
-  private def testBit4UpperBound(testKey: Boolean): Unit = {
-    dropTable()
+  private def testBit4UpperBound(testKey: Boolean, table: String): Unit = {
+    dropTable(table)
     if (testKey) {
-      jdbcUpdate(
-        s"create table $dbtable(c1 BIT(4) primary key)"
+      createTable(
+        "create table `%s`.`%s`(c1 BIT(4) primary key)",
+        table
       )
     } else {
-      jdbcUpdate(
-        s"create table $dbtable(c1 BIT(4))"
+      createTable(
+        "create table `%s`.`%s`(c1 BIT(4))",
+        table
       )
     }
 
@@ -129,6 +132,7 @@ class BitOverflowSuite extends BaseDataSourceTest("test_data_type_bit_overflow")
     compareTiDBWriteFailureWithJDBC(
       List(row),
       schema,
+      table,
       jdbcErrorClass,
       jdbcErrorMsg,
       tidbErrorClass,
@@ -138,22 +142,24 @@ class BitOverflowSuite extends BaseDataSourceTest("test_data_type_bit_overflow")
   }
 
   test("Test BIT(4) Lower bound Overflow") {
-    testBit4LowerBound(false)
+    testBit4LowerBound(testKey = false, "bit4_lower_bound_overflow")
   }
 
   test("Test BIT(4) as key Lower bound Overflow") {
-    testBit4LowerBound(true)
+    testBit4LowerBound(testKey = true, "key_bit4_lower_bound_overflow")
   }
 
-  private def testBit4LowerBound(testKey: Boolean): Unit = {
-    dropTable()
+  private def testBit4LowerBound(testKey: Boolean, table: String): Unit = {
+    dropTable(table)
     if (testKey) {
-      jdbcUpdate(
-        s"create table $dbtable(c1 BIT(4) primary key)"
+      createTable(
+        "create table `%s`.`%s`(c1 BIT(4) primary key)",
+        table
       )
     } else {
-      jdbcUpdate(
-        s"create table $dbtable(c1 BIT(4))"
+      createTable(
+        "create table `%s`.`%s`(c1 BIT(4))",
+        table
       )
     }
 
@@ -171,6 +177,7 @@ class BitOverflowSuite extends BaseDataSourceTest("test_data_type_bit_overflow")
     compareTiDBWriteFailureWithJDBC(
       List(row),
       schema,
+      table,
       jdbcErrorClass,
       jdbcErrorMsg,
       tidbErrorClass,
@@ -180,23 +187,24 @@ class BitOverflowSuite extends BaseDataSourceTest("test_data_type_bit_overflow")
   }
 
   test("Test BIT(8) Upper bound Overflow") {
-    testBit8UpperBound(false)
+    testBit8UpperBound(testKey = false, "bit8_upper_bound_overflow")
   }
 
   test("Test BIT(8) as key Upper bound Overflow") {
-    testBit8UpperBound(true)
+    testBit8UpperBound(testKey = true, "bit8_upper_bound_overflow")
   }
 
-  private def testBit8UpperBound(testKey: Boolean): Unit = {
-
-    dropTable()
+  private def testBit8UpperBound(testKey: Boolean, table: String): Unit = {
+    dropTable(table)
     if (testKey) {
-      jdbcUpdate(
-        s"create table $dbtable(c1 BIT(8) primary key)"
+      createTable(
+        "create table `%s`.`%s`(c1 BIT(8) primary key)",
+        table
       )
     } else {
-      jdbcUpdate(
-        s"create table $dbtable(c1 BIT(8))"
+      createTable(
+        "create table `%s`.`%s`(c1 BIT(8))",
+        table
       )
     }
 
@@ -214,6 +222,7 @@ class BitOverflowSuite extends BaseDataSourceTest("test_data_type_bit_overflow")
     compareTiDBWriteFailureWithJDBC(
       List(row),
       schema,
+      table,
       jdbcErrorClass,
       jdbcErrorMsg,
       tidbErrorClass,
@@ -223,22 +232,24 @@ class BitOverflowSuite extends BaseDataSourceTest("test_data_type_bit_overflow")
   }
 
   test("Test BIT(8) Lower bound Overflow") {
-    testBit8LowerBound(false)
+    testBit8LowerBound(testKey = false, "bit8_lower_bound_overflow")
   }
 
   test("Test BIT(8) as key Lower bound Overflow") {
-    testBit8LowerBound(true)
+    testBit8LowerBound(testKey = true, "key_bit8_lower_bound_overflow")
   }
 
-  private def testBit8LowerBound(testKey: Boolean): Unit = {
-    dropTable()
+  private def testBit8LowerBound(testKey: Boolean, table: String): Unit = {
+    dropTable(table)
     if (testKey) {
-      jdbcUpdate(
-        s"create table $dbtable(c1 BIT(8) primary key)"
+      createTable(
+        "create table `%s`.`%s`(c1 BIT(8) primary key)",
+        table
       )
     } else {
-      jdbcUpdate(
-        s"create table $dbtable(c1 BIT(8))"
+      createTable(
+        "create table `%s`.`%s`(c1 BIT(8))",
+        table
       )
     }
 
@@ -256,6 +267,7 @@ class BitOverflowSuite extends BaseDataSourceTest("test_data_type_bit_overflow")
     compareTiDBWriteFailureWithJDBC(
       List(row),
       schema,
+      table,
       jdbcErrorClass,
       jdbcErrorMsg,
       tidbErrorClass,
@@ -263,11 +275,4 @@ class BitOverflowSuite extends BaseDataSourceTest("test_data_type_bit_overflow")
       msgStartWith = true
     )
   }
-
-  override def afterAll(): Unit =
-    try {
-      dropTable()
-    } finally {
-      super.afterAll()
-    }
 }

--- a/core/src/test/scala/com/pingcap/tispark/overflow/BytesOverflowSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/overflow/BytesOverflowSuite.scala
@@ -13,25 +13,25 @@ import org.apache.spark.sql.types._
  * 5. MEDIUMBLOB
  * 6. LONGBLOB
  */
-class BytesOverflowSuite extends BaseDataSourceTest("test_data_type_bytes_overflow") {
+class BytesOverflowSuite extends BaseDataSourceTest {
 
   test("Test BINARY Overflow") {
-    testBinaryOverflow(false)
+    testBinaryOverflow(testKey = false, "binary_overflow")
   }
 
   test("Test BINARY as key Overflow") {
-    testBinaryOverflow(true)
+    testBinaryOverflow(testKey = true, "key_binary_overflow")
   }
 
-  private def testBinaryOverflow(testKey: Boolean): Unit = {
-    dropTable()
+  private def testBinaryOverflow(testKey: Boolean, table: String): Unit = {
+    dropTable(table)
     if (testKey) {
       jdbcUpdate(
-        s"create table $dbtable(c1 BINARY(8), primary key (c1(4)))"
+        s"create table `$database`.`$table`(c1 BINARY(8), primary key (c1(4)))"
       )
     } else {
       jdbcUpdate(
-        s"create table $dbtable(c1 BINARY(8))"
+        s"create table `$database`.`$table`(c1 BINARY(8))"
       )
     }
 
@@ -49,6 +49,7 @@ class BytesOverflowSuite extends BaseDataSourceTest("test_data_type_bytes_overfl
     compareTiDBWriteFailureWithJDBC(
       List(row),
       schema,
+      table,
       jdbcErrorClass,
       jdbcErrorMsg,
       tidbErrorClass,
@@ -57,22 +58,22 @@ class BytesOverflowSuite extends BaseDataSourceTest("test_data_type_bytes_overfl
   }
 
   test("Test VARBINARY Overflow") {
-    testVarbinaryOverflow(false)
+    testVarbinaryOverflow(testKey = false, "var_overflow")
   }
 
   test("Test VARBINARY as key Overflow") {
-    testVarbinaryOverflow(true)
+    testVarbinaryOverflow(testKey = true, "key_var_overflow")
   }
 
-  private def testVarbinaryOverflow(testKey: Boolean): Unit = {
-    dropTable()
+  private def testVarbinaryOverflow(testKey: Boolean, table: String): Unit = {
+    dropTable(table)
     if (testKey) {
       jdbcUpdate(
-        s"create table $dbtable(c1 VARBINARY(8), primary key (c1(4)))"
+        s"create table `$database`.`$table`(c1 VARBINARY(8), primary key (c1(4)))"
       )
     } else {
       jdbcUpdate(
-        s"create table $dbtable(c1 VARBINARY(8))"
+        s"create table `$database`.`$table`(c1 VARBINARY(8))"
       )
     }
 
@@ -90,6 +91,7 @@ class BytesOverflowSuite extends BaseDataSourceTest("test_data_type_bytes_overfl
     compareTiDBWriteFailureWithJDBC(
       List(row),
       schema,
+      table,
       jdbcErrorClass,
       jdbcErrorMsg,
       tidbErrorClass,
@@ -98,22 +100,22 @@ class BytesOverflowSuite extends BaseDataSourceTest("test_data_type_bytes_overfl
   }
 
   test("Test TINYBLOB Overflow") {
-    testTinyBlobOverflow(false)
+    testTinyBlobOverflow(testKey = false, "tinyblob_overflow")
   }
 
   test("Test TINYBLOB as key Overflow") {
-    testTinyBlobOverflow(true)
+    testTinyBlobOverflow(testKey = true, "key_tingblob_overflow")
   }
 
-  private def testTinyBlobOverflow(testKey: Boolean): Unit = {
-    dropTable()
+  private def testTinyBlobOverflow(testKey: Boolean, table: String): Unit = {
+    dropTable(table)
     if (testKey) {
       jdbcUpdate(
-        s"create table $dbtable(c1 TINYBLOB, primary key (c1(4)))"
+        s"create table `$database`.`$table`(c1 TINYBLOB, primary key (c1(4)))"
       )
     } else {
       jdbcUpdate(
-        s"create table $dbtable(c1 TINYBLOB)"
+        s"create table `$database`.`$table`(c1 TINYBLOB)"
       )
     }
 
@@ -137,17 +139,11 @@ class BytesOverflowSuite extends BaseDataSourceTest("test_data_type_bytes_overfl
     compareTiDBWriteFailureWithJDBC(
       List(row),
       schema,
+      table,
       jdbcErrorClass,
       jdbcErrorMsg,
       tidbErrorClass,
       tidbErrorMsg
     )
   }
-
-  override def afterAll(): Unit =
-    try {
-      dropTable()
-    } finally {
-      super.afterAll()
-    }
 }

--- a/core/src/test/scala/com/pingcap/tispark/overflow/DateOverflowSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/overflow/DateOverflowSuite.scala
@@ -8,25 +8,27 @@ import org.apache.spark.sql.types._
  * DATE type include:
  * 1. DATE
  */
-class DateOverflowSuite extends BaseDataSourceTest("test_data_type_date_overflow") {
+class DateOverflowSuite extends BaseDataSourceTest {
 
   test("Test DATE YEAR Upper bound Overflow") {
-    testYearOverflow(false)
+    testYearOverflow(testKey = false, "date_year_upper_bound_overflow")
   }
 
   test("Test DATE as key YEAR Upper bound Overflow") {
-    testYearOverflow(true)
+    testYearOverflow(testKey = true, "key_date_year_upper_bound_overflow")
   }
 
-  private def testYearOverflow(testKey: Boolean): Unit = {
-    dropTable()
+  private def testYearOverflow(testKey: Boolean, table: String): Unit = {
+    dropTable(table)
     if (testKey) {
-      jdbcUpdate(
-        s"create table $dbtable(c1 DATE primary key)"
+      createTable(
+        "create table `%s`.`%s`(c1 DATE primary key)",
+        table
       )
     } else {
-      jdbcUpdate(
-        s"create table $dbtable(c1 DATE)"
+      createTable(
+        "create table `%s`.`%s`(c1 DATE)",
+        table
       )
     }
 
@@ -44,6 +46,7 @@ class DateOverflowSuite extends BaseDataSourceTest("test_data_type_date_overflow
     compareTiDBWriteFailureWithJDBC(
       List(row),
       schema,
+      table,
       jdbcErrorClass,
       jdbcErrorMsg,
       tidbErrorClass,
@@ -52,22 +55,24 @@ class DateOverflowSuite extends BaseDataSourceTest("test_data_type_date_overflow
   }
 
   test("Test DATE Month Upper bound Overflow") {
-    testMonthOverflow(false)
+    testMonthOverflow(testKey = false, "date_month_upper_bound_overflow")
   }
 
   test("Test DATE as key Month Upper bound Overflow") {
-    testMonthOverflow(true)
+    testMonthOverflow(testKey = true, "key_date_month_upper_bound_overflow")
   }
 
-  private def testMonthOverflow(testKey: Boolean): Unit = {
-    dropTable()
+  private def testMonthOverflow(testKey: Boolean, table: String): Unit = {
+    dropTable(table)
     if (testKey) {
-      jdbcUpdate(
-        s"create table $dbtable(c1 DATE primary key)"
+      createTable(
+        "create table `%s`.`%s`(c1 DATE primary key)",
+        table
       )
     } else {
-      jdbcUpdate(
-        s"create table $dbtable(c1 DATE)"
+      createTable(
+        "create table `%s`.`%s`(c1 DATE)",
+        table
       )
     }
 
@@ -85,6 +90,7 @@ class DateOverflowSuite extends BaseDataSourceTest("test_data_type_date_overflow
     compareTiDBWriteFailureWithJDBC(
       List(row),
       schema,
+      table,
       jdbcErrorClass,
       jdbcErrorMsgStart,
       tidbErrorClass,
@@ -92,11 +98,4 @@ class DateOverflowSuite extends BaseDataSourceTest("test_data_type_date_overflow
       msgStartWith = true
     )
   }
-
-  override def afterAll(): Unit =
-    try {
-      dropTable()
-    } finally {
-      super.afterAll()
-    }
 }

--- a/core/src/test/scala/com/pingcap/tispark/overflow/DateTimeOverflowSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/overflow/DateTimeOverflowSuite.scala
@@ -8,26 +8,27 @@ import org.apache.spark.sql.types._
  * DATETIME type include:
  * 1. DATETIME
  */
-class DateTimeOverflowSuite extends BaseDataSourceTest("test_data_type_datetime_overflow") {
+class DateTimeOverflowSuite extends BaseDataSourceTest {
 
   test("Test DATETIME YEAR Overflow") {
-    testDateTimeOverflow(false)
+    testDateTimeOverflow(testKey = false, "datetime_year_overflow")
   }
 
   test("Test DATETIME as key YEAR Overflow") {
-    testDateTimeOverflow(true)
+    testDateTimeOverflow(testKey = true, "key_datetime_year_overflow")
   }
 
-  private def testDateTimeOverflow(testKey: Boolean): Unit = {
-
-    dropTable()
+  private def testDateTimeOverflow(testKey: Boolean, table: String): Unit = {
+    dropTable(table)
     if (testKey) {
-      jdbcUpdate(
-        s"create table $dbtable(c1 DATETIME(6) primary key)"
+      createTable(
+        "create table `%s`.`%s`(c1 DATETIME(6) primary key)",
+        table
       )
     } else {
-      jdbcUpdate(
-        s"create table $dbtable(c1 DATETIME(6))"
+      createTable(
+        "create table `%s`.`%s`(c1 DATETIME(6))",
+        table
       )
     }
 
@@ -45,17 +46,11 @@ class DateTimeOverflowSuite extends BaseDataSourceTest("test_data_type_datetime_
     compareTiDBWriteFailureWithJDBC(
       List(row),
       schema,
+      table,
       jdbcErrorClass,
       jdbcErrorMsg,
       tidbErrorClass,
       tidbErrorMsg
     )
   }
-
-  override def afterAll(): Unit =
-    try {
-      dropTable()
-    } finally {
-      super.afterAll()
-    }
 }

--- a/core/src/test/scala/com/pingcap/tispark/overflow/EnumOverflowSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/overflow/EnumOverflowSuite.scala
@@ -8,23 +8,25 @@ import org.apache.spark.sql.types._
  * ENUM type include:
  * 1. ENUM
  */
-class EnumOverflowSuite extends BaseDataSourceTest("test_data_type_enum_overflow") {
+class EnumOverflowSuite extends BaseDataSourceTest {
 
   test("Test ENUM Value Overflow") {
-    testEnumValueOverflow(false)
+    testEnumValueOverflow(testKey = false, "enum_val_overflow")
   }
 
   test("Test ENUM as key Value Overflow") {
-    testEnumValueOverflow(true)
+    testEnumValueOverflow(testKey = true, "key_enum_val_overflow")
   }
 
-  private def testEnumValueOverflow(testKey: Boolean): Unit = {
-
-    dropTable()
+  private def testEnumValueOverflow(testKey: Boolean, table: String): Unit = {
+    dropTable(table)
     if (testKey) {
-      jdbcUpdate(s"create table $dbtable(c1 ENUM('male', 'female', 'both', 'unknown') primary key)")
+      createTable(
+        "create table `%s`.`%s`(c1 ENUM('male', 'female', 'both', 'unknown') primary key)",
+        table
+      )
     } else {
-      jdbcUpdate(s"create table $dbtable(c1 ENUM('male', 'female', 'both', 'unknown'))")
+      createTable("create table `%s`.`%s`(c1 ENUM('male', 'female', 'both', 'unknown'))", table)
     }
 
     val row = Row("abc")
@@ -41,6 +43,7 @@ class EnumOverflowSuite extends BaseDataSourceTest("test_data_type_enum_overflow
     compareTiDBWriteFailureWithJDBC(
       List(row),
       schema,
+      table,
       jdbcErrorClass,
       jdbcErrorMsg,
       tidbErrorClass,
@@ -49,20 +52,22 @@ class EnumOverflowSuite extends BaseDataSourceTest("test_data_type_enum_overflow
   }
 
   test("Test ENUM Number Overflow") {
-    testEnumNumberOverflow(false)
+    testEnumNumberOverflow(testKey = false, "enum_number_overflow")
   }
 
   test("Test ENUM as key Number Overflow") {
-    testEnumNumberOverflow(true)
+    testEnumNumberOverflow(testKey = true, "key_enum_number_overflow")
   }
 
-  private def testEnumNumberOverflow(testKey: Boolean): Unit = {
-
-    dropTable()
+  private def testEnumNumberOverflow(testKey: Boolean, table: String): Unit = {
+    dropTable(table)
     if (testKey) {
-      jdbcUpdate(s"create table $dbtable(c1 ENUM('male', 'female', 'both', 'unknown') primary key)")
+      createTable(
+        s"create table `%s`.`%s`(c1 ENUM('male', 'female', 'both', 'unknown') primary key)",
+        table
+      )
     } else {
-      jdbcUpdate(s"create table $dbtable(c1 ENUM('male', 'female', 'both', 'unknown'))")
+      createTable(s"create table `%s`.`%s`(c1 ENUM('male', 'female', 'both', 'unknown'))", table)
     }
 
     val row = Row("5")
@@ -79,17 +84,11 @@ class EnumOverflowSuite extends BaseDataSourceTest("test_data_type_enum_overflow
     compareTiDBWriteFailureWithJDBC(
       List(row),
       schema,
+      table,
       jdbcErrorClass,
       jdbcErrorMsg,
       tidbErrorClass,
       tidbErrorMsg
     )
   }
-
-  override def afterAll(): Unit =
-    try {
-      dropTable()
-    } finally {
-      super.afterAll()
-    }
 }

--- a/core/src/test/scala/com/pingcap/tispark/overflow/SignedOverflowSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/overflow/SignedOverflowSuite.scala
@@ -13,25 +13,27 @@ import org.apache.spark.sql.types._
  * 5. BIGINT SINGED
  * 6. BOOLEAN
  */
-class SignedOverflowSuite extends BaseDataSourceTest("test_data_type_signed_overflow") {
+class SignedOverflowSuite extends BaseDataSourceTest {
 
   test("Test TINYINT Upper bound Overflow") {
-    testTinyIntUpperBound(false)
+    testTinyIntUpperBound(testKey = false, "tinyint_upper_bound_overflow")
   }
 
   test("Test TINYINT as key Upper bound Overflow") {
-    testTinyIntUpperBound(true)
+    testTinyIntUpperBound(testKey = true, "key_tinyint_upper_bound_overflow")
   }
 
-  private def testTinyIntUpperBound(testKey: Boolean): Unit = {
-    dropTable()
+  private def testTinyIntUpperBound(testKey: Boolean, table: String): Unit = {
+    dropTable(table)
     if (testKey) {
-      jdbcUpdate(
-        s"create table $dbtable(c1 TINYINT primary key)"
+      createTable(
+        "create table `%s`.`%s`(c1 TINYINT primary key)",
+        table
       )
     } else {
-      jdbcUpdate(
-        s"create table $dbtable(c1 TINYINT)"
+      createTable(
+        "create table `%s`.`%s`(c1 TINYINT)",
+        table
       )
     }
 
@@ -49,6 +51,7 @@ class SignedOverflowSuite extends BaseDataSourceTest("test_data_type_signed_over
     compareTiDBWriteFailureWithJDBC(
       List(row),
       schema,
+      table,
       jdbcErrorClass,
       jdbcErrorMsg,
       tidbErrorClass,
@@ -57,22 +60,24 @@ class SignedOverflowSuite extends BaseDataSourceTest("test_data_type_signed_over
   }
 
   test("Test TINYINT Lower bound Overflow") {
-    testTinyIntLowerBound(false)
+    testTinyIntLowerBound(testKey = false, "tinyint_lower_bound_overflow")
   }
 
   test("Test TINYINT as key Lower bound Overflow") {
-    testTinyIntLowerBound(true)
+    testTinyIntLowerBound(testKey = true, "key_tinyint_lower_bound_overflow")
   }
 
-  private def testTinyIntLowerBound(testKey: Boolean): Unit = {
-    dropTable()
+  private def testTinyIntLowerBound(testKey: Boolean, table: String): Unit = {
+    dropTable(table)
     if (testKey) {
-      jdbcUpdate(
-        s"create table $dbtable(c1 TINYINT primary key)"
+      createTable(
+        "create table `%s`.`%s`(c1 TINYINT primary key)",
+        table
       )
     } else {
-      jdbcUpdate(
-        s"create table $dbtable(c1 TINYINT)"
+      createTable(
+        "create table `%s`.`%s`(c1 TINYINT)",
+        table
       )
     }
 
@@ -90,6 +95,7 @@ class SignedOverflowSuite extends BaseDataSourceTest("test_data_type_signed_over
     compareTiDBWriteFailureWithJDBC(
       List(row),
       schema,
+      table,
       jdbcErrorClass,
       jdbcErrorMsg,
       tidbErrorClass,
@@ -98,22 +104,24 @@ class SignedOverflowSuite extends BaseDataSourceTest("test_data_type_signed_over
   }
 
   test("Test SMALLINT Upper bound Overflow") {
-    testSmallIntUpperBound(false)
+    testSmallIntUpperBound(testKey = false, "smallint_upper_bound_overflow")
   }
 
   test("Test SMALLINT as key Upper bound Overflow") {
-    testSmallIntUpperBound(true)
+    testSmallIntUpperBound(testKey = true, "key_smallint_upper_bound_overflow")
   }
 
-  private def testSmallIntUpperBound(testKey: Boolean): Unit = {
-    dropTable()
+  private def testSmallIntUpperBound(testKey: Boolean, table: String): Unit = {
+    dropTable(table)
     if (testKey) {
-      jdbcUpdate(
-        s"create table $dbtable(c1 SMALLINT primary key)"
+      createTable(
+        "create table `%s`.`%s`(c1 SMALLINT primary key)",
+        table
       )
     } else {
-      jdbcUpdate(
-        s"create table $dbtable(c1 SMALLINT)"
+      createTable(
+        "create table `%s`.`%s`(c1 SMALLINT)",
+        table
       )
     }
 
@@ -131,6 +139,7 @@ class SignedOverflowSuite extends BaseDataSourceTest("test_data_type_signed_over
     compareTiDBWriteFailureWithJDBC(
       List(row),
       schema,
+      table,
       jdbcErrorClass,
       jdbcErrorMsg,
       tidbErrorClass,
@@ -139,22 +148,24 @@ class SignedOverflowSuite extends BaseDataSourceTest("test_data_type_signed_over
   }
 
   test("Test SMALLINT Lower bound Overflow") {
-    testSmallIntLowerBound(false)
+    testSmallIntLowerBound(testKey = false, "small_int_lower_bound_overflow")
   }
 
   test("Test SMALLINT as key Lower bound Overflow") {
-    testSmallIntLowerBound(true)
+    testSmallIntLowerBound(testKey = true, "key_small_int_lower_bound_overflow")
   }
 
-  private def testSmallIntLowerBound(testKey: Boolean): Unit = {
-    dropTable()
+  private def testSmallIntLowerBound(testKey: Boolean, table: String): Unit = {
+    dropTable(table)
     if (testKey) {
-      jdbcUpdate(
-        s"create table $dbtable(c1 SMALLINT primary key)"
+      createTable(
+        "create table `%s`.`%s`(c1 SMALLINT primary key)",
+        table
       )
     } else {
-      jdbcUpdate(
-        s"create table $dbtable(c1 SMALLINT)"
+      createTable(
+        "create table `%s`.`%s`(c1 SMALLINT)",
+        table
       )
     }
 
@@ -172,6 +183,7 @@ class SignedOverflowSuite extends BaseDataSourceTest("test_data_type_signed_over
     compareTiDBWriteFailureWithJDBC(
       List(row),
       schema,
+      table,
       jdbcErrorClass,
       jdbcErrorMsg,
       tidbErrorClass,
@@ -180,22 +192,24 @@ class SignedOverflowSuite extends BaseDataSourceTest("test_data_type_signed_over
   }
 
   test("Test MEDIUMINT Upper bound Overflow") {
-    testMediumIntUpperBound(false)
+    testMediumIntUpperBound(testKey = false, "mediumint_upper_bound_overflow")
   }
 
   test("Test MEDIUMINT as key Upper bound Overflow") {
-    testMediumIntUpperBound(true)
+    testMediumIntUpperBound(testKey = true, "key_mediumint_upper_bound_overflow")
   }
 
-  private def testMediumIntUpperBound(testKey: Boolean): Unit = {
-    dropTable()
+  private def testMediumIntUpperBound(testKey: Boolean, table: String): Unit = {
+    dropTable(table)
     if (testKey) {
-      jdbcUpdate(
-        s"create table $dbtable(c1 MEDIUMINT primary key)"
+      createTable(
+        "create table `%s`.`%s`(c1 MEDIUMINT primary key)",
+        table
       )
     } else {
-      jdbcUpdate(
-        s"create table $dbtable(c1 MEDIUMINT)"
+      createTable(
+        "create table `%s`.`%s`(c1 MEDIUMINT)",
+        table
       )
     }
 
@@ -213,6 +227,7 @@ class SignedOverflowSuite extends BaseDataSourceTest("test_data_type_signed_over
     compareTiDBWriteFailureWithJDBC(
       List(row),
       schema,
+      table,
       jdbcErrorClass,
       jdbcErrorMsg,
       tidbErrorClass,
@@ -221,22 +236,24 @@ class SignedOverflowSuite extends BaseDataSourceTest("test_data_type_signed_over
   }
 
   test("Test MEDIUMINT Lower bound Overflow") {
-    testMediumIntLowerBound(false)
+    testMediumIntLowerBound(testKey = false, "mediumint_lower_bound_overflow")
   }
 
   test("Test MEDIUMINT as key Lower bound Overflow") {
-    testMediumIntLowerBound(true)
+    testMediumIntLowerBound(testKey = true, "key_mediumint_lower_bound_overflow")
   }
 
-  private def testMediumIntLowerBound(testKey: Boolean): Unit = {
-    dropTable()
+  private def testMediumIntLowerBound(testKey: Boolean, table: String): Unit = {
+    dropTable(table)
     if (testKey) {
-      jdbcUpdate(
-        s"create table $dbtable(c1 MEDIUMINT primary key)"
+      createTable(
+        "create table `%s`.`%s`(c1 MEDIUMINT primary key)",
+        table
       )
     } else {
-      jdbcUpdate(
-        s"create table $dbtable(c1 MEDIUMINT)"
+      createTable(
+        "create table `%s`.`%s`(c1 MEDIUMINT)",
+        table
       )
     }
 
@@ -254,6 +271,7 @@ class SignedOverflowSuite extends BaseDataSourceTest("test_data_type_signed_over
     compareTiDBWriteFailureWithJDBC(
       List(row),
       schema,
+      table,
       jdbcErrorClass,
       jdbcErrorMsg,
       tidbErrorClass,
@@ -262,22 +280,24 @@ class SignedOverflowSuite extends BaseDataSourceTest("test_data_type_signed_over
   }
 
   test("Test INT Upper bound Overflow") {
-    testIntUpperBound(false)
+    testIntUpperBound(testKey = false, "int_upper_bound_overflow")
   }
 
   test("Test INT as key Upper bound Overflow") {
-    testIntUpperBound(true)
+    testIntUpperBound(testKey = true, "key_int_upper_bound_overflow")
   }
 
-  private def testIntUpperBound(testKey: Boolean): Unit = {
-    dropTable()
+  private def testIntUpperBound(testKey: Boolean, table: String): Unit = {
+    dropTable(table)
     if (testKey) {
-      jdbcUpdate(
-        s"create table $dbtable(c1 INT primary key)"
+      createTable(
+        "create table `%s`.`%s`(c1 INT primary key)",
+        table
       )
     } else {
-      jdbcUpdate(
-        s"create table $dbtable(c1 INT)"
+      createTable(
+        "create table `%s`.`%s`(c1 INT)",
+        table
       )
     }
 
@@ -295,6 +315,7 @@ class SignedOverflowSuite extends BaseDataSourceTest("test_data_type_signed_over
     compareTiDBWriteFailureWithJDBC(
       List(row),
       schema,
+      table,
       jdbcErrorClass,
       jdbcErrorMsg,
       tidbErrorClass,
@@ -303,22 +324,24 @@ class SignedOverflowSuite extends BaseDataSourceTest("test_data_type_signed_over
   }
 
   test("Test INT Lower bound Overflow") {
-    testIntLowerBound(false)
+    testIntLowerBound(testKey = false, "int_lower_bound_overflow")
   }
 
   test("Test INT as key Lower bound Overflow") {
-    testIntLowerBound(true)
+    testIntLowerBound(testKey = true, "key_int_lower_bound_overflow")
   }
 
-  private def testIntLowerBound(testKey: Boolean): Unit = {
-    dropTable()
+  private def testIntLowerBound(testKey: Boolean, table: String): Unit = {
+    dropTable(table)
     if (testKey) {
-      jdbcUpdate(
-        s"create table $dbtable(c1 INT primary key)"
+      createTable(
+        "create table `%s`.`%s`(c1 INT primary key)",
+        table
       )
     } else {
-      jdbcUpdate(
-        s"create table $dbtable(c1 INT)"
+      createTable(
+        "create table `%s`.`%s`(c1 INT)",
+        table
       )
     }
 
@@ -336,6 +359,7 @@ class SignedOverflowSuite extends BaseDataSourceTest("test_data_type_signed_over
     compareTiDBWriteFailureWithJDBC(
       List(row),
       schema,
+      table,
       jdbcErrorClass,
       jdbcErrorMsg,
       tidbErrorClass,
@@ -344,22 +368,24 @@ class SignedOverflowSuite extends BaseDataSourceTest("test_data_type_signed_over
   }
 
   test("Test BIGINT Upper bound Overflow") {
-    testBigIntUpperBound(false)
+    testBigIntUpperBound(testKey = false, "big_int_upper_bound_overflow")
   }
 
   test("Test BIGINT as key Upper bound Overflow") {
-    testBigIntUpperBound(true)
+    testBigIntUpperBound(testKey = true, "key_big_int_upper_bound_overflow")
   }
 
-  private def testBigIntUpperBound(testKey: Boolean): Unit = {
-    dropTable()
+  private def testBigIntUpperBound(testKey: Boolean, table: String): Unit = {
+    dropTable(table)
     if (testKey) {
-      jdbcUpdate(
-        s"create table $dbtable(c1 BIGINT primary key)"
+      createTable(
+        "create table `%s`.`%s`(c1 BIGINT primary key)",
+        table
       )
     } else {
-      jdbcUpdate(
-        s"create table $dbtable(c1 BIGINT)"
+      createTable(
+        "create table `%s`.`%s`(c1 BIGINT)",
+        table
       )
     }
 
@@ -377,6 +403,7 @@ class SignedOverflowSuite extends BaseDataSourceTest("test_data_type_signed_over
     compareTiDBWriteFailureWithJDBC(
       List(row),
       schema,
+      table,
       jdbcErrorClass,
       jdbcErrorMsg,
       tidbErrorClass,
@@ -385,22 +412,24 @@ class SignedOverflowSuite extends BaseDataSourceTest("test_data_type_signed_over
   }
 
   test("Test BIGINT Lower bound Overflow") {
-    testBigIntLowerBound(false)
+    testBigIntLowerBound(testKey = false, "big_int_lower_bound_overflow")
   }
 
   test("Test BIGINT as key Lower bound Overflow") {
-    testBigIntLowerBound(true)
+    testBigIntLowerBound(testKey = true, "key_big_int_lower_bound_overflow")
   }
 
-  private def testBigIntLowerBound(testKey: Boolean): Unit = {
-    dropTable()
+  private def testBigIntLowerBound(testKey: Boolean, table: String): Unit = {
+    dropTable(table)
     if (testKey) {
-      jdbcUpdate(
-        s"create table $dbtable(c1 BIGINT primary key)"
+      createTable(
+        "create table `%s`.`%s`(c1 BIGINT primary key)",
+        table
       )
     } else {
-      jdbcUpdate(
-        s"create table $dbtable(c1 BIGINT)"
+      createTable(
+        "create table `%s`.`%s`(c1 BIGINT)",
+        table
       )
     }
 
@@ -418,6 +447,7 @@ class SignedOverflowSuite extends BaseDataSourceTest("test_data_type_signed_over
     compareTiDBWriteFailureWithJDBC(
       List(row),
       schema,
+      table,
       jdbcErrorClass,
       jdbcErrorMsg,
       tidbErrorClass,
@@ -426,22 +456,24 @@ class SignedOverflowSuite extends BaseDataSourceTest("test_data_type_signed_over
   }
 
   test("Test BOOLEAN Upper bound Overflow") {
-    testBooleanUpperBound(false)
+    testBooleanUpperBound(testKey = false, "boolean_upper_bound_overflow")
   }
 
   test("Test BOOLEAN as key Upper bound Overflow") {
-    testBooleanUpperBound(true)
+    testBooleanUpperBound(testKey = true, "key_boolean_upper_bound_overflow")
   }
 
-  private def testBooleanUpperBound(testKey: Boolean): Unit = {
-    dropTable()
+  private def testBooleanUpperBound(testKey: Boolean, table: String): Unit = {
+    dropTable(table)
     if (testKey) {
-      jdbcUpdate(
-        s"create table $dbtable(c1 BOOLEAN primary key)"
+      createTable(
+        "create table `%s`.`%s`(c1 BOOLEAN primary key)",
+        table
       )
     } else {
-      jdbcUpdate(
-        s"create table $dbtable(c1 BOOLEAN)"
+      createTable(
+        "create table `%s`.`%s`(c1 BOOLEAN)",
+        table
       )
     }
 
@@ -459,6 +491,7 @@ class SignedOverflowSuite extends BaseDataSourceTest("test_data_type_signed_over
     compareTiDBWriteFailureWithJDBC(
       List(row),
       schema,
+      table,
       jdbcErrorClass,
       jdbcErrorMsg,
       tidbErrorClass,
@@ -467,22 +500,24 @@ class SignedOverflowSuite extends BaseDataSourceTest("test_data_type_signed_over
   }
 
   test("Test BOOLEAN Lower bound Overflow") {
-    testBooleanLowerBound(false)
+    testBooleanLowerBound(testKey = false, "boolean_lower_bound_overflow")
   }
 
   test("Test BOOLEAN as key Lower bound Overflow") {
-    testBooleanLowerBound(true)
+    testBooleanLowerBound(testKey = true, "key_boolean_lower_bound_overflow")
   }
 
-  private def testBooleanLowerBound(testKey: Boolean): Unit = {
-    dropTable()
+  private def testBooleanLowerBound(testKey: Boolean, table: String): Unit = {
+    dropTable(table)
     if (testKey) {
-      jdbcUpdate(
-        s"create table $dbtable(c1 BOOLEAN primary key)"
+      createTable(
+        "create table `%s`.`%s`(c1 BOOLEAN primary key)",
+        table
       )
     } else {
-      jdbcUpdate(
-        s"create table $dbtable(c1 BOOLEAN)"
+      createTable(
+        "create table `%s`.`%s`(c1 BOOLEAN)",
+        table
       )
     }
 
@@ -500,17 +535,11 @@ class SignedOverflowSuite extends BaseDataSourceTest("test_data_type_signed_over
     compareTiDBWriteFailureWithJDBC(
       List(row),
       schema,
+      table,
       jdbcErrorClass,
       jdbcErrorMsg,
       tidbErrorClass,
       tidbErrorMsg
     )
   }
-
-  override def afterAll(): Unit =
-    try {
-      dropTable()
-    } finally {
-      super.afterAll()
-    }
 }

--- a/core/src/test/scala/com/pingcap/tispark/overflow/StringOverflowSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/overflow/StringOverflowSuite.scala
@@ -13,25 +13,27 @@ import org.apache.spark.sql.types.{StructField, _}
  * 5. MEDIUMTEXT
  * 6. LONGTEXT
  */
-class StringOverflowSuite extends BaseDataSourceTest("test_data_type_string_overflow") {
+class StringOverflowSuite extends BaseDataSourceTest {
 
   test("Test CHAR Overflow") {
-    testCharOverflow(false)
+    testCharOverflow(testKey = false, "char_overflow")
   }
 
   test("Test CHAR as key Overflow") {
-    testCharOverflow(true)
+    testCharOverflow(testKey = true, "key_char_overflow")
   }
 
-  private def testCharOverflow(testKey: Boolean): Unit = {
-    dropTable()
+  private def testCharOverflow(testKey: Boolean, table: String): Unit = {
+    dropTable(table)
     if (testKey) {
-      jdbcUpdate(
-        s"create table $dbtable(c1 CHAR(8) primary key)"
+      createTable(
+        "create table `%s`.`%s`(c1 CHAR(8) primary key)",
+        table
       )
     } else {
-      jdbcUpdate(
-        s"create table $dbtable(c1 CHAR(8))"
+      createTable(
+        "create table `%s`.`%s`(c1 CHAR(8))",
+        table
       )
     }
 
@@ -49,6 +51,7 @@ class StringOverflowSuite extends BaseDataSourceTest("test_data_type_string_over
     compareTiDBWriteFailureWithJDBC(
       List(row),
       schema,
+      table,
       jdbcErrorClass,
       jdbcErrorMsg,
       tidbErrorClass,
@@ -57,22 +60,24 @@ class StringOverflowSuite extends BaseDataSourceTest("test_data_type_string_over
   }
 
   test("Test VARCHAR Overflow") {
-    testVarcharOverflow(false)
+    testVarcharOverflow(testKey = false, "varchar_overflow")
   }
 
   test("Test VARCHAR as key Overflow") {
-    testVarcharOverflow(true)
+    testVarcharOverflow(testKey = true, "key_varchar_overflow")
   }
 
-  private def testVarcharOverflow(testKey: Boolean): Unit = {
-    dropTable()
+  private def testVarcharOverflow(testKey: Boolean, table: String): Unit = {
+    dropTable(table)
     if (testKey) {
-      jdbcUpdate(
-        s"create table $dbtable(c1 VARCHAR(8) primary key)"
+      createTable(
+        "create table `%s`.`%s`(c1 VARCHAR(8) primary key)",
+        table
       )
     } else {
-      jdbcUpdate(
-        s"create table $dbtable(c1 VARCHAR(8))"
+      createTable(
+        "create table `%s`.`%s`(c1 VARCHAR(8))",
+        table
       )
     }
 
@@ -90,6 +95,7 @@ class StringOverflowSuite extends BaseDataSourceTest("test_data_type_string_over
     compareTiDBWriteFailureWithJDBC(
       List(row),
       schema,
+      table,
       jdbcErrorClass,
       jdbcErrorMsg,
       tidbErrorClass,
@@ -98,22 +104,24 @@ class StringOverflowSuite extends BaseDataSourceTest("test_data_type_string_over
   }
 
   test("Test TINYTEXT Overflow") {
-    testTinyTextOverflow(false)
+    testTinyTextOverflow(testKey = false, "tiny_text_overflow")
   }
 
   test("Test TINYTEXT as key Overflow") {
-    testTinyTextOverflow(true)
+    testTinyTextOverflow(testKey = true, "key_tiny_text_overflow")
   }
 
-  private def testTinyTextOverflow(testKey: Boolean): Unit = {
-    dropTable()
+  private def testTinyTextOverflow(testKey: Boolean, table: String): Unit = {
+    dropTable(table)
     if (testKey) {
-      jdbcUpdate(
-        s"create table $dbtable(c1 TINYTEXT, primary key (c1(4)))"
+      createTable(
+        "create table `%s`.`%s`(c1 TINYTEXT, primary key (c1(4)))",
+        table
       )
     } else {
-      jdbcUpdate(
-        s"create table $dbtable(c1 TINYTEXT)"
+      createTable(
+        "create table `%s`.`%s`(c1 TINYTEXT)",
+        table
       )
     }
 
@@ -136,6 +144,7 @@ class StringOverflowSuite extends BaseDataSourceTest("test_data_type_string_over
     compareTiDBWriteFailureWithJDBC(
       List(row),
       schema,
+      table,
       jdbcErrorClass,
       jdbcErrorMsg,
       tidbErrorClass,
@@ -144,22 +153,24 @@ class StringOverflowSuite extends BaseDataSourceTest("test_data_type_string_over
   }
 
   test("Test TEXT Overflow") {
-    testTextOverflow(false)
+    testTextOverflow(testKey = false, "text_overflow")
   }
 
   test("Test TEXT as key Overflow") {
-    testTextOverflow(true)
+    testTextOverflow(testKey = true, "key_text_overflow")
   }
 
-  private def testTextOverflow(testKey: Boolean): Unit = {
-    dropTable()
+  private def testTextOverflow(testKey: Boolean, table: String): Unit = {
+    dropTable(table)
     if (testKey) {
-      jdbcUpdate(
-        s"create table $dbtable(c1 TEXT(8), primary key (c1(4)))"
+      createTable(
+        "create table `%s`.`%s`(c1 TEXT(8), primary key (c1(4)))",
+        table
       )
     } else {
-      jdbcUpdate(
-        s"create table $dbtable(c1 TEXT(8))"
+      createTable(
+        "create table `%s`.`%s`(c1 TEXT(8))",
+        table
       )
     }
 
@@ -177,17 +188,11 @@ class StringOverflowSuite extends BaseDataSourceTest("test_data_type_string_over
     compareTiDBWriteFailureWithJDBC(
       List(row),
       schema,
+      table,
       jdbcErrorClass,
       jdbcErrorMsg,
       tidbErrorClass,
       tidbErrorMsg
     )
   }
-
-  override def afterAll(): Unit =
-    try {
-      dropTable()
-    } finally {
-      super.afterAll()
-    }
 }

--- a/core/src/test/scala/com/pingcap/tispark/overflow/UnsignedOverflowSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/overflow/UnsignedOverflowSuite.scala
@@ -12,25 +12,27 @@ import org.apache.spark.sql.types._
  * 4. INT UNSIGNED
  * 5. BIGINT UNSIGNED
  */
-class UnsignedOverflowSuite extends BaseDataSourceTest("test_data_type_unsigned_overflow") {
+class UnsignedOverflowSuite extends BaseDataSourceTest {
 
   test("Test TINYINT UNSIGNED Upper bound Overflow") {
-    testTinyIntUnsignedUpperBound(false)
+    testTinyIntUnsignedUpperBound(testKey = false, "tiny_int_unsigned_upper_bound_overflow")
   }
 
   test("Test TINYINT UNSIGNED as key Upper bound Overflow") {
-    testTinyIntUnsignedUpperBound(true)
+    testTinyIntUnsignedUpperBound(testKey = true, "key_tiny_int_unsigned_upper_bound_overflow")
   }
 
-  private def testTinyIntUnsignedUpperBound(testKey: Boolean): Unit = {
-    dropTable()
+  private def testTinyIntUnsignedUpperBound(testKey: Boolean, table: String): Unit = {
+    dropTable(table)
     if (testKey) {
-      jdbcUpdate(
-        s"create table $dbtable(c1 TINYINT UNSIGNED primary key)"
+      createTable(
+        "create table `%s`.`%s`(c1 TINYINT UNSIGNED primary key)",
+        table
       )
     } else {
-      jdbcUpdate(
-        s"create table $dbtable(c1 TINYINT UNSIGNED)"
+      createTable(
+        "create table `%s`.`%s`(c1 TINYINT UNSIGNED)",
+        table
       )
     }
 
@@ -48,6 +50,7 @@ class UnsignedOverflowSuite extends BaseDataSourceTest("test_data_type_unsigned_
     compareTiDBWriteFailureWithJDBC(
       List(row),
       schema,
+      table,
       jdbcErrorClass,
       jdbcErrorMsg,
       tidbErrorClass,
@@ -56,22 +59,24 @@ class UnsignedOverflowSuite extends BaseDataSourceTest("test_data_type_unsigned_
   }
 
   test("Test TINYINT UNSIGNED Lower bound Overflow") {
-    testTinyIntUnsignedLowerBound(false)
+    testTinyIntUnsignedLowerBound(testKey = false, "tiny_int_unsigned_lower_bound_overflow")
   }
 
   test("Test TINYINT UNSIGNED as key Lower bound Overflow") {
-    testTinyIntUnsignedLowerBound(false)
+    testTinyIntUnsignedLowerBound(testKey = true, "key_tiny_int_unsigned_lower_bound_overflow")
   }
 
-  private def testTinyIntUnsignedLowerBound(testKey: Boolean): Unit = {
-    dropTable()
+  private def testTinyIntUnsignedLowerBound(testKey: Boolean, table: String): Unit = {
+    dropTable(table)
     if (testKey) {
-      jdbcUpdate(
-        s"create table $dbtable(c1 TINYINT UNSIGNED primary key)"
+      createTable(
+        "create table `%s`.`%s`(c1 TINYINT UNSIGNED primary key)",
+        table
       )
     } else {
-      jdbcUpdate(
-        s"create table $dbtable(c1 TINYINT UNSIGNED)"
+      createTable(
+        "create table `%s`.`%s`(c1 TINYINT UNSIGNED)",
+        table
       )
     }
 
@@ -89,6 +94,7 @@ class UnsignedOverflowSuite extends BaseDataSourceTest("test_data_type_unsigned_
     compareTiDBWriteFailureWithJDBC(
       List(row),
       schema,
+      table,
       jdbcErrorClass,
       jdbcErrorMsg,
       tidbErrorClass,
@@ -97,22 +103,24 @@ class UnsignedOverflowSuite extends BaseDataSourceTest("test_data_type_unsigned_
   }
 
   test("Test SMALLINT UNSIGNED Upper bound Overflow") {
-    testSmallIntUnsignedUpperBound(false)
+    testSmallIntUnsignedUpperBound(testKey = false, "small_int_unsigned_upper_bound_overflow")
   }
 
   test("Test SMALLINT UNSIGNED as key Upper bound Overflow") {
-    testSmallIntUnsignedUpperBound(true)
+    testSmallIntUnsignedUpperBound(testKey = true, "key_small_int_unsigned_upper_bound_overflow")
   }
 
-  private def testSmallIntUnsignedUpperBound(testKey: Boolean): Unit = {
-    dropTable()
+  private def testSmallIntUnsignedUpperBound(testKey: Boolean, table: String): Unit = {
+    dropTable(table)
     if (testKey) {
-      jdbcUpdate(
-        s"create table $dbtable(c1 SMALLINT UNSIGNED primary key)"
+      createTable(
+        "create table `%s`.`%s`(c1 SMALLINT UNSIGNED primary key)",
+        table
       )
     } else {
-      jdbcUpdate(
-        s"create table $dbtable(c1 SMALLINT UNSIGNED)"
+      createTable(
+        "create table `%s`.`%s`(c1 SMALLINT UNSIGNED)",
+        table
       )
     }
 
@@ -130,6 +138,7 @@ class UnsignedOverflowSuite extends BaseDataSourceTest("test_data_type_unsigned_
     compareTiDBWriteFailureWithJDBC(
       List(row),
       schema,
+      table,
       jdbcErrorClass,
       jdbcErrorMsg,
       tidbErrorClass,
@@ -138,22 +147,24 @@ class UnsignedOverflowSuite extends BaseDataSourceTest("test_data_type_unsigned_
   }
 
   test("Test SMALLINT UNSIGNED Lower bound Overflow") {
-    testSmallIntUnsignedLowerBound(false)
+    testSmallIntUnsignedLowerBound(testKey = false, "small_int_unsigned_lower_bound_overflow")
   }
 
   test("Test SMALLINT UNSIGNED as key Lower bound Overflow") {
-    testSmallIntUnsignedLowerBound(true)
+    testSmallIntUnsignedLowerBound(testKey = true, "key_small_int_unsigned_lower_bound_overflow")
   }
 
-  private def testSmallIntUnsignedLowerBound(testKey: Boolean): Unit = {
-    dropTable()
+  private def testSmallIntUnsignedLowerBound(testKey: Boolean, table: String): Unit = {
+    dropTable(table)
     if (testKey) {
-      jdbcUpdate(
-        s"create table $dbtable(c1 SMALLINT UNSIGNED primary key)"
+      createTable(
+        "create table `%s`.`%s`(c1 SMALLINT UNSIGNED primary key)",
+        table
       )
     } else {
-      jdbcUpdate(
-        s"create table $dbtable(c1 SMALLINT UNSIGNED)"
+      createTable(
+        "create table `%s`.`%s`(c1 SMALLINT UNSIGNED)",
+        table
       )
     }
 
@@ -171,6 +182,7 @@ class UnsignedOverflowSuite extends BaseDataSourceTest("test_data_type_unsigned_
     compareTiDBWriteFailureWithJDBC(
       List(row),
       schema,
+      table,
       jdbcErrorClass,
       jdbcErrorMsg,
       tidbErrorClass,
@@ -179,22 +191,24 @@ class UnsignedOverflowSuite extends BaseDataSourceTest("test_data_type_unsigned_
   }
 
   test("Test MEDIUMINT UNSIGNED Upper bound Overflow") {
-    testMediumIntUnsignedUpperBound(false)
+    testMediumIntUnsignedUpperBound(testKey = false, "medium_int_unsigned_upper_bound_overflow")
   }
 
   test("Test MEDIUMINT UNSIGNED as key Upper bound Overflow") {
-    testMediumIntUnsignedUpperBound(true)
+    testMediumIntUnsignedUpperBound(testKey = true, "key_medium_int_unsigned_upper_bound_overflow")
   }
 
-  private def testMediumIntUnsignedUpperBound(testKey: Boolean): Unit = {
-    dropTable()
+  private def testMediumIntUnsignedUpperBound(testKey: Boolean, table: String): Unit = {
+    dropTable(table)
     if (testKey) {
-      jdbcUpdate(
-        s"create table $dbtable(c1 MEDIUMINT UNSIGNED primary key)"
+      createTable(
+        "create table `%s`.`%s`(c1 MEDIUMINT UNSIGNED primary key)",
+        table
       )
     } else {
-      jdbcUpdate(
-        s"create table $dbtable(c1 MEDIUMINT UNSIGNED)"
+      createTable(
+        "create table `%s`.`%s`(c1 MEDIUMINT UNSIGNED)",
+        table
       )
     }
 
@@ -212,6 +226,7 @@ class UnsignedOverflowSuite extends BaseDataSourceTest("test_data_type_unsigned_
     compareTiDBWriteFailureWithJDBC(
       List(row),
       schema,
+      table,
       jdbcErrorClass,
       jdbcErrorMsg,
       tidbErrorClass,
@@ -220,22 +235,24 @@ class UnsignedOverflowSuite extends BaseDataSourceTest("test_data_type_unsigned_
   }
 
   test("Test MEDIUMINT UNSIGNED Lower bound Overflow") {
-    testMediumIntUnsignedLowerBound(false)
+    testMediumIntUnsignedLowerBound(testKey = false, "medium_int_unsigned_lower_bound_overflow")
   }
 
   test("Test MEDIUMINT UNSIGNED as key Lower bound Overflow") {
-    testMediumIntUnsignedLowerBound(true)
+    testMediumIntUnsignedLowerBound(testKey = true, "key_medium_int_unsigned_lower_bound_overflow")
   }
 
-  private def testMediumIntUnsignedLowerBound(testKey: Boolean): Unit = {
-    dropTable()
+  private def testMediumIntUnsignedLowerBound(testKey: Boolean, table: String): Unit = {
+    dropTable(table)
     if (testKey) {
-      jdbcUpdate(
-        s"create table $dbtable(c1 MEDIUMINT UNSIGNED primary key)"
+      createTable(
+        "create table `%s`.`%s`(c1 MEDIUMINT UNSIGNED primary key)",
+        table
       )
     } else {
-      jdbcUpdate(
-        s"create table $dbtable(c1 MEDIUMINT UNSIGNED)"
+      createTable(
+        "create table `%s`.`%s`(c1 MEDIUMINT UNSIGNED)",
+        table
       )
     }
 
@@ -253,6 +270,7 @@ class UnsignedOverflowSuite extends BaseDataSourceTest("test_data_type_unsigned_
     compareTiDBWriteFailureWithJDBC(
       List(row),
       schema,
+      table,
       jdbcErrorClass,
       jdbcErrorMsg,
       tidbErrorClass,
@@ -261,22 +279,24 @@ class UnsignedOverflowSuite extends BaseDataSourceTest("test_data_type_unsigned_
   }
 
   test("Test INT UNSIGNED Upper bound Overflow") {
-    testIntUnsignedUpperBound(false)
+    testIntUnsignedUpperBound(testKey = false, "int_unsigned_upper_bound_overflow")
   }
 
   test("Test INT UNSIGNED as key Upper bound Overflow") {
-    testIntUnsignedUpperBound(true)
+    testIntUnsignedUpperBound(testKey = true, "key_int_unsigned_upper_bound_overflow")
   }
 
-  private def testIntUnsignedUpperBound(testKey: Boolean): Unit = {
-    dropTable()
+  private def testIntUnsignedUpperBound(testKey: Boolean, table: String): Unit = {
+    dropTable(table)
     if (testKey) {
-      jdbcUpdate(
-        s"create table $dbtable(c1 INT UNSIGNED primary key)"
+      createTable(
+        "create table `%s`.`%s`(c1 INT UNSIGNED primary key)",
+        table
       )
     } else {
-      jdbcUpdate(
-        s"create table $dbtable(c1 INT UNSIGNED)"
+      createTable(
+        "create table `%s`.`%s`(c1 INT UNSIGNED)",
+        table
       )
     }
 
@@ -294,6 +314,7 @@ class UnsignedOverflowSuite extends BaseDataSourceTest("test_data_type_unsigned_
     compareTiDBWriteFailureWithJDBC(
       List(row),
       schema,
+      table,
       jdbcErrorClass,
       jdbcErrorMsg,
       tidbErrorClass,
@@ -302,22 +323,24 @@ class UnsignedOverflowSuite extends BaseDataSourceTest("test_data_type_unsigned_
   }
 
   test("Test INT UNSIGNED Lower bound Overflow") {
-    testIntUnsignedLowerBound(false)
+    testIntUnsignedLowerBound(testKey = false, "unsigned_lower_bound_overflow")
   }
 
   test("Test INT UNSIGNED as key Lower bound Overflow") {
-    testIntUnsignedLowerBound(true)
+    testIntUnsignedLowerBound(testKey = true, "key_unsigned_lower_bound_overflow")
   }
 
-  private def testIntUnsignedLowerBound(testKey: Boolean): Unit = {
-    dropTable()
+  private def testIntUnsignedLowerBound(testKey: Boolean, table: String): Unit = {
+    dropTable(table)
     if (testKey) {
-      jdbcUpdate(
-        s"create table $dbtable(c1 INT UNSIGNED primary key)"
+      createTable(
+        "create table `%s`.`%s`(c1 INT UNSIGNED primary key)",
+        table
       )
     } else {
-      jdbcUpdate(
-        s"create table $dbtable(c1 INT UNSIGNED)"
+      createTable(
+        "create table `%s`.`%s`(c1 INT UNSIGNED)",
+        table
       )
     }
 
@@ -337,6 +360,7 @@ class UnsignedOverflowSuite extends BaseDataSourceTest("test_data_type_unsigned_
     compareTiDBWriteFailureWithJDBC(
       List(row),
       schema,
+      table,
       jdbcErrorClass,
       jdbcErrorMsgStartWith,
       tidbErrorClass,
@@ -346,22 +370,24 @@ class UnsignedOverflowSuite extends BaseDataSourceTest("test_data_type_unsigned_
   }
 
   test("Test BIGINT UNSIGNED Upper bound Overflow") {
-    testBigIntUnsignedUpperBound(false)
+    testBigIntUnsignedUpperBound(testKey = false, "big_int_unsigned_upper_bound_overflow")
   }
 
   test("Test BIGINT UNSIGNED as key Upper bound Overflow") {
-    testBigIntUnsignedUpperBound(true)
+    testBigIntUnsignedUpperBound(testKey = true, "key_big_int_unsigned_upper_bound_overflow")
   }
 
-  private def testBigIntUnsignedUpperBound(testKey: Boolean): Unit = {
-    dropTable()
+  private def testBigIntUnsignedUpperBound(testKey: Boolean, table: String): Unit = {
+    dropTable(table)
     if (testKey) {
-      jdbcUpdate(
-        s"create table $dbtable(c1 BIGINT UNSIGNED primary key)"
+      createTable(
+        "create table `%s`.`%s`(c1 BIGINT UNSIGNED primary key)",
+        table
       )
     } else {
-      jdbcUpdate(
-        s"create table $dbtable(c1 BIGINT UNSIGNED)"
+      createTable(
+        "create table `%s`.`%s`(c1 BIGINT UNSIGNED)",
+        table
       )
     }
 
@@ -379,6 +405,7 @@ class UnsignedOverflowSuite extends BaseDataSourceTest("test_data_type_unsigned_
     compareTiDBWriteFailureWithJDBC(
       List(row),
       schema,
+      table,
       jdbcErrorClass,
       jdbcErrorMsg,
       tidbErrorClass,
@@ -387,22 +414,24 @@ class UnsignedOverflowSuite extends BaseDataSourceTest("test_data_type_unsigned_
   }
 
   test("Test BIGINT UNSIGNED Lower bound Overflow") {
-    testBigIntUnsignedLowerBound(false)
+    testBigIntUnsignedLowerBound(false, "big_int_unsigned_lower_bound_overflow")
   }
 
   test("Test BIGINT UNSIGNED as key Lower bound Overflow") {
-    testBigIntUnsignedLowerBound(true)
+    testBigIntUnsignedLowerBound(true, "big_int_unsigned_lower_bound_overflow")
   }
 
-  private def testBigIntUnsignedLowerBound(testKey: Boolean): Unit = {
-    dropTable()
+  private def testBigIntUnsignedLowerBound(testKey: Boolean, table: String): Unit = {
+    dropTable(table)
     if (testKey) {
-      jdbcUpdate(
-        s"create table $dbtable(c1 BIGINT UNSIGNED primary key)"
+      createTable(
+        "create table `%s`.`%s`(c1 BIGINT UNSIGNED primary key)",
+        table
       )
     } else {
-      jdbcUpdate(
-        s"create table $dbtable(c1 BIGINT UNSIGNED)"
+      createTable(
+        "create table `%s`.`%s`(c1 BIGINT UNSIGNED)",
+        table
       )
     }
 
@@ -420,17 +449,11 @@ class UnsignedOverflowSuite extends BaseDataSourceTest("test_data_type_unsigned_
     compareTiDBWriteFailureWithJDBC(
       List(row),
       schema,
+      table,
       jdbcErrorClass,
       jdbcErrorMsg,
       tidbErrorClass,
       tidbErrorMsg
     )
   }
-
-  override def afterAll(): Unit =
-    try {
-      dropTable()
-    } finally {
-      super.afterAll()
-    }
 }

--- a/core/src/test/scala/org/apache/spark/sql/TimezoneTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/TimezoneTestSuite.scala
@@ -135,7 +135,7 @@ class TimezoneTestSuite extends BaseTiSparkTest {
     val testData = "2019-11-11 11:11:11.0"
     val rowData = Row(testData)
     val schema = StructType(List(StructField("c1", StringType)))
-    tidbWrite(List(rowData), schema)
+    tidbWriteWithTable(List(rowData), schema)
 
     val resultData = queryTiDBViaJDBC(s"select * from $table").head.head
 
@@ -153,16 +153,16 @@ class TimezoneTestSuite extends BaseTiSparkTest {
     val testData = "2019-11-11 11:11:11.0"
     val rowData = Row(testData)
     val schema = StructType(List(StructField("c1", StringType)))
-    tidbWrite(List(rowData), schema)
+    tidbWriteWithTable(List(rowData), schema)
 
     val resultData = queryTiDBViaJDBC(s"select * from $table").head.head
 
     assert(testData.equals(resultData.toString))
   }
 
-  protected def tidbWrite(rows: List[Row],
-                          schema: StructType,
-                          param: Option[Map[String, String]] = None): Unit = {
+  protected def tidbWriteWithTable(rows: List[Row],
+                                   schema: StructType,
+                                   param: Option[Map[String, String]] = None): Unit = {
     val data: RDD[Row] = sc.makeRDD(rows)
     val df = sqlContext.createDataFrame(data, schema)
     df.write

--- a/core/src/test/scala/org/apache/spark/sql/insertion/BatchWritePKAndUniqueIndexSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/insertion/BatchWritePKAndUniqueIndexSuite.scala
@@ -10,7 +10,6 @@ import org.apache.spark.sql.test.generator.TestDataGenerator._
 
 class BatchWritePKAndUniqueIndexSuite
     extends BaseDataSourceTest(
-      "batch_write_insertion_pk_and_one_unique_index",
       "batch_write_test_index"
     )
     with EnumerateUniqueIndexDataTypeTestAction {
@@ -59,7 +58,8 @@ class BatchWritePKAndUniqueIndexSuite
   }
 
   test("test pk and unique indices cases") {
-    val schemas = genSchema(dataTypes, table)
+    val tablePrefix = "pk_and_unique_indices"
+    val schemas = genSchema(dataTypes, tablePrefix)
 
     schemas.foreach { schema =>
       dropAndCreateTbl(schema)
@@ -72,11 +72,4 @@ class BatchWritePKAndUniqueIndexSuite
 
   // this is only for mute the warning
   override def test(): Unit = {}
-
-  override def afterAll(): Unit =
-    try {
-      dropTable()
-    } finally {
-      super.afterAll()
-    }
 }

--- a/core/src/test/scala/org/apache/spark/sql/insertion/BatchWritePkSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/insertion/BatchWritePkSuite.scala
@@ -9,7 +9,7 @@ import org.apache.spark.sql.test.generator.Schema
 import org.apache.spark.sql.test.generator.TestDataGenerator._
 
 class BatchWritePkSuite
-    extends BaseDataSourceTest("batch_write_insertion_pk", "batch_write_test_pk")
+    extends BaseDataSourceTest("batch_write_test_pk")
     with EnumeratePKDataTypeTestAction {
   // TODO: support binary insertion.
   override val dataTypes: List[ReflectedDataType] = integers ::: decimals ::: doubles ::: charCharset
@@ -56,7 +56,8 @@ class BatchWritePkSuite
   }
 
   test("test pk cases") {
-    val schemas = genSchema(dataTypes, table)
+    val tablePrefix = "pk_batch_write_insertion"
+    val schemas = genSchema(dataTypes, tablePrefix)
 
     schemas.foreach { schema =>
       dropAndCreateTbl(schema)
@@ -69,11 +70,4 @@ class BatchWritePkSuite
 
   // this is only for mute the warning
   override def test(): Unit = {}
-
-  override def afterAll(): Unit =
-    try {
-      dropTable()
-    } finally {
-      super.afterAll()
-    }
 }

--- a/core/src/test/scala/org/apache/spark/sql/insertion/BatchWriteUniqueIndexSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/insertion/BatchWriteUniqueIndexSuite.scala
@@ -9,7 +9,7 @@ import org.apache.spark.sql.test.generator.Schema
 import org.apache.spark.sql.test.generator.TestDataGenerator._
 
 class BatchWriteUniqueIndexSuite
-    extends BaseDataSourceTest("batch_write_insertion_one_unique_index", "batch_write_test_index")
+    extends BaseDataSourceTest("batch_write_test_index")
     with EnumerateUniqueIndexDataTypeTestAction {
   // TODO: support binary insertion.
   override val dataTypes: List[ReflectedDataType] = integers ::: decimals ::: doubles ::: charCharset
@@ -56,7 +56,8 @@ class BatchWriteUniqueIndexSuite
   }
 
   test("test unique indices cases") {
-    val schemas = genSchema(dataTypes, table)
+    val tablePrefx = "unique_indices_batch_write_insertion"
+    val schemas = genSchema(dataTypes, tablePrefx)
 
     schemas.foreach { schema =>
       dropAndCreateTbl(schema)
@@ -69,11 +70,4 @@ class BatchWriteUniqueIndexSuite
 
   // this is only for mute the warning
   override def test(): Unit = {}
-
-  override def afterAll(): Unit =
-    try {
-      dropTable()
-    } finally {
-      super.afterAll()
-    }
 }


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

In this PR, we start to use a different table name for different test cases.  It closes #1040 
### What is changed and how it works?
Use different table name can avoid ddl changes that TiSpark cannot detect. 


