### PR TITLE
Fix No Matching column bug

### DIFF
--- a/core/src/main/scala/com/pingcap/tispark/TiConfigConst.scala
+++ b/core/src/main/scala/com/pingcap/tispark/TiConfigConst.scala
@@ -37,6 +37,8 @@ object TiConfigConst {
   val CACHE_EXPIRE_AFTER_ACCESS: String = "spark.tispark.statistics.expire_after_access"
   val SHOW_ROWID: String = "spark.tispark.show_rowid"
   val DB_PREFIX: String = "spark.tispark.db_prefix"
+  val ALLOW_ORDER_PROJECT_LIMIT_PUSHDOWN: String =
+    "spark.tispark.plan.allow_order_project_limit_pushdown"
 
   val SNAPSHOT_ISOLATION_LEVEL: String = "SI"
   val READ_COMMITTED_ISOLATION_LEVEL: String = "RC"

--- a/core/src/main/scala/org/apache/spark/sql/TiStrategy.scala
+++ b/core/src/main/scala/org/apache/spark/sql/TiStrategy.scala
@@ -510,24 +510,10 @@ case class TiStrategy(getOrCreateTiContext: SparkSession => TiContext)(sparkSess
       plan match {
         case logical.ReturnAnswer(rootPlan) =>
           rootPlan match {
-            /*case logical.Limit(IntegerLiteral(limit), logical.Sort(order, true, child)) =>
-              takeOrderedAndProject(limit, order, child, child.output) :: Nil*/
-            /*case logical.Limit(
-                IntegerLiteral(limit),
-                logical.Project(projectList, logical.Sort(order, true, child))
-                ) =>
-              takeOrderedAndProject(limit, order, child, projectList) :: Nil*/
             case logical.Limit(IntegerLiteral(limit), child) =>
               execution.CollectLimitExec(limit, collectLimit(limit, child)) :: Nil
             case other => planLater(other) :: Nil
           }
-        /*case logical.Limit(IntegerLiteral(limit), logical.Sort(order, true, child)) =>
-          takeOrderedAndProject(limit, order, child, child.output) :: Nil*/
-        /* case logical.Limit(
-            IntegerLiteral(limit),
-            logical.Project(projectList, logical.Sort(order, true, child))
-            ) =>
-          takeOrderedAndProject(limit, order, child, projectList) :: Nil*/
         // Collapse filters and projections and push plan directly
         case PhysicalOperation(
             projectList,

--- a/core/src/main/scala/org/apache/spark/sql/TiStrategy.scala
+++ b/core/src/main/scala/org/apache/spark/sql/TiStrategy.scala
@@ -306,9 +306,9 @@ case class TiStrategy(getOrCreateTiContext: SparkSession => TiContext)(sparkSess
   ): SparkPlan = {
     val request = new TiDAGRequest(pushDownType(), timeZoneOffset())
     request.setLimit(limit)
-    if (shouldAddSortOrder(projectList, sortOrder)) {
-      addSortOrder(request, sortOrder)
-    }
+    //if (shouldAddSortOrder(projectList, sortOrder)) {
+    addSortOrder(request, sortOrder)
+    //}
     pruneFilterProject(projectList, filterPredicates, source, request)
   }
 
@@ -517,24 +517,24 @@ case class TiStrategy(getOrCreateTiContext: SparkSession => TiContext)(sparkSess
     plan match {
       case logical.ReturnAnswer(rootPlan) =>
         rootPlan match {
-          case logical.Limit(IntegerLiteral(limit), logical.Sort(order, true, child)) =>
-            takeOrderedAndProject(limit, order, child, child.output) :: Nil
-          case logical.Limit(
+          /*case logical.Limit(IntegerLiteral(limit), logical.Sort(order, true, child)) =>
+            takeOrderedAndProject(limit, order, child, child.output) :: Nil*/
+          /*case logical.Limit(
               IntegerLiteral(limit),
               logical.Project(projectList, logical.Sort(order, true, child))
               ) =>
-            takeOrderedAndProject(limit, order, child, projectList) :: Nil
+            takeOrderedAndProject(limit, order, child, projectList) :: Nil*/
           case logical.Limit(IntegerLiteral(limit), child) =>
             execution.CollectLimitExec(limit, collectLimit(limit, child)) :: Nil
           case other => planLater(other) :: Nil
         }
-      case logical.Limit(IntegerLiteral(limit), logical.Sort(order, true, child)) =>
-        takeOrderedAndProject(limit, order, child, child.output) :: Nil
-      case logical.Limit(
+      /*case logical.Limit(IntegerLiteral(limit), logical.Sort(order, true, child)) =>
+        takeOrderedAndProject(limit, order, child, child.output) :: Nil*/
+      /* case logical.Limit(
           IntegerLiteral(limit),
           logical.Project(projectList, logical.Sort(order, true, child))
           ) =>
-        takeOrderedAndProject(limit, order, child, projectList) :: Nil
+        takeOrderedAndProject(limit, order, child, projectList) :: Nil*/
       // Collapse filters and projections and push plan directly
       case PhysicalOperation(
           projectList,

--- a/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
@@ -39,6 +39,9 @@ class IssueTestSuite extends BaseTiSparkSuite {
                 |    SELECT get_json_object(t.json,  '$.id') as id from t_no_match_column t
                 |) as temp44 order by temp44.id desc limit 1
       """.stripMargin).explain(true)
+
+    judge("select tp_int from full_data_type_table order by tp_int limit 20")
+    judge("select tp_int g from full_data_type_table order by g limit 20")
   }
 
   // https://github.com/pingcap/tispark/issues/1147


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
close https://github.com/pingcap/tispark/issues/1161

```
CREATE TABLE `t_no_match_column` (
  `json` text DEFAULT NULL
)
```


```
select temp44.id from (
    SELECT get_json_object(t.json,  '$.id') as id from t_no_match_column t
) as temp44 order by temp44.id desc limit 1
```


```
No Matching column id from table t_no_match_column
com.pingcap.tikv.exception.TiExpressionException: No Matching column id from table t_no_match_column
	at com.pingcap.tikv.expression.ColumnRef.resolve(ColumnRef.java:71)
	at com.pingcap.tikv.expression.visitor.MetaResolver.visit(MetaResolver.java:52)
	at com.pingcap.tikv.expression.visitor.MetaResolver.visit(MetaResolver.java:24)
	at com.pingcap.tikv.expression.ColumnRef.accept(ColumnRef.java:141)
	at com.pingcap.tikv.expression.visitor.MetaResolver.lambda$resolve$0(MetaResolver.java:42)
	at java.lang.Iterable.forEach(Iterable.java:75)
	at com.pingcap.tikv.expression.visitor.MetaResolver.resolve(MetaResolver.java:42)
	at com.pingcap.tikv.meta.TiDAGRequest.resolve(TiDAGRequest.java:264)
	at org.apache.spark.sql.TiStrategy.toCoprocessorRDD(TiStrategy.scala:159)
	at org.apache.spark.sql.TiStrategy.pruneFilterProject(TiStrategy.scala:416)
	at org.apache.spark.sql.TiStrategy.pruneTopNFilterProject(TiStrategy.scala:312)
	at org.apache.spark.sql.TiStrategy.takeOrderedAndProject(TiStrategy.scala:351)
	at org.apache.spark.sql.TiStrategy.org$apache$spark$sql$TiStrategy$$doPlan(TiStrategy.scala:521)
	at org.apache.spark.sql.TiStrategy$$anonfun$apply$1.applyOrElse(TiStrategy.scala:146)
	at org.apache.spark.sql.TiStrategy$$anonfun$apply$1.applyOrElse(TiStrategy.scala:144)
```

### What is changed and how it works?
This is a hotfix.
Add a config `spark.tispark.plan.allow_order_project_limit_pushdown`, default value = false.

will solve this problem in https://github.com/pingcap/tispark/issues/1163

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 
Related changes

 - Need to cherry-pick to the release branch
 - Need to be included in the release note
