### PR TITLE
Remove recreate flag when creating TiSession

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/TiContext.scala
+++ b/core/src/main/scala/org/apache/spark/sql/TiContext.scala
@@ -43,7 +43,7 @@ class TiContext(val sparkSession: SparkSession, options: Option[TiDBOptions] = N
   lazy val sqlContext: SQLContext = sparkSession.sqlContext
   val conf: SparkConf = mergeWithDataSourceConfig(sparkSession.sparkContext.conf, options)
   val tiConf: TiConfiguration = TiUtil.sparkConfToTiConf(conf)
-  val tiSession: TiSession = TiSession.getInstance(tiConf, true)
+  val tiSession: TiSession = TiSession.getInstance(tiConf)
   val meta: MetaManager = new MetaManager(tiSession.getCatalog)
 
   StatisticsManager.initStatisticsManager(tiSession)

--- a/tikv-client/src/main/java/com/pingcap/tikv/TiSession.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/TiSession.java
@@ -45,10 +45,10 @@ public class TiSession implements AutoCloseable {
 
   private static final Map<String, TiSession> sessionCachedMap = new HashMap<>();
 
-  public static TiSession getInstance(TiConfiguration conf, boolean recreate) {
+  public static TiSession getInstance(TiConfiguration conf) {
     synchronized (sessionCachedMap) {
       String key = conf.getPdAddrsString();
-      if (sessionCachedMap.containsKey(key) && !recreate) {
+      if (sessionCachedMap.containsKey(key)) {
         return sessionCachedMap.get(key);
       }
 
@@ -56,12 +56,6 @@ public class TiSession implements AutoCloseable {
       sessionCachedMap.put(key, newSession);
       return newSession;
     }
-  }
-
-  // Since we create session as singleton now, configuration change will not
-  // reflect change
-  public static TiSession getInstance(TiConfiguration conf) {
-    return getInstance(conf, false);
   }
 
   private TiSession(TiConfiguration conf) {


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
This PR https://github.com/pingcap/tispark/pull/1064 adds a recreate flag in TiSession to fix ci failure.

This PR https://github.com/pingcap/tispark/pull/1108 fixes no such table problem, so the recreate flag could be removed.

close https://github.com/pingcap/tispark/issues/1058

### What is changed and how it works?
Remove recreate flag when creating TiSession

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code


Related changes

 - Need to cherry-pick to the release branch
