### PR TITLE
disable set, enum and bit pushed down

### DIFF
--- a/core/src/main/scala/com/pingcap/tispark/utils/TiUtil.scala
+++ b/core/src/main/scala/com/pingcap/tispark/utils/TiUtil.scala
@@ -28,8 +28,6 @@ import org.apache.spark.SparkConf
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.catalyst.expressions.aggregate._
 import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Expression, Literal, NamedExpression}
-import org.apache.spark.sql.execution.SparkPlan
-import org.apache.spark.sql.execution.aggregate.SortAggregateExec
 import org.apache.spark.sql.types.{MetadataBuilder, StructField, StructType}
 import org.tikv.kvproto.Kvrpcpb.{CommandPri, IsolationLevel}
 
@@ -75,10 +73,9 @@ object TiUtil {
 
     if (expr.children.isEmpty) {
       expr match {
-        // bit/duration type is not allowed to be pushed down
+        // bit, duration, set, and enum type is not allowed to be pushed down
         case attr: AttributeReference if nameTypeMap.contains(attr.name) =>
-          val head = nameTypeMap.get(attr.name).head
-          return !head.isInstanceOf[BitType]
+          return nameTypeMap.get(attr.name).head.isPushDownSupported
         // TODO:Currently we do not support literal null type push down
         // when Constant is ready to support literal null or we have other
         // options, remove this.
@@ -96,6 +93,11 @@ object TiUtil {
 
     true
   }
+
+  def isSupportedOrderBy(expr: Expression,
+                         source: TiDBRelation,
+                         blacklist: ExpressionBlacklist): Boolean =
+    isSupportedBasicExpression(expr, source, blacklist) && isPushDownSupported(expr, source)
 
   def isSupportedFilter(expr: Expression,
                         source: TiDBRelation,

--- a/core/src/main/scala/org/apache/spark/sql/TiStrategy.scala
+++ b/core/src/main/scala/org/apache/spark/sql/TiStrategy.scala
@@ -308,8 +308,12 @@ case class TiStrategy(getOrCreateTiContext: SparkSession => TiContext)(sparkSess
     sortOrder: Seq[SortOrder]
   ): SparkPlan = {
     val request = new TiDAGRequest(pushDownType(), timeZoneOffsetInSeconds())
+    val filteredSortOrder =
+      sortOrder.filter(order => TiUtil.isSupportedOrderBy(order, source, blacklist))
+
     request.setLimit(limit)
-    addSortOrder(request, sortOrder)
+    addSortOrder(request, filteredSortOrder)
+
     pruneFilterProject(projectList, filterPredicates, source, request)
   }
 

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/BitType.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/BitType.java
@@ -97,4 +97,9 @@ public class BitType extends IntegerType {
     }
     return result;
   }
+
+  @Override
+  public boolean isPushDownSupported() {
+    return false;
+  }
 }

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/DataType.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/DataType.java
@@ -322,6 +322,13 @@ public abstract class DataType implements Serializable {
    */
   public abstract Object getOriginDefaultValueNonNull(String value, long version);
 
+  /**
+   * @return true if this type can be pushed down to TiKV or TiFLASH
+   */
+  public boolean isPushDownSupported() {
+    return true;
+  }
+
   public Object getOriginDefaultValue(String value, long version) {
     if (value == null) return null;
     return getOriginDefaultValueNonNull(value, version);

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/DataType.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/DataType.java
@@ -322,9 +322,7 @@ public abstract class DataType implements Serializable {
    */
   public abstract Object getOriginDefaultValueNonNull(String value, long version);
 
-  /**
-   * @return true if this type can be pushed down to TiKV or TiFLASH
-   */
+  /** @return true if this type can be pushed down to TiKV or TiFLASH */
   public boolean isPushDownSupported() {
     return true;
   }

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/EnumType.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/EnumType.java
@@ -140,4 +140,9 @@ public class EnumType extends DataType {
   public Object getOriginDefaultValueNonNull(String value, long version) {
     return value;
   }
+
+  @Override
+  public boolean isPushDownSupported() {
+    return false;
+  }
 }

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/JsonType.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/JsonType.java
@@ -389,4 +389,9 @@ public class JsonType extends DataType {
   public Object getOriginDefaultValueNonNull(String value, long version) {
     throw new AssertionError("json can't have a default value");
   }
+
+  @Override
+  public boolean isPushDownSupported() {
+    return false;
+  }
 }

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/SetType.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/SetType.java
@@ -121,4 +121,9 @@ public class SetType extends DataType {
   public Object getOriginDefaultValueNonNull(String value, long version) {
     return value;
   }
+
+  @Override
+  public boolean isPushDownSupported() {
+    return false;
+  }
 }

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/UninitializedType.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/UninitializedType.java
@@ -82,4 +82,10 @@ public class UninitializedType extends DataType {
     throw new UnsupportedOperationException(
         "UninitializedType cannot be applied in calculation process.");
   }
+
+  @Override
+  public boolean isPushDownSupported() {
+    throw new UnsupportedOperationException(
+        "UninitializedType cannot be applied in calculation process.");
+  }
 }


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
This PR disables set, enum and bit pushed down. 

The reason we do that is because TiKV does not support these type's pushdown. 

This PR closes https://github.com/pingcap/tispark/issues/1244
