### PR TITLE
Fix Bit Type default value bug

### DIFF
--- a/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
@@ -20,7 +20,7 @@ import org.apache.spark.sql.functions.{col, sum}
 
 class IssueTestSuite extends BaseTiSparkTest {
   // https://github.com/pingcap/tispark/issues/1147
-  test("GetOriginDefaultValue from BIT") {
+  test("Fix Bit Type default value bug") {
     def runBitTest(bitNumber: Int, bitString: String): Unit = {
       tidbStmt.execute("DROP TABLE IF EXISTS t_origin_default_value")
       tidbStmt.execute(

--- a/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
@@ -19,6 +19,49 @@ import com.pingcap.tispark.TiConfigConst
 import org.apache.spark.sql.functions.{col, sum}
 
 class IssueTestSuite extends BaseTiSparkTest {
+  // https://github.com/pingcap/tispark/issues/1147
+  test("GetOriginDefaultValue from BIT") {
+    def runBitTest(bitNumber: Int, bitString: String): Unit = {
+      tidbStmt.execute("DROP TABLE IF EXISTS t_origin_default_value")
+      tidbStmt.execute(
+        s"CREATE TABLE t_origin_default_value (id bigint(20) NOT NULL, approved bit($bitNumber) NOT NULL DEFAULT b'$bitString')"
+      )
+      tidbStmt.execute("insert into t_origin_default_value(id) values (1), (2), (3)")
+      judge("select * from t_origin_default_value")
+
+      tidbStmt.execute("DROP TABLE IF EXISTS t_origin_default_value")
+      tidbStmt.execute("CREATE TABLE t_origin_default_value (id bigint(20) NOT NULL)")
+      tidbStmt.execute("insert into t_origin_default_value(id) values (1), (2), (3)")
+      tidbStmt.execute(
+        s"alter table t_origin_default_value add approved bit($bitNumber) NOT NULL DEFAULT b'$bitString'"
+      )
+      judge("select * from t_origin_default_value")
+    }
+
+    "0" :: "1" :: Nil foreach { bitString =>
+      runBitTest(1, bitString)
+    }
+
+    "000" :: "001" :: "010" :: "011" :: "100" :: "101" :: "110" :: "111" :: Nil foreach {
+      bitString =>
+        runBitTest(3, bitString)
+    }
+
+    "00000000" ::
+      //"11111111" :: error because of https://github.com/pingcap/tidb/issues/12703
+      //"10101010" :: error
+      "01010101" ::
+      Nil foreach { bitString =>
+      runBitTest(8, bitString)
+    }
+
+    "0000000000000000000000000000000000000000000000000000000000000000" ::
+      "1111111111111111111111111111111111111111111111111111111111111111" ::
+      //"1010101010101010101010101010101001010101010101010101010101010101" :: error
+      Nil foreach { bitString =>
+      runBitTest(64, bitString)
+    }
+  }
 
   // https://github.com/pingcap/tispark/issues/1083
   test("TiSpark Catalog has no delay") {
@@ -346,6 +389,7 @@ class IssueTestSuite extends BaseTiSparkTest {
       tidbStmt.execute("drop table if exists enum_t")
       tidbStmt.execute("drop table if exists table_group_by_bigint")
       tidbStmt.execute("drop table if exists catalog_delay")
+      tidbStmt.execute("drop table if exists t_origin_default_value")
     } finally {
       super.afterAll()
     }

--- a/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
@@ -107,10 +107,6 @@ abstract class QueryTest extends SparkFunSuite {
     }
 
     def compValue(lhs: Any, rhs: Any): Boolean = {
-      doCompValue(lhs, rhs) || doCompValue(rhs, lhs)
-    }
-
-    def doCompValue(lhs: Any, rhs: Any): Boolean = {
       if (lhs == rhs || compNull(lhs, rhs) || lhs.toString == rhs.toString) {
         true
       } else
@@ -148,7 +144,7 @@ abstract class QueryTest extends SparkFunSuite {
             val l = toDouble(lhs)
             val r = toDouble(rhs)
             Math.abs(l - r) < eps || Math.abs(r) > eps && Math.abs((l - r) / r) < eps
-          case _: Number | _: BigInt | _: java.math.BigInteger =>
+          case _: Number | _: BigInt | _: java.math.BigInteger | _: Boolean =>
             toInteger(lhs) == toInteger(rhs)
           case _: Timestamp =>
             toString(lhs) == toString(rhs)

--- a/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
@@ -106,12 +106,16 @@ abstract class QueryTest extends SparkFunSuite {
       false
     }
 
-    def compValue(lhs: Any, rhs: Any): Boolean =
+    def compValue(lhs: Any, rhs: Any): Boolean = {
+      doCompValue(lhs, rhs) || doCompValue(rhs, lhs)
+    }
+
+    def doCompValue(lhs: Any, rhs: Any): Boolean = {
       if (lhs == rhs || compNull(lhs, rhs) || lhs.toString == rhs.toString) {
         true
       } else
         lhs match {
-          case _: Array[Byte] =>
+          case _: Array[Byte] if rhs.isInstanceOf[Array[Byte]] =>
             val l = lhs.asInstanceOf[Array[Byte]]
             val r = rhs.asInstanceOf[Array[Byte]]
             if (l.length != r.length) {
@@ -124,6 +128,22 @@ abstract class QueryTest extends SparkFunSuite {
               }
               true
             }
+          case _: Array[Byte] if rhs.isInstanceOf[Long] =>
+            val l = lhs.asInstanceOf[Array[Byte]].toList.reverse
+            val r = rhs.asInstanceOf[Long]
+            if (l.length > 8) {
+              false
+            } else {
+              var eq = true
+              for (i <- l.indices) {
+                val a = (((255L << (i * 8)) & r) >> (i * 8)).toByte
+                if (!l(i).equals(a)) {
+                  eq = false
+                }
+              }
+              eq
+            }
+
           case _: Double | _: Float | _: BigDecimal | _: java.math.BigDecimal =>
             val l = toDouble(lhs)
             val r = toDouble(rhs)
@@ -135,6 +155,7 @@ abstract class QueryTest extends SparkFunSuite {
           case _ =>
             false
         }
+    }
 
     def compRow(lhs: List[Any], rhs: List[Any]): Boolean =
       if (lhs == null && rhs == null) {

--- a/tikv-client/src/main/java/com/pingcap/tikv/meta/TiColumnInfo.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/meta/TiColumnInfo.java
@@ -196,6 +196,8 @@ public class TiColumnInfo implements Serializable {
     return defaultValueBit;
   }
 
+  // Default value use to stored in DefaultValue field, but now, bit type default value will store
+  // in DefaultValueBit for fix bit default value decode/encode bug.
   String getOriginDefaultValue() {
     if (this.getType().getType() == MySQLType.TypeBit
         && originDefaultValue != null

--- a/tikv-client/src/main/java/com/pingcap/tikv/meta/TiColumnInfo.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/meta/TiColumnInfo.java
@@ -28,6 +28,7 @@ import com.pingcap.tikv.types.DataType;
 import com.pingcap.tikv.types.DataType.EncodeType;
 import com.pingcap.tikv.types.DataTypeFactory;
 import com.pingcap.tikv.types.IntegerType;
+import com.pingcap.tikv.types.MySQLType;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Objects;
@@ -43,6 +44,8 @@ public class TiColumnInfo implements Serializable {
   private final boolean isPrimaryKey;
   private final String defaultValue;
   private final String originDefaultValue;
+  private final String defaultValueBit;
+
   // this version is from ColumnInfo which is used to address compatible issue.
   // If version is 0 then timestamp's default value will be read and decoded as local timezone.
   // if version is 1 then timestamp's default value will be read and decoded as utc.
@@ -64,6 +67,7 @@ public class TiColumnInfo implements Serializable {
       @JsonProperty("state") int schemaState,
       @JsonProperty("origin_default") String originalDefaultValue,
       @JsonProperty("default") String defaultValue,
+      @JsonProperty("default_bit") String defaultValueBit,
       @JsonProperty("comment") String comment,
       @JsonProperty("version") long version,
       @JsonProperty("generated_expr_string") String generatedExprString) {
@@ -75,6 +79,7 @@ public class TiColumnInfo implements Serializable {
     this.comment = comment;
     this.defaultValue = defaultValue;
     this.originDefaultValue = originalDefaultValue;
+    this.defaultValueBit = defaultValueBit;
     // I don't think pk flag should be set on type
     // Refactor against original tidb code
     this.isPrimaryKey = (type.getFlag() & PK_MASK) > 0;
@@ -90,6 +95,7 @@ public class TiColumnInfo implements Serializable {
       SchemaState schemaState,
       String originalDefaultValue,
       String defaultValue,
+      String defaultValueBit,
       String comment,
       long version,
       String generatedExprString) {
@@ -101,6 +107,7 @@ public class TiColumnInfo implements Serializable {
     this.comment = comment;
     this.defaultValue = defaultValue;
     this.originDefaultValue = originalDefaultValue;
+    this.defaultValueBit = defaultValueBit;
     this.isPrimaryKey = (type.getFlag() & PK_MASK) > 0;
     this.version = version;
     this.generatedExprString = generatedExprString;
@@ -118,6 +125,7 @@ public class TiColumnInfo implements Serializable {
         this.schemaState,
         this.originDefaultValue,
         this.defaultValue,
+        this.defaultValueBit,
         this.comment,
         this.version,
         this.generatedExprString);
@@ -134,6 +142,7 @@ public class TiColumnInfo implements Serializable {
     this.isPrimaryKey = isPrimaryKey;
     this.originDefaultValue = "1";
     this.defaultValue = "";
+    this.defaultValueBit = null;
     this.version = DataType.COLUMN_VERSION_FLAG;
     this.generatedExprString = "";
   }
@@ -183,13 +192,24 @@ public class TiColumnInfo implements Serializable {
     return defaultValue;
   }
 
+  public String getDefaultValueBit() {
+    return defaultValueBit;
+  }
+
   String getOriginDefaultValue() {
-    return originDefaultValue;
+    if (this.getType().getType() == MySQLType.TypeBit
+        && originDefaultValue != null
+        && defaultValueBit != null) {
+      return defaultValueBit;
+    } else {
+      return originDefaultValue;
+    }
   }
 
   private ByteString getOriginDefaultValueAsByteString() {
     CodecDataOutput cdo = new CodecDataOutput();
-    type.encode(cdo, EncodeType.VALUE, type.getOriginDefaultValue(originDefaultValue, version));
+    type.encode(
+        cdo, EncodeType.VALUE, type.getOriginDefaultValue(getOriginDefaultValue(), version));
     return cdo.toByteString();
   }
 

--- a/tikv-client/src/main/java/com/pingcap/tikv/meta/TiTableInfo.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/meta/TiTableInfo.java
@@ -221,6 +221,7 @@ public class TiTableInfo implements Serializable {
             col.getSchemaState(),
             col.getOriginDefaultValue(),
             col.getDefaultValue(),
+            col.getDefaultValueBit(),
             col.getComment(),
             col.getVersion(),
             col.getGeneratedExprString())

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/BitType.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/BitType.java
@@ -83,10 +83,13 @@ public class BitType extends IntegerType {
 
   @Override
   public Object getOriginDefaultValueNonNull(String value, long version) {
+    // Default value use to stored in DefaultValue field, but now, bit type default value will store
+    // in DefaultValueBit for fix bit default value decode/encode bug.
+    // DefaultValueBit is encoded using Base64.
     Long result = 0L;
     byte[] bytes = Base64.getDecoder().decode(value);
     if (bytes.length <= 0 || bytes.length > 8) {
-      throw new CastingException("byte[] to Long Overflow");
+      throw new CastingException("Base64 format Bit Type to Long Overflow");
     }
     int size = bytes.length;
     for (int i = 0; i < bytes.length; i++) {


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
close https://github.com/pingcap/tispark/issues/1147

see https://github.com/pingcap/tidb/pull/12168

```
CREATE TABLE t_origin_default_value_1 (id bigint(20) NOT NULL, approved bit(8) NOT NULL DEFAULT b'11111111');
insert into t_origin_default_value_1(id) values (1), (2), (3);

CREATE TABLE t_origin_default_value_2 (id bigint(20) NOT NULL);
insert into t_origin_default_value_2(id) values (1), (2), (3);
alter table t_origin_default_value_2 add approved bit(8) NOT NULL DEFAULT b'11111111';
```

```
spark-sql> select * from t_origin_default_value_1;
1       255
2       255
3       255
Time taken: 0.144 seconds, Fetched 3 row(s)
```

```
spark-sql> select * from t_origin_default_value_2;                                                                      
19/10/15 10:49:14 ERROR SparkSQLDriver: Failed in [select * from t_origin_default_value_2]                              
java.lang.NumberFormatException: For input string: "�"                                                                  
        at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)                                
        at java.lang.Long.parseLong(Long.java:589)                                                                      
        at java.lang.Long.parseLong(Long.java:631)                                                                      
        at com.pingcap.tikv.types.IntegerType.getOriginDefaultValueNonNull(IntegerType.java:157)                        
        at com.pingcap.tikv.types.DataType.getOriginDefaultValue(DataType.java:327)                                     
        at com.pingcap.tikv.meta.TiColumnInfo.getOriginDefaultValueAsByteString(TiColumnInfo.java:192)                  
        at com.pingcap.tikv.meta.TiColumnInfo.toProtoBuilder(TiColumnInfo.java:315)                                     
        at com.pingcap.tikv.meta.TiColumnInfo.toProto(TiColumnInfo.java:304)                                            
        at com.pingcap.tikv.meta.TiDAGRequest.buildScan(TiDAGRequest.java:427)                                          
        at com.pingcap.tikv.meta.TiDAGRequest.buildTableScan(TiDAGRequest.java:276)                                     
        at com.pingcap.tikv.meta.TiDAGRequest.init(TiDAGRequest.java:969)                                               
        at com.pingcap.tikv.meta.TiDAGRequest.init(TiDAGRequest.java:974)                                               
        at com.pingcap.tikv.meta.TiDAGRequest.toString(TiDAGRequest.java:997)                                           
        at java.lang.String.valueOf(String.java:2994)      
        at java.lang.StringBuilder.append(StringBuilder.java:131) 
```

### What is changed and how it works?
use `defaultValueBit` instead of `originDefaultValue` for Bit Type

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Related changes

 - Need to cherry-pick to the release branch
 - Need to be included in the release note
