### PR TITLE
fix view

### DIFF
--- a/core/src/test/scala/org/apache/spark/sql/ViewTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/ViewTestSuite.scala
@@ -4,17 +4,14 @@ class ViewTestSuite extends BaseTiSparkTest {
   private val table = "test_view"
 
   test("Test View") {
-    tidbStmt.execute(s"drop table if exists $table")
+    tidbStmt.execute(s"create table $table(qty INT, price INT);")
+    tidbStmt.execute(s"INSERT INTO $table VALUES(3, 50);")
+
     try {
-      tidbStmt.execute("drop view if exists v")
+      tidbStmt.execute(s"CREATE VIEW v AS SELECT qty, price, qty*price AS value FROM $table;")
     } catch {
       case _: Exception => cancel
     }
-
-    tidbStmt.execute(s"create table $table(qty INT, price INT);")
-
-    tidbStmt.execute(s"INSERT INTO $table VALUES(3, 50);")
-    tidbStmt.execute(s"CREATE VIEW v AS SELECT qty, price, qty*price AS value FROM $table;")
 
     refreshConnections()
 
@@ -22,5 +19,14 @@ class ViewTestSuite extends BaseTiSparkTest {
     intercept[AnalysisException](spark.sql("select * from v"))
 
     spark.sql("show tables").show(false)
+  }
+
+  override def afterAll() = {
+    tidbStmt.execute(s"drop table if exists $table")
+    try {
+      tidbStmt.execute("drop view if exists v")
+    } catch {
+      case _: Exception => cancel
+    }
   }
 }

--- a/tikv-client/src/main/java/com/pingcap/tikv/meta/TiViewInfo.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/meta/TiViewInfo.java
@@ -3,6 +3,7 @@ package com.pingcap.tikv.meta;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -33,6 +34,10 @@ public class TiViewInfo implements Serializable {
     this.viewSecurity = viewSecurity;
     this.viewSelect = viewSelect;
     this.viewCheckOpt = viewCheckOpt;
-    this.viewCols = viewCols.stream().map(CIStr::getO).collect(Collectors.toList());
+    if (viewCols != null) {
+      this.viewCols = viewCols.stream().map(CIStr::getO).collect(Collectors.toList());
+    } else {
+      this.viewCols = new ArrayList<>();
+    }
   }
 }


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
This PR fixes TiSpark cannot parse view table's json.

### What is changed and how it works?
ViewCols could be null. If such case happens, we do not need parse viewCols.

Tests <!-- At least one of them must be included. -->
 - Integration test

