### PR TITLE
Push decimal

### DIFF
--- a/core/src/main/scala/com/pingcap/tispark/BasicExpression.scala
+++ b/core/src/main/scala/com/pingcap/tispark/BasicExpression.scala
@@ -130,6 +130,14 @@ object BasicExpression {
       case Like(BasicExpression(lhs), BasicExpression(rhs)) =>
         Some(StringRegExpression.like(lhs, rhs))
 
+      // Coprocessor has its own behavior of type promoting and overflow check
+      // so we simply remove it from expression and let cop handle it
+      case CheckOverflow(BasicExpression(expr), _) =>
+        Some(expr)
+
+      case PromotePrecision(Cast(BasicExpression(expr), _, _)) =>
+        Some(expr)
+
       // TODO: Are all AttributeReference column reference in such context?
       case attr: AttributeReference =>
         // Do we need add ValToType in TiExpr?

--- a/core/src/main/scala/com/pingcap/tispark/BasicExpression.scala
+++ b/core/src/main/scala/com/pingcap/tispark/BasicExpression.scala
@@ -135,7 +135,7 @@ object BasicExpression {
       case CheckOverflow(BasicExpression(expr), _) =>
         Some(expr)
 
-      case PromotePrecision(Cast(BasicExpression(expr), _, _)) =>
+      case PromotePrecision(Cast(BasicExpression(expr), _: DecimalType, _)) =>
         Some(expr)
 
       // TODO: Are all AttributeReference column reference in such context?

--- a/core/src/main/scala/com/pingcap/tispark/utils/TiUtil.scala
+++ b/core/src/main/scala/com/pingcap/tispark/utils/TiUtil.scala
@@ -31,7 +31,7 @@ import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Expression
 import org.apache.spark.sql.tispark.BasicExpression
 import org.apache.spark.sql.types.{MetadataBuilder, StructField, StructType}
 import org.apache.spark.sql.{DataFrame, Row, SparkSession}
-import org.apache.spark.{SparkConf, sql}
+import org.apache.spark.{sql, SparkConf}
 import org.tikv.kvproto.Kvrpcpb.{CommandPri, IsolationLevel}
 
 import scala.collection.JavaConversions._

--- a/core/src/main/scala/com/pingcap/tispark/utils/TiUtil.scala
+++ b/core/src/main/scala/com/pingcap/tispark/utils/TiUtil.scala
@@ -24,13 +24,14 @@ import com.pingcap.tikv.expression.visitor.{MetaResolver, SupportedExpressionVal
 import com.pingcap.tikv.meta.{TiColumnInfo, TiDAGRequest, TiTableInfo}
 import com.pingcap.tikv.region.RegionStoreClient.RequestTypes
 import com.pingcap.tikv.types._
-import com.pingcap.tispark._
+import com.pingcap.tispark.{TiConfigConst, TiDBRelation, _}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.aggregate._
 import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Expression, GenericInternalRow, Literal, NamedExpression}
+import org.apache.spark.sql.tispark.BasicExpression
 import org.apache.spark.sql.types.{MetadataBuilder, StructField, StructType}
 import org.apache.spark.sql.{DataFrame, Row, SparkSession}
-import org.apache.spark.{sql, SparkConf}
+import org.apache.spark.{SparkConf, sql}
 import org.tikv.kvproto.Kvrpcpb.{CommandPri, IsolationLevel}
 
 import scala.collection.JavaConversions._

--- a/core/src/main/scala/org/apache/spark/sql/TiStrategy.scala
+++ b/core/src/main/scala/org/apache/spark/sql/TiStrategy.scala
@@ -30,7 +30,7 @@ import com.pingcap.tispark.statistics.StatisticsManager
 import org.apache.spark.sql.execution.TiConverter._
 import com.pingcap.tispark.utils.TiUtil
 import com.pingcap.tispark.utils.ReflectionUtil._
-import com.pingcap.tispark.{BasicExpression, TiConfigConst, TiDBRelation}
+import com.pingcap.tispark.{TiConfigConst, TiDBRelation}
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.analysis.CleanupAliases
 import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, _}
@@ -41,6 +41,7 @@ import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.execution.{ColumnarCoprocessorRDD, _}
 import org.apache.spark.sql.execution.datasources.LogicalRelation
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.tispark.BasicExpression
 import org.joda.time.{DateTime, DateTimeZone}
 
 import scala.collection.JavaConverters._

--- a/core/src/main/scala/org/apache/spark/sql/tispark/BasicExpression.scala
+++ b/core/src/main/scala/org/apache/spark/sql/tispark/BasicExpression.scala
@@ -13,7 +13,6 @@
  * limitations under the License.
  */
 
-
 package org.apache.spark.sql.tispark
 
 import java.sql.Timestamp

--- a/core/src/main/scala/org/apache/spark/sql/tispark/BasicExpression.scala
+++ b/core/src/main/scala/org/apache/spark/sql/tispark/BasicExpression.scala
@@ -65,10 +65,10 @@ object BasicExpression {
 
   def sameCopType(lhs: DataType, rhs: DataType): Boolean = {
     (lhs, rhs) match {
-      case (_: IntegralType, _: IntegralType) => true
-      case (_: DecimalType, _: DecimalType) => true
+      case (_: IntegralType, _: IntegralType)                           => true
+      case (_: DecimalType, _: DecimalType)                             => true
       case (_: FloatType | _: DoubleType, _: FloatType | _: DoubleType) => true
-      case _ => lhs.sameType(rhs)
+      case _                                                            => lhs.sameType(rhs)
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/tispark/BasicExpression.scala
+++ b/core/src/main/scala/org/apache/spark/sql/tispark/BasicExpression.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 package org.apache.spark.sql.tispark
 
 import java.sql.Timestamp

--- a/core/src/main/scala/org/apache/spark/sql/tispark/BasicExpression.scala
+++ b/core/src/main/scala/org/apache/spark/sql/tispark/BasicExpression.scala
@@ -127,6 +127,9 @@ object BasicExpression {
       case CheckOverflow(BasicExpression(expr), _) =>
         Some(expr)
 
+      case PromotePrecision(BasicExpression(expr)) =>
+        Some(expr)
+
       case PromotePrecision(Cast(BasicExpression(expr), _: DecimalType, _)) =>
         Some(expr)
 

--- a/core/src/test/scala/org/apache/spark/sql/expression/index/UnsignedTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/index/UnsignedTestSuite.scala
@@ -41,7 +41,6 @@ class UnsignedTestSuite extends BaseTiSparkTest {
 
     tidbStmt.execute("ANALYZE TABLE `unsigned_test`")
     refreshConnections()
-    judge("select * from unsigned_test where c2 < 18446744073709551616")
 
     // TODO: After we fixed unsigned behavior, delete `skipped` setting for this test
     val queries = Seq[String](

--- a/core/src/test/scala/org/apache/spark/sql/expression/index/UnsignedTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/index/UnsignedTestSuite.scala
@@ -38,8 +38,11 @@ class UnsignedTestSuite extends BaseTiSparkTest {
         |  (0,18446744073709551615,-9223372036854775808),
         |  (18446744073709551615,18446744073709551615,9223372036854775807)""".stripMargin
     )
+
     tidbStmt.execute("ANALYZE TABLE `unsigned_test`")
     refreshConnections()
+    judge("select * from unsigned_test where c2 < 18446744073709551616")
+
     // TODO: After we fixed unsigned behavior, delete `skipped` setting for this test
     val queries = Seq[String](
       "select * from unsigned_test",
@@ -112,6 +115,7 @@ class UnsignedTestSuite extends BaseTiSparkTest {
     )
     assert(queries.size == answers.size)
     for (i <- queries.indices) {
+      println(queries(i))
       explainAndRunTest(queries(i), rJDBC = answers(i), skipTiDB = true)
     }
   }

--- a/tikv-client/src/main/java/com/pingcap/tikv/codec/Codec.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/codec/Codec.java
@@ -415,7 +415,20 @@ public class Codec {
      * @param cdo cdo is destination data.
      * @param dec is decimal value that will be written into cdo.
      */
-    static void writeDecimal(CodecDataOutput cdo, MyDecimal dec) {
+    public static void writeDecimal(
+        CodecDataOutput cdo, MyDecimal dec, int precision, int fraction) {
+      int[] data = dec.toBin(precision, fraction);
+      cdo.writeByte(precision);
+      cdo.writeByte(fraction);
+      for (int aData : data) {
+        cdo.writeByte(aData & 0xFF);
+      }
+    }
+
+    //  TODO remove this once we refactor unit test CodecTest
+    public static void writeDecimal(CodecDataOutput cdo, BigDecimal val) {
+      MyDecimal dec = new MyDecimal();
+      dec.fromString(val.toPlainString());
       int[] data = dec.toBin(dec.precision(), dec.frac());
       cdo.writeByte(dec.precision());
       cdo.writeByte(dec.frac());
@@ -424,26 +437,10 @@ public class Codec {
       }
     }
 
-    public static void writeDecimalFully(CodecDataOutput cdo, BigDecimal val) {
+    public static void writeDecimalFully(
+        CodecDataOutput cdo, MyDecimal val, int precision, int fraction) {
       cdo.writeByte(DECIMAL_FLAG);
-      writeDecimal(cdo, val);
-    }
-
-    public static void writeDecimalFully(CodecDataOutput cdo, MyDecimal val) {
-      cdo.writeByte(DECIMAL_FLAG);
-      writeDecimal(cdo, val);
-    }
-
-    /**
-     * Encoding a double value to byte buffer
-     *
-     * @param cdo For outputting data in bytes array
-     * @param val The data to encode
-     */
-    public static void writeDecimal(CodecDataOutput cdo, BigDecimal val) {
-      MyDecimal dec = new MyDecimal();
-      dec.fromString(val.toPlainString());
-      writeDecimal(cdo, dec);
+      writeDecimal(cdo, val, precision, fraction);
     }
   }
 

--- a/tikv-client/src/main/java/com/pingcap/tikv/expression/Constant.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/expression/Constant.java
@@ -16,6 +16,7 @@
 package com.pingcap.tikv.expression;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.primitives.UnsignedLong;
 import com.pingcap.tikv.exception.TiExpressionException;
 import com.pingcap.tikv.types.*;
 import java.math.BigDecimal;
@@ -123,5 +124,17 @@ public class Constant implements Expression {
   @Override
   public <R, C> R accept(Visitor<R, C> visitor, C context) {
     return visitor.visit(this, context);
+  }
+
+  private BigDecimal UNSIGNED_LONG_MAX = new BigDecimal(UnsignedLong.fromLongBits(-1).toString());
+
+  public boolean isOverflowed() {
+    if (type instanceof IntegerType) {
+      if (((IntegerType) type).isUnsignedLong()) {
+        return ((BigDecimal) value).min(UNSIGNED_LONG_MAX).signum() > 0
+            || ((BigDecimal) value).signum() < 0;
+      }
+    }
+    return false;
   }
 }

--- a/tikv-client/src/main/java/com/pingcap/tikv/expression/visitor/ProtoConverter.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/expression/visitor/ProtoConverter.java
@@ -280,6 +280,12 @@ public class ProtoConverter extends Visitor<Expr, Object> {
     if (node.getValue() == null) {
       builder.setTp(ExprType.Null);
     } else {
+      // this is useful since SupportedExpressionValidator will catch this exception
+      // can mark it cannot be pushed down to coprocessor.
+      if (node.isOverflowed()) {
+        throw new UnsupportedOperationException(
+            "overflowed value cannot be pushed down to coprocessor");
+      }
       builder.setTp(type.getProtoExprType());
       CodecDataOutput cdo = new CodecDataOutput();
       type.encode(cdo, EncodeType.PROTO, node.getValue());

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/DecimalType.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/DecimalType.java
@@ -127,28 +127,27 @@ public class DecimalType extends DataType {
 
   @Override
   protected void encodeKey(CodecDataOutput cdo, Object value) {
-    if (value instanceof MyDecimal) {
-      DecimalCodec.writeDecimalFully(cdo, (MyDecimal) value);
+    if (value instanceof BigDecimal) {
+      MyDecimal dec = new MyDecimal();
+      dec.fromString(((BigDecimal) value).toPlainString());
+      DecimalCodec.writeDecimalFully(cdo, dec, (int) this.length, this.decimal);
     } else {
-      BigDecimal val = Converter.convertToBigDecimal(value);
-      DecimalCodec.writeDecimalFully(cdo, val);
+      DecimalCodec.writeDecimalFully(cdo, (MyDecimal) value, (int) this.length, this.decimal);
     }
   }
 
   @Override
   protected void encodeValue(CodecDataOutput cdo, Object value) {
-    if (value instanceof MyDecimal) {
-      DecimalCodec.writeDecimalFully(cdo, (MyDecimal) value);
-    } else {
-      BigDecimal val = Converter.convertToBigDecimal(value);
-      DecimalCodec.writeDecimalFully(cdo, val);
-    }
+    // we can simply encodeKey here since the encoded value of decimal is also need comparable.
+    encodeKey(cdo, value);
   }
 
   @Override
   protected void encodeProto(CodecDataOutput cdo, Object value) {
     BigDecimal val = Converter.convertToBigDecimal(value);
-    DecimalCodec.writeDecimal(cdo, val);
+    MyDecimal dec = new MyDecimal();
+    dec.fromString(val.toPlainString());
+    DecimalCodec.writeDecimal(cdo, dec, dec.precision(), dec.frac());
   }
 
   @Override

--- a/tikv-client/src/test/java/com/pingcap/tikv/codec/MyDecimalTest.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/codec/MyDecimalTest.java
@@ -99,6 +99,7 @@ public class MyDecimalTest {
     tests.add(new MyDecimalTestStruct("0000000.001", "0.001", 3, 3));
     tests.add(new MyDecimalTestStruct("0.00012345000098765", "0.00012345000098765", 17, 17));
     tests.add(new MyDecimalTestStruct("-0.00012345000098765", "-0.00012345000098765", 17, 17));
+    tests.add(new MyDecimalTestStruct("0", "0", 1, 0));
     for (MyDecimalTestStruct a : tests) {
       MyDecimal dec = new MyDecimal();
       dec.fromString(a.in);

--- a/tikv-client/src/test/java/com/pingcap/tikv/types/DecimalTypeTest.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/types/DecimalTypeTest.java
@@ -17,8 +17,6 @@
 
 package com.pingcap.tikv.types;
 
-import static org.junit.Assert.assertEquals;
-
 import com.pingcap.tikv.codec.CodecDataInput;
 import com.pingcap.tikv.codec.CodecDataOutput;
 import com.pingcap.tikv.types.DataType.EncodeType;
@@ -30,9 +28,10 @@ public class DecimalTypeTest {
   public void encodeTest() {
     DataType type = DecimalType.DECIMAL;
     BigDecimal originalVal = BigDecimal.valueOf(6.66);
-    byte[] encodedKey = encode(originalVal, EncodeType.KEY, type);
-    Object val = decode(encodedKey, type);
-    assertEquals(originalVal, val);
+    // TODO(Zhexuan Yang) DecimalType.DECIMAL has unspecified len which cannot be used in encode.
+    // byte[] encodedKey = encode(originalVal, EncodeType.VALUE, type);
+    // Object val = decode(encodedKey, type);
+    // assertEquals(originalVal, val);
   }
 
   private static byte[] encode(Object val, EncodeType encodeType, DataType type) {

--- a/tikv-client/src/test/java/com/pingcap/tikv/types/DecimalTypeTest.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/types/DecimalTypeTest.java
@@ -17,6 +17,8 @@
 
 package com.pingcap.tikv.types;
 
+import static org.junit.Assert.assertEquals;
+
 import com.pingcap.tikv.codec.CodecDataInput;
 import com.pingcap.tikv.codec.CodecDataOutput;
 import com.pingcap.tikv.types.DataType.EncodeType;
@@ -26,12 +28,11 @@ import org.junit.Test;
 public class DecimalTypeTest {
   @Test
   public void encodeTest() {
-    DataType type = DecimalType.DECIMAL;
+    DataType type = new DecimalType(MySQLType.TypeNewDecimal, 6, 2);
     BigDecimal originalVal = BigDecimal.valueOf(6.66);
-    // TODO(Zhexuan Yang) DecimalType.DECIMAL has unspecified len which cannot be used in encode.
-    // byte[] encodedKey = encode(originalVal, EncodeType.VALUE, type);
-    // Object val = decode(encodedKey, type);
-    // assertEquals(originalVal, val);
+    byte[] encodedKey = encode(originalVal, EncodeType.VALUE, type);
+    Object val = decode(encodedKey, type);
+    assertEquals(originalVal, val);
   }
 
   private static byte[] encode(Object val, EncodeType encodeType, DataType type) {


### PR DESCRIPTION
In order to make decimal pushable to TiFlash cop, we need to remove checkoverflow and promote_precision. Both TiFlash and TiKV's cop has its own logic of promoting and checkoverflow we should just trust them for their own part.