### PR TITLE
fix output offsets

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/TiStrategy.scala
+++ b/core/src/main/scala/org/apache/spark/sql/TiStrategy.scala
@@ -233,7 +233,6 @@ case class TiStrategy(getOrCreateTiContext: SparkSession => TiContext)(sparkSess
                 ref.getType
             )
           )
-
       case _ =>
     }
 

--- a/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
@@ -19,6 +19,11 @@ import com.pingcap.tispark.TiConfigConst
 import org.apache.spark.sql.functions.{col, sum}
 
 class IssueTestSuite extends BaseTiSparkTest {
+  test("abc") {
+    explainAndRunTest(
+      "select  id_dt  from full_data_type_table  where tp_timestamp = '2017-11-02 08:47:43'"
+    )
+  }
 
   // https://github.com/pingcap/tispark/issues/1186
   test("Consider nulls order when performing TopN") {
@@ -308,6 +313,7 @@ class IssueTestSuite extends BaseTiSparkTest {
     t2_df.show
     val join_df = t1_group_df.join(t2_df, Seq("k1", "k2"), "left_outer")
     join_df.printSchema()
+    join_df.explain
     join_df.show
     val filter_df = join_df.filter(col("c2").isNotNull)
     filter_df.show

--- a/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
@@ -19,12 +19,6 @@ import com.pingcap.tispark.TiConfigConst
 import org.apache.spark.sql.functions.{col, sum}
 
 class IssueTestSuite extends BaseTiSparkTest {
-  test("abc") {
-    explainAndRunTest(
-      "select  id_dt  from full_data_type_table  where tp_timestamp = '2017-11-02 08:47:43'"
-    )
-  }
-
   // https://github.com/pingcap/tispark/issues/1186
   test("Consider nulls order when performing TopN") {
     // table `full_data_type_table` contains a single line of nulls

--- a/core/src/test/scala/org/apache/spark/sql/OutputOffsetsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/OutputOffsetsSuite.scala
@@ -1,0 +1,18 @@
+package org.apache.spark.sql
+
+class OutputOffsetsSuite extends BaseTiSparkTest {
+
+  test("test the correctness of setting output-offsets in dag request") {
+    judge("select sum(tp_double) from full_data_type_table group by id_dt, tp_float");
+    judge("select avg(tp_double) from full_data_type_table group by id_dt, tp_float");
+    judge("select count(tp_double) from full_data_type_table group by id_dt, tp_float");
+    judge("select min(tp_double) from full_data_type_table group by id_dt, tp_float");
+    judge("select max(tp_double) from full_data_type_table group by id_dt, tp_float");
+    judge(
+      "select sum(tp_double), avg(tp_float) from full_data_type_table group by id_dt, tp_float"
+    );
+    judge(
+      "select count(tp_double), avg(tp_float) from full_data_type_table group by id_dt, tp_float"
+    );
+  }
+}

--- a/tikv-client/src/main/java/com/pingcap/tikv/expression/visitor/ProtoConverter.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/expression/visitor/ProtoConverter.java
@@ -72,8 +72,13 @@ public class ProtoConverter extends Visitor<Expr, Object> {
 
   private DataType getType(Expression expression) {
     DataType type = typeMap.get(expression);
+
     if (type == null) {
       throw new TiExpressionException(String.format("Expression %s type unknown", expression));
+    }
+    // for timestamp type, coprocessor will use datetime to do calculation.
+    if (type instanceof TimestampType) {
+      return DateTimeType.DATETIME;
     }
     return type;
   }

--- a/tikv-client/src/main/java/com/pingcap/tikv/expression/visitor/ProtoConverter.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/expression/visitor/ProtoConverter.java
@@ -264,7 +264,7 @@ public class ProtoConverter extends Visitor<Expr, Object> {
     // the first executor of a DAG request.
     IntegerCodec.writeLong(cdo, position);
     builder.setVal(cdo.toByteString());
-
+    builder.setFieldType(toPBFieldType(getType(node)));
     return builder.build();
   }
 
@@ -279,6 +279,7 @@ public class ProtoConverter extends Visitor<Expr, Object> {
       CodecDataOutput cdo = new CodecDataOutput();
       type.encode(cdo, EncodeType.PROTO, node.getValue());
       builder.setVal(cdo.toByteString());
+      builder.setFieldType(toPBFieldType(getType(node)));
     }
     return builder.build();
   }

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/TimestampType.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/TimestampType.java
@@ -109,6 +109,7 @@ public class TimestampType extends AbstractDateTimeType {
     DateTime utcDateTime = localExtendedDateTime.getDateTime().toDateTime(DateTimeZone.UTC);
     ExtendedDateTime utcExtendedDateTime =
         new ExtendedDateTime(utcDateTime, localExtendedDateTime.getMicrosOfMillis());
-    DateTimeCodec.writeDateTimeProto(cdo, utcExtendedDateTime, Converter.getLocalTimezone());
+    // when we encode timestamp we need use timestamp's timezone
+    DateTimeCodec.writeDateTimeProto(cdo, utcExtendedDateTime, getTimezone());
   }
 }

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/TimestampType.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/TimestampType.java
@@ -109,7 +109,6 @@ public class TimestampType extends AbstractDateTimeType {
     DateTime utcDateTime = localExtendedDateTime.getDateTime().toDateTime(DateTimeZone.UTC);
     ExtendedDateTime utcExtendedDateTime =
         new ExtendedDateTime(utcDateTime, localExtendedDateTime.getMicrosOfMillis());
-    // when we encode timestamp we need use timestamp's timezone
-    DateTimeCodec.writeDateTimeProto(cdo, utcExtendedDateTime, getTimezone());
+    DateTimeCodec.writeDateTimeProto(cdo, utcExtendedDateTime, Converter.getLocalTimezone());
   }
 }


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
This PR adds field type to Constant and ColumnRef when encode proto. 

With this, tikv can switch to vectorize execution which can improve the performance. 


When we push down a timestamp literal, tidb will convert it to datetime type.  TiSpark should adopt this behavior. 

Related changes

 - Need to cherry-pick to the release branch

