### PR TITLE
Print exception when ut fails

### DIFF
--- a/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
@@ -26,6 +26,7 @@ import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.util._
 import org.apache.spark.sql.execution.columnar.InMemoryRelation
 import org.apache.spark.sql.types.StructField
+import org.slf4j.LoggerFactory
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
@@ -35,6 +36,8 @@ abstract class QueryTest extends SparkFunSuite {
   protected def spark: SparkSession
 
   private val eps = 1.0e-2
+
+  private val logger = LoggerFactory.getLogger(getClass.getName)
 
   protected def compSqlResult(sql: String,
                               lhs: List[List[Any]],
@@ -454,6 +457,7 @@ abstract class QueryTest extends SparkFunSuite {
                                  retryOnFailure: Int,
                                  exception: Exception = null): A = {
     if (retryOnFailure <= 0) {
+      logger.error("callWithRetry failure", exception)
       fail(exception)
     } else
       try {

--- a/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
@@ -26,7 +26,6 @@ import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.util._
 import org.apache.spark.sql.execution.columnar.InMemoryRelation
 import org.apache.spark.sql.types.StructField
-import org.slf4j.LoggerFactory
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
@@ -36,8 +35,6 @@ abstract class QueryTest extends SparkFunSuite {
   protected def spark: SparkSession
 
   private val eps = 1.0e-2
-
-  private val logger = LoggerFactory.getLogger(getClass.getName)
 
   protected def compSqlResult(sql: String,
                               lhs: List[List[Any]],


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
ut fails without error message

see https://internal.pingcap.net/idc-jenkins/blue/organizations/jenkins/tispark_regression_test_daily/detail/tispark_regression_test_daily/89/pipeline

```
[2019-09-22T18:19:59.017Z] - ti batch write *** FAILED ***

[2019-09-22T18:19:59.017Z]   org.scalatest.exceptions.TestFailedException was thrown. (QueryTest.scala:457)
```

### What is changed and how it works?
Print exception when ut fails

