### PR TITLE
Fix ci: IssueTestSuite failed if run DataSourceWithoutExtensionsSuite before IssueTestSuite

### DIFF
--- a/.ci/integration_test.groovy
+++ b/.ci/integration_test.groovy
@@ -166,6 +166,7 @@ def call(ghprbActualCommit, ghprbCommentBody, ghprbPullId, ghprbPullTitle, ghprb
                     sh """
                         export MAVEN_OPTS="-Xmx6G -XX:MaxPermSize=512M -XX:ReservedCodeCacheSize=512M"
                         mvn test ${MVN_PROFILE} -am -pl tikv-client
+                        mvn test ${MVN_PROFILE} -Dtest=moo -DwildcardSuites=com.pingcap.tispark.datasource.DataSourceWithoutExtensionsSuite,org.apache.spark.sql.IssueTestSuite -DfailIfNoTests=false
                     """
                     unstash "CODECOV_TOKEN"
                     sh 'curl -s https://codecov.io/bash | bash -s - -t @CODECOV_TOKEN'

--- a/core/src/test/scala/org/apache/spark/sql/test/SharedSQLContext.scala
+++ b/core/src/test/scala/org/apache/spark/sql/test/SharedSQLContext.scala
@@ -21,6 +21,7 @@ import java.io.File
 import java.sql.{Connection, Date, Statement}
 import java.util.{Locale, Properties, TimeZone}
 
+import com.pingcap.tikv.TiSession
 import com.pingcap.tispark.TiConfigConst.PD_ADDRESSES
 import com.pingcap.tispark.TiDBUtils
 import com.pingcap.tispark.statistics.StatisticsManager
@@ -451,6 +452,8 @@ object SharedSQLContext extends Logging {
    * Stop the underlying resources, if any.
    */
   def stop(): Unit = {
+    TiSession.clearCache()
+
     if (_spark != null) {
       _spark.sessionState.catalog.reset()
       _spark.close()

--- a/core/src/test/scala/org/apache/spark/sql/test/SharedSQLContext.scala
+++ b/core/src/test/scala/org/apache/spark/sql/test/SharedSQLContext.scala
@@ -191,24 +191,25 @@ object SharedSQLContext extends Logging {
       _ti
     }
 
-    private[test] def clear(): Unit =
+    private[test] def clear(): Unit = {
       if (_ti == null) {
         get()
       }
 
-    if (_ti != null) {
-      _ti.sparkSession.sessionState.catalog.reset()
-      _ti.meta.close()
-      _ti.sparkSession.close()
-      _ti.tiSession.close()
-      _ti = null
+      if (_ti != null) {
+        _ti.sparkSession.sessionState.catalog.reset()
+        _ti.meta.close()
+        _ti.sparkSession.close()
+        _ti.tiSession.close()
+        _ti = null
+      }
     }
   }
 
   private val tiContextCache = new TiContextCache
 
   // get the current TiContext lazily
-  protected implicit def ti: TiContext = tiContextCache.get
+  protected implicit def ti: TiContext = tiContextCache.get()
 
   protected implicit def tidbConn: Connection = _tidbConnection
 

--- a/tikv-client/src/main/java/com/pingcap/tikv/TiSession.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/TiSession.java
@@ -58,12 +58,6 @@ public class TiSession implements AutoCloseable {
     }
   }
 
-  public static void clearCache() {
-    synchronized (sessionCachedMap) {
-      sessionCachedMap.clear();
-    }
-  }
-
   private TiSession(TiConfiguration conf) {
     this.conf = conf;
     this.channelFactory = new ChannelFactory(conf.getMaxFrameSize());

--- a/tikv-client/src/main/java/com/pingcap/tikv/TiSession.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/TiSession.java
@@ -58,6 +58,12 @@ public class TiSession implements AutoCloseable {
     }
   }
 
+  public static void clearCache() {
+    synchronized (sessionCachedMap) {
+      sessionCachedMap.clear();
+    }
+  }
+
   private TiSession(TiConfiguration conf) {
     this.conf = conf;
     this.channelFactory = new ChannelFactory(conf.getMaxFrameSize());


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
close https://github.com/pingcap/tispark/issues/1124

IssueTestSuite failed after DataSourceWithoutExtensionsSuite

### What is changed and how it works?
Reason is: TiSession Cache is not cleared without TiExtension.

![image](https://user-images.githubusercontent.com/51775583/65485720-3465d500-ded5-11e9-88ea-ab8ad971a325.png)


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
