### PR TITLE
Remove scala-lang from assembly jar to fix bug when use tispark in Livy

### DIFF
--- a/tikv-client/pom.xml
+++ b/tikv-client/pom.xml
@@ -359,6 +359,11 @@
                                     <shadedPattern>shade.com.google.common</shadedPattern>
                                 </relocation>
                             </relocations>
+                            <artifactSet>
+                                <excludes>
+                                    <exclude>org.scala-lang:*</exclude>
+                                </excludes>
+                            </artifactSet>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
### What problem does this PR solve? 
https://github.com/pingcap/tispark/issues/1076

### What is changed and how it works?
The bug reason is tispark include scala-lang class which is not compatible with livy. While it is not necessary to include scala-lang class in assembly jar, so I remove them all.

Similar issue: https://social.msdn.microsoft.com/Forums/azure/en-US/fe7bd433-bc38-4513-9bb6-a87641ccdcfe/import-external-jars-when-using-jupyter-notebook-with-spark-kernel?forum=hdinsight

### Check List <!--REMOVE the items that are not applicable-->

Tests 
Have tested manually

Code changes
build script changes

Side effects
May need to include scala-lang dependency if not using spark
