### PR TITLE
Fix task retry if tikv is down

### DIFF
--- a/tikv-client/src/main/java/com/pingcap/tikv/operation/KVErrorHandler.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/operation/KVErrorHandler.java
@@ -248,6 +248,8 @@ public class KVErrorHandler<RespT> implements ErrorHandler<RespT> {
         BackOffFunction.BackOffFuncType.BoTiKVRPC,
         new GrpcException(
             "send tikv request error: " + e.getMessage() + ", try next peer later", e));
+    // TiKV maybe down, so do not retry in `callWithRetry`
+    // should refetch the new leader from PD and send request to it
     return false;
   }
 }

--- a/tikv-client/src/main/java/com/pingcap/tikv/operation/KVErrorHandler.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/operation/KVErrorHandler.java
@@ -248,6 +248,6 @@ public class KVErrorHandler<RespT> implements ErrorHandler<RespT> {
         BackOffFunction.BackOffFuncType.BoTiKVRPC,
         new GrpcException(
             "send tikv request error: " + e.getMessage() + ", try next peer later", e));
-    return true;
+    return false;
   }
 }

--- a/tikv-client/src/main/java/com/pingcap/tikv/policy/RetryPolicy.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/policy/RetryPolicy.java
@@ -62,7 +62,7 @@ public abstract class RetryPolicy<RespT> {
       }
 
       // Handle response error
-      if (handler != null) {
+      if (handler != null && result != null) {
         boolean retry = handler.handleResponseError(backOffer, result);
         if (retry) {
           continue;


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
close https://github.com/pingcap/tispark/issues/1208

Retry fails if TiKV is down during spark task running

### What is changed and how it works?
 if TiKV is down during spark task running, tispark will refetch leader from PD.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

1. set breakpoint on RegionStoreClient.java line 713
2. start a tidb cluster with 3 TiKV instance
3. select data from tidb
4. stop on breakpoint on RegionStoreClient.java line 713
5. kill a tikv instance
6. continue running

Related changes

 - Need to cherry-pick to the release branch

