### PR TITLE
Fix bug: TiSpark Catalog has 10-20s delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,6 @@ The configurations in the table below can be put together with `spark-defaults.c
 | `spark.tispark.pd.addresses` |  `127.0.0.1:2379` | The addresses of PD cluster, which are split by comma |
 | `spark.tispark.grpc.framesize` |  `268435456` | The maximum frame size of gRPC response |
 | `spark.tispark.grpc.timeout_in_sec` |  `10` | The gRPC timeout time in seconds |
-| `spark.tispark.meta.reload_period_in_sec` |  `60` | The reloading period of metastore in seconds |
 | `spark.tispark.plan.allow_agg_pushdown` |  `true` | Whether aggregations are allowed to push down to TiKV (in case of busy TiKV nodes) |
 | `spark.tispark.plan.allow_index_read` |  `true` |  Whether index is enabled in planning (which might cause heavy pressure on TiKV) |
 | `spark.tispark.index.scan_batch_size` |  `20000` | The number of row key in batch for the concurrent index scan |

--- a/core/src/main/scala/com/pingcap/tispark/MetaManager.scala
+++ b/core/src/main/scala/com/pingcap/tispark/MetaManager.scala
@@ -23,12 +23,6 @@ import scala.collection.JavaConversions._
 // Likely this needs to be merge to client project
 // and serving inside metastore if any
 class MetaManager(catalog: Catalog) {
-  def reloadAllMeta(): Unit =
-    catalog.reloadCache(true)
-
-  def reloadDBMeta(): Unit =
-    catalog.reloadCache()
-
   def getDatabases: List[TiDBInfo] =
     catalog.listDatabases().toList
 

--- a/core/src/main/scala/com/pingcap/tispark/TiConfigConst.scala
+++ b/core/src/main/scala/com/pingcap/tispark/TiConfigConst.scala
@@ -19,7 +19,6 @@ object TiConfigConst {
   val PD_ADDRESSES: String = "spark.tispark.pd.addresses"
   val GRPC_FRAME_SIZE: String = "spark.tispark.grpc.framesize"
   val GRPC_TIMEOUT: String = "spark.tispark.grpc.timeout_in_sec"
-  val META_RELOAD_PERIOD: String = "spark.tispark.meta.reload_period_in_sec"
   val GRPC_RETRY_TIMES: String = "spark.tispark.grpc.retry.times"
   val INDEX_SCAN_BATCH_SIZE: String = "spark.tispark.index.scan_batch_size"
   val INDEX_SCAN_CONCURRENCY: String = "spark.tispark.index.scan_concurrency"

--- a/core/src/main/scala/com/pingcap/tispark/utils/TiUtil.scala
+++ b/core/src/main/scala/com/pingcap/tispark/utils/TiUtil.scala
@@ -137,11 +137,6 @@ object TiUtil {
       tiConf.setTimeoutUnit(TimeUnit.SECONDS)
     }
 
-    if (conf.contains(TiConfigConst.META_RELOAD_PERIOD)) {
-      tiConf.setMetaReloadPeriod(conf.get(TiConfigConst.META_RELOAD_PERIOD).toInt)
-      tiConf.setMetaReloadPeriodUnit(TimeUnit.SECONDS)
-    }
-
     if (conf.contains(TiConfigConst.INDEX_SCAN_BATCH_SIZE)) {
       tiConf.setIndexScanBatchSize(conf.get(TiConfigConst.INDEX_SCAN_BATCH_SIZE).toInt)
     }

--- a/core/src/test/scala/org/apache/spark/sql/BaseTiSparkTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/BaseTiSparkTest.scala
@@ -124,7 +124,6 @@ class BaseTiSparkTest extends QueryTest with SharedSQLContext {
 
   protected def loadTestData(databases: Seq[String] = defaultTestDatabases): Unit =
     try {
-      //ti.meta.reloadAllMeta()
       tableNames = Seq.empty[String]
       for (dbName <- databases) {
         setCurrentDatabase(dbName)
@@ -178,7 +177,7 @@ class BaseTiSparkTest extends QueryTest with SharedSQLContext {
   }
 
   override protected def refreshConnections(): Unit = {
-    //super.refreshConnections()
+    super.refreshConnections()
     loadTestData()
   }
 

--- a/core/src/test/scala/org/apache/spark/sql/BaseTiSparkTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/BaseTiSparkTest.scala
@@ -124,7 +124,7 @@ class BaseTiSparkTest extends QueryTest with SharedSQLContext {
 
   protected def loadTestData(databases: Seq[String] = defaultTestDatabases): Unit =
     try {
-      ti.meta.reloadAllMeta()
+      //ti.meta.reloadAllMeta()
       tableNames = Seq.empty[String]
       for (dbName <- databases) {
         setCurrentDatabase(dbName)
@@ -178,7 +178,7 @@ class BaseTiSparkTest extends QueryTest with SharedSQLContext {
   }
 
   override protected def refreshConnections(): Unit = {
-    super.refreshConnections()
+    //super.refreshConnections()
     loadTestData()
   }
 

--- a/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
@@ -20,6 +20,26 @@ import org.apache.spark.sql.functions.{col, sum}
 
 class IssueTestSuite extends BaseTiSparkTest {
 
+  // https://github.com/pingcap/tispark/issues/1083
+  test("TiSpark Catalog has no delay") {
+    tidbStmt.execute("drop table if exists catalog_delay")
+    tidbStmt.execute("create table catalog_delay(c1 bigint)")
+    refreshConnections()
+    val tiTableInfo1 =
+      this.ti.tiSession.getCatalog.getTable(s"${dbPrefix}tispark_test", "catalog_delay")
+    assert("catalog_delay".equals(tiTableInfo1.getName))
+    assert("c1".equals(tiTableInfo1.getColumns.get(0).getName))
+
+    tidbStmt.execute("drop table if exists catalog_delay")
+    tidbStmt.execute("create table catalog_delay(c2 bigint)")
+    val tiTableInfo2 =
+      this.ti.tiSession.getCatalog.getTable(s"${dbPrefix}tispark_test", "catalog_delay")
+    assert("catalog_delay".equals(tiTableInfo2.getName))
+    assert("c2".equals(tiTableInfo2.getColumns.get(0).getName))
+
+    assert(tiTableInfo1.getId != tiTableInfo2.getId)
+  }
+
   // https://github.com/pingcap/tispark/issues/1039
   test("Distinct without alias throws NullPointerException") {
     tidbStmt.execute("drop table if exists t_distinct_alias")
@@ -325,6 +345,7 @@ class IssueTestSuite extends BaseTiSparkTest {
       tidbStmt.execute("drop table if exists set_t")
       tidbStmt.execute("drop table if exists enum_t")
       tidbStmt.execute("drop table if exists table_group_by_bigint")
+      tidbStmt.execute("drop table if exists catalog_delay")
     } finally {
       super.afterAll()
     }

--- a/core/src/test/scala/org/apache/spark/sql/test/SharedSQLContext.scala
+++ b/core/src/test/scala/org/apache/spark/sql/test/SharedSQLContext.scala
@@ -75,9 +75,7 @@ trait SharedSQLContext extends SparkFunSuite with Eventually with BeforeAndAfter
 
   protected def defaultTimeZone: TimeZone = SharedSQLContext.timeZone
 
-  protected def refreshConnections(): Unit = {
-    SharedSQLContext.refreshConnections(false)
-  }
+  protected def refreshConnections(): Unit = SharedSQLContext.refreshConnections(false)
 
   protected def refreshConnections(isHiveEnabled: Boolean): Unit =
     SharedSQLContext.refreshConnections(isHiveEnabled)
@@ -211,7 +209,7 @@ object SharedSQLContext extends Logging {
 
   protected var _sparkSession: SparkSession = _
 
-  private def refreshConnections(isHiveEnabled: Boolean): Unit = {
+  def refreshConnections(isHiveEnabled: Boolean): Unit = {
     stop()
     init(forceNotLoad = true, isHiveEnabled = isHiveEnabled)
   }

--- a/core/src/test/scala/org/apache/spark/sql/test/SharedSQLContext.scala
+++ b/core/src/test/scala/org/apache/spark/sql/test/SharedSQLContext.scala
@@ -75,7 +75,9 @@ trait SharedSQLContext extends SparkFunSuite with Eventually with BeforeAndAfter
 
   protected def defaultTimeZone: TimeZone = SharedSQLContext.timeZone
 
-  protected def refreshConnections(): Unit = SharedSQLContext.refreshConnections(false)
+  protected def refreshConnections(): Unit = {
+    //SharedSQLContext.refreshConnections(false)
+  }
 
   protected def refreshConnections(isHiveEnabled: Boolean): Unit =
     SharedSQLContext.refreshConnections(isHiveEnabled)

--- a/core/src/test/scala/org/apache/spark/sql/test/SharedSQLContext.scala
+++ b/core/src/test/scala/org/apache/spark/sql/test/SharedSQLContext.scala
@@ -76,7 +76,7 @@ trait SharedSQLContext extends SparkFunSuite with Eventually with BeforeAndAfter
   protected def defaultTimeZone: TimeZone = SharedSQLContext.timeZone
 
   protected def refreshConnections(): Unit = {
-    //SharedSQLContext.refreshConnections(false)
+    SharedSQLContext.refreshConnections(false)
   }
 
   protected def refreshConnections(isHiveEnabled: Boolean): Unit =
@@ -211,7 +211,7 @@ object SharedSQLContext extends Logging {
 
   protected var _sparkSession: SparkSession = _
 
-  def refreshConnections(isHiveEnabled: Boolean): Unit = {
+  private def refreshConnections(isHiveEnabled: Boolean): Unit = {
     stop()
     init(forceNotLoad = true, isHiveEnabled = isHiveEnabled)
   }

--- a/tikv-client/src/main/java/com/pingcap/tikv/TiConfiguration.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/TiConfiguration.java
@@ -32,8 +32,6 @@ public class TiConfiguration implements Serializable {
   private static final int DEF_SCAN_BATCH_SIZE = 100;
   private static final boolean DEF_IGNORE_TRUNCATE = true;
   private static final boolean DEF_TRUNCATE_AS_WARNING = false;
-  private static final int DEF_META_RELOAD_PERIOD = 10;
-  private static final TimeUnit DEF_META_RELOAD_UNIT = TimeUnit.SECONDS;
   private static final int DEF_MAX_FRAME_SIZE = 268435456 * 2; // 256 * 2 MB
   private static final int DEF_INDEX_SCAN_BATCH_SIZE = 20000;
   // if keyRange size per request exceeds this limit, the request might be too large to be accepted
@@ -54,8 +52,6 @@ public class TiConfiguration implements Serializable {
   private TimeUnit timeoutUnit = DEF_TIMEOUT_UNIT;
   private boolean ignoreTruncate = DEF_IGNORE_TRUNCATE;
   private boolean truncateAsWarning = DEF_TRUNCATE_AS_WARNING;
-  private TimeUnit metaReloadUnit = DEF_META_RELOAD_UNIT;
-  private int metaReloadPeriod = DEF_META_RELOAD_PERIOD;
   private int maxFrameSize = DEF_MAX_FRAME_SIZE;
   private List<URI> pdAddrs = new ArrayList<>();
   private int indexScanBatchSize = DEF_INDEX_SCAN_BATCH_SIZE;
@@ -97,24 +93,6 @@ public class TiConfiguration implements Serializable {
 
   public TimeUnit getTimeoutUnit() {
     return timeoutUnit;
-  }
-
-  public TimeUnit getMetaReloadPeriodUnit() {
-    return metaReloadUnit;
-  }
-
-  public TiConfiguration setMetaReloadPeriodUnit(TimeUnit timeUnit) {
-    this.metaReloadUnit = timeUnit;
-    return this;
-  }
-
-  public TiConfiguration setMetaReloadPeriod(int metaReloadPeriod) {
-    this.metaReloadPeriod = metaReloadPeriod;
-    return this;
-  }
-
-  public int getMetaReloadPeriod() {
-    return metaReloadPeriod;
   }
 
   public TiConfiguration setTimeoutUnit(TimeUnit timeoutUnit) {

--- a/tikv-client/src/main/java/com/pingcap/tikv/TiSession.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/TiSession.java
@@ -124,13 +124,7 @@ public class TiSession implements AutoCloseable {
     if (res == null) {
       synchronized (this) {
         if (catalog == null) {
-          catalog =
-              new Catalog(
-                  this::createSnapshot,
-                  conf.getMetaReloadPeriod(),
-                  conf.getMetaReloadPeriodUnit(),
-                  conf.ifShowRowId(),
-                  conf.getDBPrefix());
+          catalog = new Catalog(this::createSnapshot, conf.ifShowRowId(), conf.getDBPrefix());
         }
         res = catalog;
       }

--- a/tikv-client/src/main/java/com/pingcap/tikv/catalog/Catalog.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/catalog/Catalog.java
@@ -18,34 +18,24 @@ package com.pingcap.tikv.catalog;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.pingcap.tikv.Snapshot;
 import com.pingcap.tikv.meta.TiDBInfo;
 import com.pingcap.tikv.meta.TiTableInfo;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.apache.log4j.Logger;
 
 public class Catalog implements AutoCloseable {
   private Supplier<Snapshot> snapshotProvider;
-  private ScheduledExecutorService service;
   private CatalogCache metaCache;
   private final boolean showRowId;
   private final String dbPrefix;
   private final Logger logger = Logger.getLogger(this.getClass());
 
   @Override
-  public void close() throws Exception {
-    if (service != null) {
-      service.shutdownNow();
-      service.awaitTermination(1, TimeUnit.SECONDS);
-    }
-  }
+  public void close() {}
 
   private static class CatalogCache {
 
@@ -128,39 +118,14 @@ public class Catalog implements AutoCloseable {
     }
   }
 
-  public Catalog(
-      Supplier<Snapshot> snapshotProvider,
-      int refreshPeriod,
-      TimeUnit periodUnit,
-      boolean showRowId,
-      String dbPrefix) {
+  public Catalog(Supplier<Snapshot> snapshotProvider, boolean showRowId, String dbPrefix) {
     this.snapshotProvider = Objects.requireNonNull(snapshotProvider, "Snapshot Provider is null");
     this.showRowId = showRowId;
     this.dbPrefix = dbPrefix;
     metaCache = new CatalogCache(new CatalogTransaction(snapshotProvider.get()), dbPrefix, false);
-    service =
-        Executors.newSingleThreadScheduledExecutor(
-            new ThreadFactoryBuilder().setDaemon(true).build());
-    service.scheduleAtFixedRate(
-        () -> {
-          // Wrap this with a try catch block in case schedule update fails
-          try {
-            reloadCache(true);
-          } catch (Exception e) {
-            logger.warn("Reload Cache failed", e);
-          }
-        },
-        refreshPeriod,
-        refreshPeriod,
-        periodUnit);
   }
 
-  private CatalogCache getLatestMetaCache() {
-    reloadCache();
-    return metaCache;
-  }
-
-  public synchronized void reloadCache(boolean loadTables) {
+  private synchronized void reloadCache(boolean loadTables) {
     Snapshot snapshot = snapshotProvider.get();
     CatalogTransaction newTrx = new CatalogTransaction(snapshot);
     long latestVersion = newTrx.getLatestSchemaVersion();
@@ -169,30 +134,33 @@ public class Catalog implements AutoCloseable {
     }
   }
 
-  public void reloadCache() {
+  private void reloadCache() {
     reloadCache(false);
   }
 
   public List<TiDBInfo> listDatabases() {
-    return getLatestMetaCache().listDatabases();
+    reloadCache();
+    return metaCache.listDatabases();
   }
 
   public List<TiTableInfo> listTables(TiDBInfo database) {
     Objects.requireNonNull(database, "database is null");
+    reloadCache();
     if (showRowId) {
-      return getLatestMetaCache()
+      return metaCache
           .listTables(database)
           .stream()
           .map(TiTableInfo::copyTableWithRowId)
           .collect(Collectors.toList());
     } else {
-      return getLatestMetaCache().listTables(database);
+      return metaCache.listTables(database);
     }
   }
 
   public TiDBInfo getDatabase(String dbName) {
     Objects.requireNonNull(dbName, "dbName is null");
-    return getLatestMetaCache().getDatabase(dbName);
+    reloadCache();
+    return metaCache.getDatabase(dbName);
   }
 
   public TiTableInfo getTable(String dbName, String tableName) {
@@ -206,7 +174,8 @@ public class Catalog implements AutoCloseable {
   public TiTableInfo getTable(TiDBInfo database, String tableName) {
     Objects.requireNonNull(database, "database is null");
     Objects.requireNonNull(tableName, "tableName is null");
-    TiTableInfo table = getLatestMetaCache().getTable(database, tableName);
+    reloadCache();
+    TiTableInfo table = metaCache.getTable(database, tableName);
     if (showRowId && table != null) {
       return table.copyTableWithRowId();
     } else {


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
close https://github.com/pingcap/tispark/issues/1083

TiSpark Catalog has 10-20s delay, because tispark refresh catalog every 10 seconds.

### What is changed and how it works?
`GetTable` and `GetDatabase` works as follows:
1. get latest schema version from TiKV (2 RPC, getTimeStamp from PD & getSchemaVersion from TiKV)
2. check schema in cache(memory) and TiKV
3. if schema version in cache == that in TiKV, return data from cache
4. if schema version in cache != that in TiKV, refresh catalog in cache

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Related changes

 - Need to cherry-pick to the release branch
 - Need to be included in the release note
