### PR TITLE
Update isolationLevel Document

### DIFF
--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -280,7 +280,11 @@ df.write
 .save()
 ```
 
-Please set `isolationLevel` to `NONE` to avoid large single transactions which might lead to TiDB OOM.
+Please set `isolationLevel` to `NONE` to avoid large single transactions which might lead to TiDB OOM and also avoid the following error:
+
+```
+java.sql.SQLException: variable 'tx_isolation' does not yet support value: READ-UNCOMMITTED
+```
 
 ## Statistics information
 

--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -275,12 +275,12 @@ df.write
 // as tested, setting to `150` is a good practice
 .option(JDBCOptions.JDBC_BATCH_INSERT_SIZE, 150)
 .option("dbtable", s"cust_test_select") // database name and table name here
-.option("isolationLevel", "NONE") // recommended to set isolationLevel to NONE if you have a large DF to load.
+.option("isolationLevel", "NONE") // set isolationLevel to NONE
 .option("user", "root") // TiDB user here
 .save()
 ```
 
-It is recommended that you set `isolationLevel` to `NONE` to avoid large single transactions which might lead to TiDB OOM.
+Please set `isolationLevel` to `NONE` to avoid large single transactions which might lead to TiDB OOM.
 
 ## Statistics information
 

--- a/docs/userguide_spark2.1.md
+++ b/docs/userguide_spark2.1.md
@@ -266,7 +266,7 @@ df.write
 // as tested, setting to `150` is a good practice
 .option(JDBCOptions.JDBC_BATCH_INSERT_SIZE, 150)
 .option("dbtable", s"cust_test_select") // database name and table name here
-.option("isolationLevel", "None") // set isolationLevel to NONE
+.option("isolationLevel", "NONE") // set isolationLevel to NONE
 .option("user", "root") // TiDB user here
 .save()
 ```

--- a/docs/userguide_spark2.1.md
+++ b/docs/userguide_spark2.1.md
@@ -271,7 +271,11 @@ df.write
 .save()
 ```
 
-Please set `isolationLevel` to `NONE` to avoid large single transactions which might lead to TiDB OOM.
+Please set `isolationLevel` to `NONE` to avoid large single transactions which might lead to TiDB OOM and also avoid the following error:
+
+```
+java.sql.SQLException: variable 'tx_isolation' does not yet support value: READ-UNCOMMITTED
+```
 
 ## Statistics information
 

--- a/docs/userguide_spark2.1.md
+++ b/docs/userguide_spark2.1.md
@@ -266,12 +266,12 @@ df.write
 // as tested, setting to `150` is a good practice
 .option(JDBCOptions.JDBC_BATCH_INSERT_SIZE, 150)
 .option("dbtable", s"cust_test_select") // database name and table name here
-.option("isolationLevel", "NONE") // recommended to set isolationLevel to NONE if you have a large DF to load.
+.option("isolationLevel", "None") // set isolationLevel to NONE
 .option("user", "root") // TiDB user here
 .save()
 ```
 
-It is recommended that you set `isolationLevel` to `NONE` to avoid large single transactions which might lead to TiDB OOM.
+Please set `isolationLevel` to `NONE` to avoid large single transactions which might lead to TiDB OOM.
 
 ## Statistics information
 


### PR DESCRIPTION
if isolationLevel is not set when using jdbc, we will get the following error.

```
Caused by: java.sql.SQLException: variable 'tx_isolation' does not yet support value: READ-UNCOMMITTED
  at com.mysql.jdbc.SQLError.createSQLException(SQLError.java:964)
  at com.mysql.jdbc.MysqlIO.checkErrorPacket(MysqlIO.java:3973)
  at com.mysql.jdbc.MysqlIO.checkErrorPacket(MysqlIO.java:3909)
  at com.mysql.jdbc.MysqlIO.sendCommand(MysqlIO.java:2527)
  at com.mysql.jdbc.MysqlIO.sqlQueryDirect(MysqlIO.java:2680)
  at com.mysql.jdbc.ConnectionImpl.execSQL(ConnectionImpl.java:2483)
  at com.mysql.jdbc.ConnectionImpl.setTransactionIsolation(ConnectionImpl.java:5107)
  at org.apache.spark.sql.execution.datasources.jdbc.JdbcUtils$.savePartition(JdbcUtils.scala:631)
  at org.apache.spark.sql.execution.datasources.jdbc.JdbcUtils$$anonfun$saveTable$1.apply(JdbcUtils.scala:821)
  at org.apache.spark.sql.execution.datasources.jdbc.JdbcUtils$$anonfun$saveTable$1.apply(JdbcUtils.scala:821)
  at org.apache.spark.rdd.RDD$$anonfun$foreachPartition$1$$anonfun$apply$29.apply(RDD.scala:935)
  at org.apache.spark.rdd.RDD$$anonfun$foreachPartition$1$$anonfun$apply$29.apply(RDD.scala:935)
  at org.apache.spark.SparkContext$$anonfun$runJob$5.apply(SparkContext.scala:2074)
  at org.apache.spark.SparkContext$$anonfun$runJob$5.apply(SparkContext.scala:2074)
  at org.apache.spark.scheduler.ResultTask.runTask(ResultTask.scala:87)
  at org.apache.spark.scheduler.Task.run(Task.scala:109)
  at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:345)
  at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
  at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
  at java.lang.Thread.run(Thread.java:748)
```

