### PR TITLE
Forbid to add TiDB password to SparkConf

### DIFF
--- a/docs/datasource_api_userguide.md
+++ b/docs/datasource_api_userguide.md
@@ -55,7 +55,8 @@ Fow how to use it with extensions enabled, see [code examples with extensions](h
       setIfMissing("spark.tispark.pd.addresses", "pd0:2379").
       setIfMissing("spark.tispark.tidb.addr", "tidb").
       setIfMissing("spark.tispark.tidb.port", "4000")
-      //.setIfMissing("spark.tispark.write.without_lock_table", "true")
+      // if tidb <= 3.x, please set the spark.tispark.write.without_lock_table=true
+      // .setIfMissing("spark.tispark.write.without_lock_table", "true")
 
     val spark = SparkSession.builder.config(sparkConf).getOrCreate()
     ```
@@ -162,6 +163,8 @@ import org.apache.spark.sql.{DataFrame, SQLContext, SparkSession}
 val sparkConf = new SparkConf()
   .setIfMissing("spark.master", "local[*]")
   .setIfMissing("spark.app.name", getClass.getName)
+  // if tidb <= 3.x, please set the spark.tispark.write.without_lock_table=true
+  // .setIfMissing("spark.tispark.write.without_lock_table", "true")
 
 val spark = SparkSession.builder.config(sparkConf).getOrCreate()
 ```
@@ -240,6 +243,8 @@ spark.tispark.pd.addresses 127.0.0.1:2379
 spark.tispark.tidb.addr 127.0.0.1
 spark.tispark.tidb.port 4000
 spark.tispark.write.allow_spark_sql true
+# if tidb <= 3.x, please set the spark.tispark.write.without_lock_table=true
+# spark.tispark.write.without_lock_table true
 ```
 
 2. Create a new table using mysql-client:

--- a/docs/datasource_api_userguide.md
+++ b/docs/datasource_api_userguide.md
@@ -48,34 +48,37 @@ Fow how to use it with extensions enabled, see [code examples with extensions](h
 1. Initiate `SparkConf`.
 
     ```scala
-    val sparkConf = new SparkConf()
-      .setIfMissing("spark.master", "local[*]")
-      .setIfMissing("spark.app.name", getClass.getName)
-      .setIfMissing("spark.sql.extensions", "org.apache.spark.sql.TiExtensions")
-      .setIfMissing("spark.tispark.pd.addresses", "pd0:2379")
-      .setIfMissing("spark.tispark.tidb.addr", "tidb")
-      .setIfMissing("spark.tispark.tidb.port", "4000")
+    val sparkConf = new SparkConf().
+      setIfMissing("spark.master", "local[*]").
+      setIfMissing("spark.app.name", getClass.getName).
+      setIfMissing("spark.sql.extensions", "org.apache.spark.sql.TiExtensions").
+      setIfMissing("spark.tispark.pd.addresses", "pd0:2379").
+      setIfMissing("spark.tispark.tidb.addr", "tidb").
+      setIfMissing("spark.tispark.tidb.port", "4000")
+      //.setIfMissing("spark.tispark.write.without_lock_table", "true")
 
     val spark = SparkSession.builder.config(sparkConf).getOrCreate()
-    val sqlContext = spark.sqlContext
     ```
 
 2. Read using scala.
 
     ```scala
+    val sqlContext = spark.sqlContext
+
     // use TiDB config in the spark config if no data source config is provided
     val tidbOptions: Map[String, String] = Map(
       "tidb.user" -> "root",
       "tidb.password" -> ""
     )
-    val df = sqlContext.read
-      .format("tidb")
-      .options(tidbOptions)
-      .option("database", "tpch_test")
-      .option("table", "CUSTOMER")
-      .load()
-      .filter("C_CUSTKEY = 1")
-      .select("C_NAME")
+
+    val df = sqlContext.read.
+      format("tidb").
+      options(tidbOptions).
+      option("database", "tpch_test").
+      option("table", "CUSTOMER").
+      load().
+      filter("C_CUSTKEY = 1").
+      select("C_NAME")
     df.show()
     ```
 
@@ -103,21 +106,21 @@ Fow how to use it with extensions enabled, see [code examples with extensions](h
     )
 
     // data to write
-    val df = sqlContext.read
-      .format("tidb")
-      .options(tidbOptions)
-      .option("database", "tpch_test")
-      .option("table", "ORDERS")
-      .load()
+    val df = sqlContext.read.
+      format("tidb").
+      options(tidbOptions).
+      option("database", "tpch_test").
+      option("table", "ORDERS").
+      load()
 
     // append
-    df.write
-      .format("tidb")
-      .options(tidbOptions)
-      .option("database", "tpch_test")
-      .option("table", "target_table_orders")
-      .mode("append")
-      .save()
+    df.write.
+      format("tidb").
+      options(tidbOptions).
+      option("database", "tpch_test").
+      option("table", "target_table_orders").
+      mode("append").
+      save()
     ```
 
 4. Use another TiDB.
@@ -134,14 +137,14 @@ Fow how to use it with extensions enabled, see [code examples with extensions](h
       "spark.tispark.pd.addresses" -> "pd0:2379"
     )
 
-    val df = sqlContext.read
-      .format("tidb")
-      .options(tidbOptions)
-      .option("database", "tpch_test")
-      .option("table", "CUSTOMER")
-      .load()
-      .filter("C_CUSTKEY = 1")
-      .select("C_NAME")
+    val df = sqlContext.read.
+      format("tidb").
+      options(tidbOptions).
+      option("database", "tpch_test").
+      option("table", "CUSTOMER").
+      load().
+      filter("C_CUSTKEY = 1").
+      select("C_NAME").
     df.show()
     ```
 
@@ -161,12 +164,13 @@ val sparkConf = new SparkConf()
   .setIfMissing("spark.app.name", getClass.getName)
 
 val spark = SparkSession.builder.config(sparkConf).getOrCreate()
-val sqlContext = spark.sqlContext
 ```
 
 2. Read using scala:
 
 ```scala
+val sqlContext = spark.sqlContext
+
 // TiSpark's common options can also be passed in,
 // for example, spark.tispark.plan.allow_agg_pushdown`, spark.tispark.plan.allow_index_read, etc.
 // spark.tispark.plan.allow_index_read is optional.
@@ -178,14 +182,14 @@ val tidbOptions: Map[String, String] = Map(
   "spark.tispark.pd.addresses" -> "pd0:2379"
 )
 
-val df = sqlContext.read
-  .format("tidb")
-  .options(tidbOptions)
-  .option("database", "tpch_test")
-  .option("table", "CUSTOMER")
-  .load()
-  .filter("C_CUSTKEY = 1")
-  .select("C_NAME")
+val df = sqlContext.read.
+  format("tidb").
+  options(tidbOptions).
+  option("database", "tpch_test").
+  option("table", "CUSTOMER").
+  load().
+  filter("C_CUSTKEY = 1").
+  select("C_NAME").
 df.show()
 ```
 
@@ -218,14 +222,13 @@ val tidbOptions: Map[String, String] = Map(
 
 val df = readUsingScala(sqlContext)
 
-// append
-df.write
-  .format("tidb")
-  .options(tidbOptions)
-  .option("database", "tpch_test")
-  .option("table", "target_table_customer")
-  .mode("append")
-  .save()
+df.write.
+  format("tidb").
+  options(tidbOptions).
+  option("database", "tpch_test").
+  option("table", "target_table_customer").
+  mode("append").
+  save()
 ```
 
 ## Use Data Source API in SparkSQL

--- a/docs/datasource_api_userguide.md
+++ b/docs/datasource_api_userguide.md
@@ -54,9 +54,7 @@ Fow how to use it with extensions enabled, see [code examples with extensions](h
       .setIfMissing("spark.sql.extensions", "org.apache.spark.sql.TiExtensions")
       .setIfMissing("spark.tispark.pd.addresses", "pd0:2379")
       .setIfMissing("spark.tispark.tidb.addr", "tidb")
-      .setIfMissing("spark.tispark.tidb.password", "")
       .setIfMissing("spark.tispark.tidb.port", "4000")
-      .setIfMissing("spark.tispark.tidb.user", "root")
 
     val spark = SparkSession.builder.config(sparkConf).getOrCreate()
     val sqlContext = spark.sqlContext
@@ -66,7 +64,10 @@ Fow how to use it with extensions enabled, see [code examples with extensions](h
 
     ```scala
     // use TiDB config in the spark config if no data source config is provided
-    val tidbOptions: Map[String, String] = Map()
+    val tidbOptions: Map[String, String] = Map(
+      "tidb.user" -> "root",
+      "tidb.password" -> ""
+    )
     val df = sqlContext.read
       .format("tidb")
       .options(tidbOptions)
@@ -96,7 +97,10 @@ Fow how to use it with extensions enabled, see [code examples with extensions](h
     */
 
     // use TiDB config in the spark config if no data source config is provided
-    val tidbOptions: Map[String, String] = Map()
+    val tidbOptions: Map[String, String] = Map(
+      "tidb.user" -> "root",
+      "tidb.password" -> ""
+    )
 
     // data to write
     val df = sqlContext.read
@@ -232,8 +236,6 @@ df.write
 spark.tispark.pd.addresses 127.0.0.1:2379
 spark.tispark.tidb.addr 127.0.0.1
 spark.tispark.tidb.port 4000
-spark.tispark.tidb.user root
-spark.tispark.tidb.password password
 spark.tispark.write.allow_spark_sql true
 ```
 
@@ -255,7 +257,12 @@ CREATE TABLE tpch_test.TARGET_TABLE_CUSTOMER (
 3. Register a TiDB table `tpch_test.CUSTOMER` to the Spark Catalog:
 
 ```
-CREATE TABLE CUSTOMER_SRC USING tidb OPTIONS (database 'tpch_test', table 'CUSTOMER')
+CREATE TABLE CUSTOMER_SRC USING tidb OPTIONS (
+  tidb.user 'root',
+  tidb.password '',
+  database 'tpch_test',
+  table 'CUSTOMER'
+)
 ```
 
 4. Select data from `tpch_test.CUSTOMER`:
@@ -282,21 +289,21 @@ INSERT INTO CUSTOMER_DST SELECT * FROM CUSTOMER_SRC
 
 The following table shows the TiDB-specific options, which can be passed in through `TiDBOptions` or `SparkConf`.
 
-| Key                         | Short Name    | Required value | Description                                                                                                 | Default |
-| --------------------------- | ------------- | -------- | ----------------------------------------------------------------------------------------------------------- | ------- |
-| spark.tispark.pd.addresses  | -             | true     | The addresses of PD clusters, split by comma                                                                        | -       |
-| spark.tispark.tidb.addr     | tidb.addr     | true     | TiDB address, which currently only supports one instance                                                           | -       |
-| spark.tispark.tidb.port     | tidb.port     | true     | TiDB Port                                                                                                   | -       |
-| spark.tispark.tidb.user     | tidb.user     | true     | TiDB User                                                                                                   | -       |
-| spark.tispark.tidb.password | tidb.password | true     | TiDB Password                                                                                               | -       |
-| database                    | -             | true     | TiDB Database                                                                                               | -       |
-| table                       | -             | true     | TiDB Table                                                                                                  | -       |
-| skipCommitSecondaryKey      | -             | false    | Whether to skip the commit phase of secondary keys                                                                                   | false   |
-| enableRegionSplit           | -             | false    | To split Region to avoid hot Region during insertion                                                        | true    |
-| regionSplitNum              | -             | false    | The Region split number defined by user during insertion                                                           | 0       |
-| replace                     | -             | false    | To define the behavior of append                                                                              | false   |
-| lockTTLSeconds              | -             | false    | TiKV's lock TTL. The write duration must be no longer than `lockTTLSeconds`, otherwise write might fail because of the Garbage Collection (GC).              | 3600    |
-| writeConcurrency            | -             | false    | The maximum number of threads that write data to TiKV. It is recommended that `writeConcurrency` is smaller than or equal to 8 * `number of TiKV instance`. | 0       |
+| Key                        | Short Name    | Required value | Description                                                                                                                                                 | Default |
+| -------------------------- | ------------- | -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| spark.tispark.pd.addresses | -             | true           | The addresses of PD clusters, split by comma                                                                                                                | -       |
+| spark.tispark.tidb.addr    | tidb.addr     | true           | TiDB address, which currently only supports one instance                                                                                                    | -       |
+| spark.tispark.tidb.port    | tidb.port     | true           | TiDB Port                                                                                                                                                   | -       |
+| spark.tispark.tidb.user    | tidb.user     | true           | TiDB User                                                                                                                                                   | -       |
+| tidb.password              | tidb.password | true           | TiDB Password                                                                                                                                               | -       |
+| database                   | -             | true           | TiDB Database                                                                                                                                               | -       |
+| table                      | -             | true           | TiDB Table                                                                                                                                                  | -       |
+| skipCommitSecondaryKey     | -             | false          | Whether to skip the commit phase of secondary keys                                                                                                          | false   |
+| enableRegionSplit          | -             | false          | To split Region to avoid hot Region during insertion                                                                                                        | true    |
+| regionSplitNum             | -             | false          | The Region split number defined by user during insertion                                                                                                    | 0       |
+| replace                    | -             | false          | To define the behavior of append                                                                                                                            | false   |
+| lockTTLSeconds             | -             | false          | TiKV's lock TTL. The write duration must be no longer than `lockTTLSeconds`, otherwise write might fail because of the Garbage Collection (GC).             | 3600    |
+| writeConcurrency           | -             | false          | The maximum number of threads that write data to TiKV. It is recommended that `writeConcurrency` is smaller than or equal to 8 * `number of TiKV instance`. | 0       |
 
 ## TiDB Version and Configuration for Write
 


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
close https://github.com/pingcap/tispark/issues/1137

Forbid to add TiDB password to SparkConf because it will be shown on Spark WebUI.

### What is changed and how it works?
throw an error if TiDB password is added to SparkConf

TiDB password should be passed in via hand-made code, e.g.

```
val sparkConf = new SparkConf().
  setIfMissing("spark.master", "local[*]").
  setIfMissing("spark.app.name", getClass.getName).
  setIfMissing("spark.sql.extensions", "org.apache.spark.sql.TiExtensions").
  setIfMissing("spark.tispark.pd.addresses", "pd0:2379").
  setIfMissing("spark.tispark.tidb.addr", "tidb").
  setIfMissing("spark.tispark.tidb.port", "4000")

val spark = SparkSession.builder.config(sparkConf).getOrCreate()
val sqlContext = spark.sqlContext

val tidbOptions: Map[String, String] = Map(
  "tidb.user" -> "root",
  "tidb.password" -> ""
)

val df = sqlContext.read.
  format("tidb").
  options(tidbOptions).
  option("database", "tpch_test").
  option("table", "ORDERS").
  load()

df.write.
  format("tidb").
  options(tidbOptions).
  option("database", "tpch_test").
  option("table", "target_table_orders").
  mode("append").
  save()
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to be included in the release note
