### PR TITLE
use `df.limit(1).count`  instead of `df.count` to express `df.isEmpty`

### DIFF
--- a/core/src/main/scala/com/pingcap/tispark/TiBatchWrite.scala
+++ b/core/src/main/scala/com/pingcap/tispark/TiBatchWrite.scala
@@ -29,6 +29,7 @@ import com.pingcap.tikv.types.IntegerType
 import com.pingcap.tikv.util.{BackOffer, ConcreteBackOffer, KeyRangeUtils}
 import com.pingcap.tikv.{TiBatchWriteUtils, TiDBJDBCClient, _}
 import com.pingcap.tispark.TiBatchWrite.TiRow
+import com.pingcap.tispark.utils.TiUtil
 import org.apache.spark.Partitioner
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException
@@ -141,7 +142,7 @@ class TiBatchWrite(@transient val df: DataFrame,
     checkUnsupported()
 
     // check empty
-    if (df.count() == 0) {
+    if (TiUtil.isDataFrameEmpty(df)) {
       logger.warn("data is empty!")
       return
     }

--- a/core/src/main/scala/com/pingcap/tispark/utils/TiUtil.scala
+++ b/core/src/main/scala/com/pingcap/tispark/utils/TiUtil.scala
@@ -25,6 +25,7 @@ import com.pingcap.tikv.region.RegionStoreClient.RequestTypes
 import com.pingcap.tikv.types._
 import com.pingcap.tispark.{BasicExpression, TiConfigConst, TiDBRelation}
 import org.apache.spark.SparkConf
+import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.catalyst.expressions.aggregate._
 import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Expression, Literal, NamedExpression}
 import org.apache.spark.sql.execution.SparkPlan
@@ -123,6 +124,10 @@ object TiUtil {
       )
     }
     new StructType(fields)
+  }
+
+  def isDataFrameEmpty(df: DataFrame): Boolean = {
+    df.limit(1).count() == 0
   }
 
   def sparkConfToTiConf(conf: SparkConf): TiConfiguration = {


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
Close #1228

### What is changed and how it works?
implement a dataset empty check util function; and use it instead of checking it by `df.count() == 0` to improve the performance

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

Related changes

 - Need to cherry-pick to the release branch
