### PR TITLE
cache data before write

### DIFF
--- a/core/src/main/scala/com/pingcap/tispark/TiBatchWrite.scala
+++ b/core/src/main/scala/com/pingcap/tispark/TiBatchWrite.scala
@@ -141,6 +141,9 @@ class TiBatchWrite(@transient val df: DataFrame,
     // check unsupported
     checkUnsupported()
 
+    // cache data
+    df.persist(org.apache.spark.storage.StorageLevel.MEMORY_AND_DISK)
+
     // check empty
     if (TiUtil.isDataFrameEmpty(df)) {
       logger.warn("data is empty!")


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
cache data before write to TiDB in order to avoid recaculating

### What is changed and how it works?
call `DataSet.persist`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

