### PR TITLE
rename tispark core maven name

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -17,7 +17,7 @@
     <dependencies>
         <dependency>
             <groupId>com.pingcap.tispark</groupId>
-            <artifactId>tispark-core</artifactId>
+            <artifactId>tispark-core-internal</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
         <dependency>

--- a/assembly/src/main/assembly/assembly.xml
+++ b/assembly/src/main/assembly/assembly.xml
@@ -10,7 +10,7 @@
     <dependencySets>
         <dependencySet>
             <includes>
-                <include>com.pingcap.tispark:tispark-core:jar</include>
+                <include>com.pingcap.tispark:tispark-core-internal:jar</include>
                 <include>com.pingcap.tikv:tikv-client:jar</include>
                 <include>mysql:mysql-connector-java:jar</include>
             </includes>

--- a/core-test/pom.xml
+++ b/core-test/pom.xml
@@ -21,7 +21,7 @@
     <dependencies>
         <dependency>
             <groupId>com.pingcap.tispark</groupId>
-            <artifactId>tispark-core</artifactId>
+            <artifactId>tispark-core-internal</artifactId>
             <version>${project.parent.version}</version>
             <exclusions>
                 <exclusion>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -9,9 +9,9 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <artifactId>tispark-core</artifactId>
+    <artifactId>tispark-core-internal</artifactId>
     <packaging>jar</packaging>
-    <name>TiSpark Project Core</name>
+    <name>TiSpark Project Core Internal</name>
     <url>http://github.copm/pingcap/tispark</url>
 
     <properties>

--- a/spark-wrapper/spark-2.3/pom.xml
+++ b/spark-wrapper/spark-2.3/pom.xml
@@ -17,7 +17,7 @@
     <dependencies>
         <dependency>
             <groupId>com.pingcap.tispark</groupId>
-            <artifactId>tispark-core</artifactId>
+            <artifactId>tispark-core-internal</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
         <dependency>

--- a/spark-wrapper/spark-2.4/pom.xml
+++ b/spark-wrapper/spark-2.4/pom.xml
@@ -17,7 +17,7 @@
     <dependencies>
         <dependency>
             <groupId>com.pingcap.tispark</groupId>
-            <artifactId>tispark-core</artifactId>
+            <artifactId>tispark-core-internal</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
         <dependency>


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
When user upgrades from tispark-2.1.x to tispark-2.2.x, they may still use `tispark-core`, but they should use `tispark-assembly`.

### What is changed and how it works?
In this PR, we renamed tispark core maven name from `tispark-core` to `tispark-core-internal`.


close https://github.com/pingcap/tispark/issues/1096