### PR TITLE
adding recreate flag when create tisession

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/TiContext.scala
+++ b/core/src/main/scala/org/apache/spark/sql/TiContext.scala
@@ -43,7 +43,7 @@ class TiContext(val sparkSession: SparkSession, options: Option[TiDBOptions] = N
   lazy val sqlContext: SQLContext = sparkSession.sqlContext
   val conf: SparkConf = mergeWithDataSourceConfig(sparkSession.sparkContext.conf, options)
   val tiConf: TiConfiguration = TiUtil.sparkConfToTiConf(conf)
-  val tiSession: TiSession = TiSession.getInstance(tiConf)
+  val tiSession: TiSession = TiSession.getInstance(tiConf, true)
   val meta: MetaManager = new MetaManager(tiSession.getCatalog)
 
   StatisticsManager.initStatisticsManager(tiSession)

--- a/core/src/test/scala/com/pingcap/tispark/datasource/BaseDataSourceTest.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/BaseDataSourceTest.scala
@@ -36,8 +36,6 @@ class BaseDataSourceTest(val table: String,
 
   protected def dropTable(): Unit = {
     jdbcUpdate(s"drop table if exists $dbtable")
-    // If we reuse tiSession, cache in catalog will be outdated after dropping and creating table.
-    TiSession.clearCache()
   }
 
   protected def dropTable(tblName: String): Unit = {

--- a/tikv-client/src/main/java/com/pingcap/tikv/TiSession.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/TiSession.java
@@ -61,16 +61,7 @@ public class TiSession implements AutoCloseable {
   // Since we create session as singleton now, configuration change will not
   // reflect change
   public static TiSession getInstance(TiConfiguration conf) {
-    synchronized (sessionCachedMap) {
-      String key = conf.getPdAddrsString();
-      if (sessionCachedMap.containsKey(key)) {
-        return sessionCachedMap.get(key);
-      }
-
-      TiSession newSession = new TiSession(conf);
-      sessionCachedMap.put(key, newSession);
-      return newSession;
-    }
+  	return getInstance(conf, false);
   }
 
   private TiSession(TiConfiguration conf) {

--- a/tikv-client/src/main/java/com/pingcap/tikv/TiSession.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/TiSession.java
@@ -46,16 +46,16 @@ public class TiSession implements AutoCloseable {
   private static final Map<String, TiSession> sessionCachedMap = new HashMap<>();
 
   public static TiSession getInstance(TiConfiguration conf, boolean recreate) {
-		synchronized (sessionCachedMap) {
-			String key = conf.getPdAddrsString();
-			if (sessionCachedMap.containsKey(key) && !recreate) {
-				return sessionCachedMap.get(key);
-			}
+    synchronized (sessionCachedMap) {
+      String key = conf.getPdAddrsString();
+      if (sessionCachedMap.containsKey(key) && !recreate) {
+        return sessionCachedMap.get(key);
+      }
 
-			TiSession newSession = new TiSession(conf);
-			sessionCachedMap.put(key, newSession);
-			return newSession;
-		}
+      TiSession newSession = new TiSession(conf);
+      sessionCachedMap.put(key, newSession);
+      return newSession;
+    }
   }
 
   // Since we create session as singleton now, configuration change will not

--- a/tikv-client/src/main/java/com/pingcap/tikv/TiSession.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/TiSession.java
@@ -45,6 +45,19 @@ public class TiSession implements AutoCloseable {
 
   private static final Map<String, TiSession> sessionCachedMap = new HashMap<>();
 
+  public static TiSession getInstance(TiConfiguration conf, boolean recreate) {
+		synchronized (sessionCachedMap) {
+			String key = conf.getPdAddrsString();
+			if (sessionCachedMap.containsKey(key) && !recreate) {
+				return sessionCachedMap.get(key);
+			}
+
+			TiSession newSession = new TiSession(conf);
+			sessionCachedMap.put(key, newSession);
+			return newSession;
+		}
+  }
+
   // Since we create session as singleton now, configuration change will not
   // reflect change
   public static TiSession getInstance(TiConfiguration conf) {
@@ -186,12 +199,6 @@ public class TiSession implements AutoCloseable {
    */
   public void injectCallBackFunc(Function<CacheInvalidateEvent, Void> callBackFunc) {
     this.cacheInvalidateCallback = callBackFunc;
-  }
-
-  public static void clearCache() {
-    synchronized (sessionCachedMap) {
-      sessionCachedMap.clear();
-    }
   }
 
   @Override

--- a/tikv-client/src/main/java/com/pingcap/tikv/TiSession.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/TiSession.java
@@ -61,7 +61,7 @@ public class TiSession implements AutoCloseable {
   // Since we create session as singleton now, configuration change will not
   // reflect change
   public static TiSession getInstance(TiConfiguration conf) {
-  	return getInstance(conf, false);
+    return getInstance(conf, false);
   }
 
   private TiSession(TiConfiguration conf) {

--- a/tikv-client/src/test/java/com/pingcap/tikv/txn/LockResolverSITest.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/txn/LockResolverSITest.java
@@ -41,7 +41,6 @@ public class LockResolverSITest extends LockResolverTest {
   public void setUp() {
     TiConfiguration conf = TiConfiguration.createDefault("127.0.0.1:2379");
     conf.setIsolationLevel(IsolationLevel.SI);
-    TiSession.clearCache();
     try {
       session = TiSession.getInstance(conf);
       this.builder = session.getRegionStoreClientBuilder();


### PR DESCRIPTION
After we remove `TiSession.create()` from codebase, our ci randomly reports no-such-table exception. In this PR, we add it back in a different way. 