### PR TITLE
fix datetime year overflow error message

### DIFF
--- a/core/src/test/scala/com/pingcap/tispark/datasource/BaseDataSourceTest.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/BaseDataSourceTest.scala
@@ -106,7 +106,6 @@ class BaseDataSourceTest(val table: String,
     data: List[Row],
     schema: StructType,
     jdbcErrorClass: Class[_],
-    jdbcErrorMsg: String,
     tidbErrorClass: Class[_],
     tidbErrorMsg: String,
     msgStartWith: Boolean = false
@@ -118,18 +117,6 @@ class BaseDataSourceTest(val table: String,
       caughtJDBC.getCause.getClass.equals(jdbcErrorClass),
       s"${caughtJDBC.getCause.getClass.getName} not equals to ${jdbcErrorClass.getName}"
     )
-
-    if (!msgStartWith) {
-      assert(
-        Objects.equals(caughtJDBC.getCause.getMessage, jdbcErrorMsg),
-        s"${caughtJDBC.getCause.getMessage} not equals to $jdbcErrorMsg"
-      )
-    } else {
-      assert(
-        startWith(caughtJDBC.getCause.getMessage, jdbcErrorMsg),
-        s"${caughtJDBC.getCause.getMessage} not start with $jdbcErrorMsg"
-      )
-    }
 
     val caughtTiDB = intercept[SparkException] {
       this.tidbWrite(data, schema)

--- a/core/src/test/scala/com/pingcap/tispark/overflow/BitOverflowSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/overflow/BitOverflowSuite.scala
@@ -37,7 +37,6 @@ class BitOverflowSuite extends BaseDataSourceTest("test_data_type_bit_overflow")
       )
     )
     val jdbcErrorClass = classOf[java.sql.BatchUpdateException]
-    val jdbcErrorMsg = "Data truncation"
     val tidbErrorClass = classOf[com.pingcap.tikv.exception.ConvertOverflowException]
     val tidbErrorMsg = "value 2 > upperBound 2"
 
@@ -45,7 +44,6 @@ class BitOverflowSuite extends BaseDataSourceTest("test_data_type_bit_overflow")
       List(row),
       schema,
       jdbcErrorClass,
-      jdbcErrorMsg,
       tidbErrorClass,
       tidbErrorMsg,
       msgStartWith = true
@@ -80,7 +78,6 @@ class BitOverflowSuite extends BaseDataSourceTest("test_data_type_bit_overflow")
       )
     )
     val jdbcErrorClass = classOf[java.sql.BatchUpdateException]
-    val jdbcErrorMsg = "Data truncation"
     val tidbErrorClass = classOf[com.pingcap.tikv.exception.ConvertOverflowException]
     val tidbErrorMsg = "value -1 < lowerBound 0"
 
@@ -88,7 +85,6 @@ class BitOverflowSuite extends BaseDataSourceTest("test_data_type_bit_overflow")
       List(row),
       schema,
       jdbcErrorClass,
-      jdbcErrorMsg,
       tidbErrorClass,
       tidbErrorMsg,
       msgStartWith = true
@@ -122,7 +118,6 @@ class BitOverflowSuite extends BaseDataSourceTest("test_data_type_bit_overflow")
       )
     )
     val jdbcErrorClass = classOf[java.sql.BatchUpdateException]
-    val jdbcErrorMsg = "Data truncation"
     val tidbErrorClass = classOf[com.pingcap.tikv.exception.ConvertOverflowException]
     val tidbErrorMsg = "value 16 > upperBound 16"
 
@@ -130,7 +125,6 @@ class BitOverflowSuite extends BaseDataSourceTest("test_data_type_bit_overflow")
       List(row),
       schema,
       jdbcErrorClass,
-      jdbcErrorMsg,
       tidbErrorClass,
       tidbErrorMsg,
       msgStartWith = true
@@ -164,7 +158,6 @@ class BitOverflowSuite extends BaseDataSourceTest("test_data_type_bit_overflow")
       )
     )
     val jdbcErrorClass = classOf[java.sql.BatchUpdateException]
-    val jdbcErrorMsg = "Data truncation"
     val tidbErrorClass = classOf[com.pingcap.tikv.exception.ConvertOverflowException]
     val tidbErrorMsg = "value -1 < lowerBound 0"
 
@@ -172,7 +165,6 @@ class BitOverflowSuite extends BaseDataSourceTest("test_data_type_bit_overflow")
       List(row),
       schema,
       jdbcErrorClass,
-      jdbcErrorMsg,
       tidbErrorClass,
       tidbErrorMsg,
       msgStartWith = true
@@ -207,7 +199,6 @@ class BitOverflowSuite extends BaseDataSourceTest("test_data_type_bit_overflow")
       )
     )
     val jdbcErrorClass = classOf[java.sql.BatchUpdateException]
-    val jdbcErrorMsg = "Data truncation"
     val tidbErrorClass = classOf[com.pingcap.tikv.exception.ConvertOverflowException]
     val tidbErrorMsg = "value 256 > upperBound 256"
 
@@ -215,7 +206,6 @@ class BitOverflowSuite extends BaseDataSourceTest("test_data_type_bit_overflow")
       List(row),
       schema,
       jdbcErrorClass,
-      jdbcErrorMsg,
       tidbErrorClass,
       tidbErrorMsg,
       msgStartWith = true
@@ -249,7 +239,6 @@ class BitOverflowSuite extends BaseDataSourceTest("test_data_type_bit_overflow")
       )
     )
     val jdbcErrorClass = classOf[java.sql.BatchUpdateException]
-    val jdbcErrorMsg = "Data truncation"
     val tidbErrorClass = classOf[com.pingcap.tikv.exception.ConvertOverflowException]
     val tidbErrorMsg = "value -1 < lowerBound 0"
 
@@ -257,7 +246,6 @@ class BitOverflowSuite extends BaseDataSourceTest("test_data_type_bit_overflow")
       List(row),
       schema,
       jdbcErrorClass,
-      jdbcErrorMsg,
       tidbErrorClass,
       tidbErrorMsg,
       msgStartWith = true

--- a/core/src/test/scala/com/pingcap/tispark/overflow/BytesOverflowSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/overflow/BytesOverflowSuite.scala
@@ -42,7 +42,6 @@ class BytesOverflowSuite extends BaseDataSourceTest("test_data_type_bytes_overfl
       )
     )
     val jdbcErrorClass = classOf[java.sql.BatchUpdateException]
-    val jdbcErrorMsg = "Data truncation: Data too long for column 'c1' at row 1"
     val tidbErrorClass = classOf[com.pingcap.tikv.exception.ConvertOverflowException]
     val tidbErrorMsg = "length 10 > max length 8"
 
@@ -50,7 +49,6 @@ class BytesOverflowSuite extends BaseDataSourceTest("test_data_type_bytes_overfl
       List(row),
       schema,
       jdbcErrorClass,
-      jdbcErrorMsg,
       tidbErrorClass,
       tidbErrorMsg
     )
@@ -83,7 +81,6 @@ class BytesOverflowSuite extends BaseDataSourceTest("test_data_type_bytes_overfl
       )
     )
     val jdbcErrorClass = classOf[java.sql.BatchUpdateException]
-    val jdbcErrorMsg = "Data truncation: Data too long for column 'c1' at row 1"
     val tidbErrorClass = classOf[com.pingcap.tikv.exception.ConvertOverflowException]
     val tidbErrorMsg = "length 10 > max length 8"
 
@@ -91,7 +88,6 @@ class BytesOverflowSuite extends BaseDataSourceTest("test_data_type_bytes_overfl
       List(row),
       schema,
       jdbcErrorClass,
-      jdbcErrorMsg,
       tidbErrorClass,
       tidbErrorMsg
     )
@@ -130,7 +126,6 @@ class BytesOverflowSuite extends BaseDataSourceTest("test_data_type_bytes_overfl
       )
     )
     val jdbcErrorClass = classOf[java.sql.BatchUpdateException]
-    val jdbcErrorMsg = "Data truncation: Data too long for column 'c1' at row 1"
     val tidbErrorClass = classOf[com.pingcap.tikv.exception.ConvertOverflowException]
     val tidbErrorMsg = "length 300 > max length 255"
 
@@ -138,7 +133,6 @@ class BytesOverflowSuite extends BaseDataSourceTest("test_data_type_bytes_overfl
       List(row),
       schema,
       jdbcErrorClass,
-      jdbcErrorMsg,
       tidbErrorClass,
       tidbErrorMsg
     )

--- a/core/src/test/scala/com/pingcap/tispark/overflow/DateOverflowSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/overflow/DateOverflowSuite.scala
@@ -37,7 +37,6 @@ class DateOverflowSuite extends BaseDataSourceTest("test_data_type_date_overflow
       )
     )
     val jdbcErrorClass = classOf[java.sql.BatchUpdateException]
-    val jdbcErrorMsg = "Data truncation: invalid time format: '{10000 1 1 0 0 0 0}'"
     val tidbErrorClass = classOf[java.lang.IllegalArgumentException]
     val tidbErrorMsg = null
 
@@ -45,7 +44,6 @@ class DateOverflowSuite extends BaseDataSourceTest("test_data_type_date_overflow
       List(row),
       schema,
       jdbcErrorClass,
-      jdbcErrorMsg,
       tidbErrorClass,
       tidbErrorMsg
     )
@@ -78,7 +76,6 @@ class DateOverflowSuite extends BaseDataSourceTest("test_data_type_date_overflow
       )
     )
     val jdbcErrorClass = classOf[java.sql.BatchUpdateException]
-    val jdbcErrorMsgStart = "Data truncation"
     val tidbErrorClass = classOf[java.lang.IllegalArgumentException]
     val tidbErrorMsgStart = null
 
@@ -86,7 +83,6 @@ class DateOverflowSuite extends BaseDataSourceTest("test_data_type_date_overflow
       List(row),
       schema,
       jdbcErrorClass,
-      jdbcErrorMsgStart,
       tidbErrorClass,
       tidbErrorMsgStart,
       msgStartWith = true

--- a/core/src/test/scala/com/pingcap/tispark/overflow/DateTimeOverflowSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/overflow/DateTimeOverflowSuite.scala
@@ -38,7 +38,6 @@ class DateTimeOverflowSuite extends BaseDataSourceTest("test_data_type_datetime_
       )
     )
     val jdbcErrorClass = classOf[java.sql.BatchUpdateException]
-    val jdbcErrorMsg = "Data truncation: invalid time format: '{10000 11 11 11 11 11 0}'"
     val tidbErrorClass = classOf[java.lang.IllegalArgumentException]
     val tidbErrorMsg = "Timestamp format must be yyyy-mm-dd hh:mm:ss[.fffffffff]"
 
@@ -46,7 +45,6 @@ class DateTimeOverflowSuite extends BaseDataSourceTest("test_data_type_datetime_
       List(row),
       schema,
       jdbcErrorClass,
-      jdbcErrorMsg,
       tidbErrorClass,
       tidbErrorMsg
     )

--- a/core/src/test/scala/com/pingcap/tispark/overflow/DecimalOverflowSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/overflow/DecimalOverflowSuite.scala
@@ -89,7 +89,6 @@ class DecimalOverflowSuite extends BaseDataSourceTest("test_data_type_decimal_ov
       )
 
       val jdbcErrorClass = classOf[java.sql.BatchUpdateException]
-      val jdbcErrorMsg = "Data truncation: Out of range value for column 'c1' at row 1"
       val tidbErrorClass = classOf[com.pingcap.tikv.exception.ConvertOverflowException]
       val tidbErrorMsg = "Out of range"
 
@@ -97,7 +96,6 @@ class DecimalOverflowSuite extends BaseDataSourceTest("test_data_type_decimal_ov
         List(row1),
         schema,
         jdbcErrorClass,
-        jdbcErrorMsg,
         tidbErrorClass,
         tidbErrorMsg
       )

--- a/core/src/test/scala/com/pingcap/tispark/overflow/EnumOverflowSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/overflow/EnumOverflowSuite.scala
@@ -34,7 +34,6 @@ class EnumOverflowSuite extends BaseDataSourceTest("test_data_type_enum_overflow
       )
     )
     val jdbcErrorClass = classOf[java.sql.BatchUpdateException]
-    val jdbcErrorMsg = "Incorrect enum value: 'abc' for column 'c1' at row 1"
     val tidbErrorClass = classOf[com.pingcap.tikv.exception.ConvertOverflowException]
     val tidbErrorMsg = "Incorrect enum value: 'abc'"
 
@@ -42,7 +41,6 @@ class EnumOverflowSuite extends BaseDataSourceTest("test_data_type_enum_overflow
       List(row),
       schema,
       jdbcErrorClass,
-      jdbcErrorMsg,
       tidbErrorClass,
       tidbErrorMsg
     )
@@ -72,7 +70,6 @@ class EnumOverflowSuite extends BaseDataSourceTest("test_data_type_enum_overflow
       )
     )
     val jdbcErrorClass = classOf[java.sql.BatchUpdateException]
-    val jdbcErrorMsg = "Incorrect enum value: '5' for column 'c1' at row 1"
     val tidbErrorClass = classOf[com.pingcap.tikv.exception.ConvertOverflowException]
     val tidbErrorMsg = "value 5 > upperBound 4"
 
@@ -80,7 +77,6 @@ class EnumOverflowSuite extends BaseDataSourceTest("test_data_type_enum_overflow
       List(row),
       schema,
       jdbcErrorClass,
-      jdbcErrorMsg,
       tidbErrorClass,
       tidbErrorMsg
     )

--- a/core/src/test/scala/com/pingcap/tispark/overflow/SignedOverflowSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/overflow/SignedOverflowSuite.scala
@@ -42,7 +42,6 @@ class SignedOverflowSuite extends BaseDataSourceTest("test_data_type_signed_over
       )
     )
     val jdbcErrorClass = classOf[java.sql.BatchUpdateException]
-    val jdbcErrorMsg = "Data truncation: Out of range value for column 'c1' at row 1"
     val tidbErrorClass = classOf[com.pingcap.tikv.exception.ConvertOverflowException]
     val tidbErrorMsg = "value 128 > upperBound 127"
 
@@ -50,7 +49,6 @@ class SignedOverflowSuite extends BaseDataSourceTest("test_data_type_signed_over
       List(row),
       schema,
       jdbcErrorClass,
-      jdbcErrorMsg,
       tidbErrorClass,
       tidbErrorMsg
     )
@@ -83,7 +81,6 @@ class SignedOverflowSuite extends BaseDataSourceTest("test_data_type_signed_over
       )
     )
     val jdbcErrorClass = classOf[java.sql.BatchUpdateException]
-    val jdbcErrorMsg = "Data truncation: Out of range value for column 'c1' at row 1"
     val tidbErrorClass = classOf[com.pingcap.tikv.exception.ConvertOverflowException]
     val tidbErrorMsg = "value -129 < lowerBound -128"
 
@@ -91,7 +88,6 @@ class SignedOverflowSuite extends BaseDataSourceTest("test_data_type_signed_over
       List(row),
       schema,
       jdbcErrorClass,
-      jdbcErrorMsg,
       tidbErrorClass,
       tidbErrorMsg
     )
@@ -124,7 +120,6 @@ class SignedOverflowSuite extends BaseDataSourceTest("test_data_type_signed_over
       )
     )
     val jdbcErrorClass = classOf[java.sql.BatchUpdateException]
-    val jdbcErrorMsg = "Data truncation: Out of range value for column 'c1' at row 1"
     val tidbErrorClass = classOf[com.pingcap.tikv.exception.ConvertOverflowException]
     val tidbErrorMsg = "value 32768 > upperBound 32767"
 
@@ -132,7 +127,6 @@ class SignedOverflowSuite extends BaseDataSourceTest("test_data_type_signed_over
       List(row),
       schema,
       jdbcErrorClass,
-      jdbcErrorMsg,
       tidbErrorClass,
       tidbErrorMsg
     )
@@ -165,7 +159,6 @@ class SignedOverflowSuite extends BaseDataSourceTest("test_data_type_signed_over
       )
     )
     val jdbcErrorClass = classOf[java.sql.BatchUpdateException]
-    val jdbcErrorMsg = "Data truncation: Out of range value for column 'c1' at row 1"
     val tidbErrorClass = classOf[com.pingcap.tikv.exception.ConvertOverflowException]
     val tidbErrorMsg = "value -32769 < lowerBound -32768"
 
@@ -173,7 +166,6 @@ class SignedOverflowSuite extends BaseDataSourceTest("test_data_type_signed_over
       List(row),
       schema,
       jdbcErrorClass,
-      jdbcErrorMsg,
       tidbErrorClass,
       tidbErrorMsg
     )
@@ -206,7 +198,6 @@ class SignedOverflowSuite extends BaseDataSourceTest("test_data_type_signed_over
       )
     )
     val jdbcErrorClass = classOf[java.sql.BatchUpdateException]
-    val jdbcErrorMsg = "Data truncation: Out of range value for column 'c1' at row 1"
     val tidbErrorClass = classOf[com.pingcap.tikv.exception.ConvertOverflowException]
     val tidbErrorMsg = "value 8388608 > upperBound 8388607"
 
@@ -214,7 +205,6 @@ class SignedOverflowSuite extends BaseDataSourceTest("test_data_type_signed_over
       List(row),
       schema,
       jdbcErrorClass,
-      jdbcErrorMsg,
       tidbErrorClass,
       tidbErrorMsg
     )
@@ -247,7 +237,6 @@ class SignedOverflowSuite extends BaseDataSourceTest("test_data_type_signed_over
       )
     )
     val jdbcErrorClass = classOf[java.sql.BatchUpdateException]
-    val jdbcErrorMsg = "Data truncation: Out of range value for column 'c1' at row 1"
     val tidbErrorClass = classOf[com.pingcap.tikv.exception.ConvertOverflowException]
     val tidbErrorMsg = "value -8388609 < lowerBound -8388608"
 
@@ -255,7 +244,6 @@ class SignedOverflowSuite extends BaseDataSourceTest("test_data_type_signed_over
       List(row),
       schema,
       jdbcErrorClass,
-      jdbcErrorMsg,
       tidbErrorClass,
       tidbErrorMsg
     )
@@ -288,7 +276,6 @@ class SignedOverflowSuite extends BaseDataSourceTest("test_data_type_signed_over
       )
     )
     val jdbcErrorClass = classOf[java.sql.BatchUpdateException]
-    val jdbcErrorMsg = "Data truncation: Out of range value for column 'c1' at row 1"
     val tidbErrorClass = classOf[com.pingcap.tikv.exception.ConvertOverflowException]
     val tidbErrorMsg = "value 2147483648 > upperBound 2147483647"
 
@@ -296,7 +283,6 @@ class SignedOverflowSuite extends BaseDataSourceTest("test_data_type_signed_over
       List(row),
       schema,
       jdbcErrorClass,
-      jdbcErrorMsg,
       tidbErrorClass,
       tidbErrorMsg
     )
@@ -329,7 +315,6 @@ class SignedOverflowSuite extends BaseDataSourceTest("test_data_type_signed_over
       )
     )
     val jdbcErrorClass = classOf[java.sql.BatchUpdateException]
-    val jdbcErrorMsg = "Data truncation: Out of range value for column 'c1' at row 1"
     val tidbErrorClass = classOf[com.pingcap.tikv.exception.ConvertOverflowException]
     val tidbErrorMsg = "value -2147483649 < lowerBound -2147483648"
 
@@ -337,7 +322,6 @@ class SignedOverflowSuite extends BaseDataSourceTest("test_data_type_signed_over
       List(row),
       schema,
       jdbcErrorClass,
-      jdbcErrorMsg,
       tidbErrorClass,
       tidbErrorMsg
     )
@@ -370,7 +354,6 @@ class SignedOverflowSuite extends BaseDataSourceTest("test_data_type_signed_over
       )
     )
     val jdbcErrorClass = classOf[java.sql.BatchUpdateException]
-    val jdbcErrorMsg = "Data truncation: Out of range value for column 'c1' at row 1"
     val tidbErrorClass = classOf[java.lang.NumberFormatException]
     val tidbErrorMsg = "For input string: \"9223372036854775808\""
 
@@ -378,7 +361,6 @@ class SignedOverflowSuite extends BaseDataSourceTest("test_data_type_signed_over
       List(row),
       schema,
       jdbcErrorClass,
-      jdbcErrorMsg,
       tidbErrorClass,
       tidbErrorMsg
     )
@@ -411,7 +393,6 @@ class SignedOverflowSuite extends BaseDataSourceTest("test_data_type_signed_over
       )
     )
     val jdbcErrorClass = classOf[java.sql.BatchUpdateException]
-    val jdbcErrorMsg = "Data truncation: Out of range value for column 'c1' at row 1"
     val tidbErrorClass = classOf[java.lang.NumberFormatException]
     val tidbErrorMsg = "For input string: \"-9223372036854775809\""
 
@@ -419,7 +400,6 @@ class SignedOverflowSuite extends BaseDataSourceTest("test_data_type_signed_over
       List(row),
       schema,
       jdbcErrorClass,
-      jdbcErrorMsg,
       tidbErrorClass,
       tidbErrorMsg
     )
@@ -452,7 +432,6 @@ class SignedOverflowSuite extends BaseDataSourceTest("test_data_type_signed_over
       )
     )
     val jdbcErrorClass = classOf[java.sql.BatchUpdateException]
-    val jdbcErrorMsg = "Data truncation: Out of range value for column 'c1' at row 1"
     val tidbErrorClass = classOf[com.pingcap.tikv.exception.ConvertOverflowException]
     val tidbErrorMsg = "value 128 > upperBound 127"
 
@@ -460,7 +439,6 @@ class SignedOverflowSuite extends BaseDataSourceTest("test_data_type_signed_over
       List(row),
       schema,
       jdbcErrorClass,
-      jdbcErrorMsg,
       tidbErrorClass,
       tidbErrorMsg
     )
@@ -493,7 +471,6 @@ class SignedOverflowSuite extends BaseDataSourceTest("test_data_type_signed_over
       )
     )
     val jdbcErrorClass = classOf[java.sql.BatchUpdateException]
-    val jdbcErrorMsg = "Data truncation: Out of range value for column 'c1' at row 1"
     val tidbErrorClass = classOf[com.pingcap.tikv.exception.ConvertOverflowException]
     val tidbErrorMsg = "value -129 < lowerBound -128"
 
@@ -501,7 +478,6 @@ class SignedOverflowSuite extends BaseDataSourceTest("test_data_type_signed_over
       List(row),
       schema,
       jdbcErrorClass,
-      jdbcErrorMsg,
       tidbErrorClass,
       tidbErrorMsg
     )

--- a/core/src/test/scala/com/pingcap/tispark/overflow/StringOverflowSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/overflow/StringOverflowSuite.scala
@@ -42,7 +42,6 @@ class StringOverflowSuite extends BaseDataSourceTest("test_data_type_string_over
       )
     )
     val jdbcErrorClass = classOf[java.sql.BatchUpdateException]
-    val jdbcErrorMsg = "Data truncation: Data too long for column 'c1' at row 1"
     val tidbErrorClass = classOf[com.pingcap.tikv.exception.ConvertOverflowException]
     val tidbErrorMsg = "value 123456789 length > max length 8"
 
@@ -50,7 +49,6 @@ class StringOverflowSuite extends BaseDataSourceTest("test_data_type_string_over
       List(row),
       schema,
       jdbcErrorClass,
-      jdbcErrorMsg,
       tidbErrorClass,
       tidbErrorMsg
     )
@@ -83,7 +81,6 @@ class StringOverflowSuite extends BaseDataSourceTest("test_data_type_string_over
       )
     )
     val jdbcErrorClass = classOf[java.sql.BatchUpdateException]
-    val jdbcErrorMsg = "Data truncation: Data too long for column 'c1' at row 1"
     val tidbErrorClass = classOf[com.pingcap.tikv.exception.ConvertOverflowException]
     val tidbErrorMsg = "value 123456789 length > max length 8"
 
@@ -91,7 +88,6 @@ class StringOverflowSuite extends BaseDataSourceTest("test_data_type_string_over
       List(row),
       schema,
       jdbcErrorClass,
-      jdbcErrorMsg,
       tidbErrorClass,
       tidbErrorMsg
     )
@@ -129,7 +125,6 @@ class StringOverflowSuite extends BaseDataSourceTest("test_data_type_string_over
       )
     )
     val jdbcErrorClass = classOf[java.sql.BatchUpdateException]
-    val jdbcErrorMsg = "Data truncation: Data too long for column 'c1' at row 1"
     val tidbErrorClass = classOf[com.pingcap.tikv.exception.ConvertOverflowException]
     val tidbErrorMsg = s"value $str length > max length 255"
 
@@ -137,7 +132,6 @@ class StringOverflowSuite extends BaseDataSourceTest("test_data_type_string_over
       List(row),
       schema,
       jdbcErrorClass,
-      jdbcErrorMsg,
       tidbErrorClass,
       tidbErrorMsg
     )
@@ -170,7 +164,6 @@ class StringOverflowSuite extends BaseDataSourceTest("test_data_type_string_over
       )
     )
     val jdbcErrorClass = classOf[java.sql.BatchUpdateException]
-    val jdbcErrorMsg = "Data truncation: Data too long for column 'c1' at row 1"
     val tidbErrorClass = classOf[com.pingcap.tikv.exception.ConvertOverflowException]
     val tidbErrorMsg = "value 123456789 length > max length 8"
 
@@ -178,7 +171,6 @@ class StringOverflowSuite extends BaseDataSourceTest("test_data_type_string_over
       List(row),
       schema,
       jdbcErrorClass,
-      jdbcErrorMsg,
       tidbErrorClass,
       tidbErrorMsg
     )

--- a/core/src/test/scala/com/pingcap/tispark/overflow/UnsignedOverflowSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/overflow/UnsignedOverflowSuite.scala
@@ -41,7 +41,6 @@ class UnsignedOverflowSuite extends BaseDataSourceTest("test_data_type_unsigned_
       )
     )
     val jdbcErrorClass = classOf[java.sql.BatchUpdateException]
-    val jdbcErrorMsg = "Data truncation: Out of range value for column 'c1' at row 1"
     val tidbErrorClass = classOf[com.pingcap.tikv.exception.ConvertOverflowException]
     val tidbErrorMsg = "value 256 > upperBound 255"
 
@@ -49,7 +48,6 @@ class UnsignedOverflowSuite extends BaseDataSourceTest("test_data_type_unsigned_
       List(row),
       schema,
       jdbcErrorClass,
-      jdbcErrorMsg,
       tidbErrorClass,
       tidbErrorMsg
     )
@@ -82,7 +80,6 @@ class UnsignedOverflowSuite extends BaseDataSourceTest("test_data_type_unsigned_
       )
     )
     val jdbcErrorClass = classOf[java.sql.BatchUpdateException]
-    val jdbcErrorMsg = "Data truncation: Out of range value for column 'c1' at row 1"
     val tidbErrorClass = classOf[com.pingcap.tikv.exception.ConvertOverflowException]
     val tidbErrorMsg = "value -1 < lowerBound 0"
 
@@ -90,7 +87,6 @@ class UnsignedOverflowSuite extends BaseDataSourceTest("test_data_type_unsigned_
       List(row),
       schema,
       jdbcErrorClass,
-      jdbcErrorMsg,
       tidbErrorClass,
       tidbErrorMsg
     )
@@ -123,7 +119,6 @@ class UnsignedOverflowSuite extends BaseDataSourceTest("test_data_type_unsigned_
       )
     )
     val jdbcErrorClass = classOf[java.sql.BatchUpdateException]
-    val jdbcErrorMsg = "Data truncation: Out of range value for column 'c1' at row 1"
     val tidbErrorClass = classOf[com.pingcap.tikv.exception.ConvertOverflowException]
     val tidbErrorMsg = "value 65536 > upperBound 65535"
 
@@ -131,7 +126,6 @@ class UnsignedOverflowSuite extends BaseDataSourceTest("test_data_type_unsigned_
       List(row),
       schema,
       jdbcErrorClass,
-      jdbcErrorMsg,
       tidbErrorClass,
       tidbErrorMsg
     )
@@ -164,7 +158,6 @@ class UnsignedOverflowSuite extends BaseDataSourceTest("test_data_type_unsigned_
       )
     )
     val jdbcErrorClass = classOf[java.sql.BatchUpdateException]
-    val jdbcErrorMsg = "Data truncation: Out of range value for column 'c1' at row 1"
     val tidbErrorClass = classOf[com.pingcap.tikv.exception.ConvertOverflowException]
     val tidbErrorMsg = "value -1 < lowerBound 0"
 
@@ -172,7 +165,6 @@ class UnsignedOverflowSuite extends BaseDataSourceTest("test_data_type_unsigned_
       List(row),
       schema,
       jdbcErrorClass,
-      jdbcErrorMsg,
       tidbErrorClass,
       tidbErrorMsg
     )
@@ -205,7 +197,6 @@ class UnsignedOverflowSuite extends BaseDataSourceTest("test_data_type_unsigned_
       )
     )
     val jdbcErrorClass = classOf[java.sql.BatchUpdateException]
-    val jdbcErrorMsg = "Data truncation: Out of range value for column 'c1' at row 1"
     val tidbErrorClass = classOf[com.pingcap.tikv.exception.ConvertOverflowException]
     val tidbErrorMsg = "value 16777216 > upperBound 16777215"
 
@@ -213,7 +204,6 @@ class UnsignedOverflowSuite extends BaseDataSourceTest("test_data_type_unsigned_
       List(row),
       schema,
       jdbcErrorClass,
-      jdbcErrorMsg,
       tidbErrorClass,
       tidbErrorMsg
     )
@@ -246,7 +236,6 @@ class UnsignedOverflowSuite extends BaseDataSourceTest("test_data_type_unsigned_
       )
     )
     val jdbcErrorClass = classOf[java.sql.BatchUpdateException]
-    val jdbcErrorMsg = "Data truncation: Out of range value for column 'c1' at row 1"
     val tidbErrorClass = classOf[com.pingcap.tikv.exception.ConvertOverflowException]
     val tidbErrorMsg = "value -1 < lowerBound 0"
 
@@ -254,7 +243,6 @@ class UnsignedOverflowSuite extends BaseDataSourceTest("test_data_type_unsigned_
       List(row),
       schema,
       jdbcErrorClass,
-      jdbcErrorMsg,
       tidbErrorClass,
       tidbErrorMsg
     )
@@ -287,7 +275,6 @@ class UnsignedOverflowSuite extends BaseDataSourceTest("test_data_type_unsigned_
       )
     )
     val jdbcErrorClass = classOf[java.sql.BatchUpdateException]
-    val jdbcErrorMsg = "Data truncation: Out of range value for column 'c1' at row 1"
     val tidbErrorClass = classOf[com.pingcap.tikv.exception.ConvertOverflowException]
     val tidbErrorMsg = "value 4294967296 > upperBound 4294967295"
 
@@ -295,7 +282,6 @@ class UnsignedOverflowSuite extends BaseDataSourceTest("test_data_type_unsigned_
       List(row),
       schema,
       jdbcErrorClass,
-      jdbcErrorMsg,
       tidbErrorClass,
       tidbErrorMsg
     )
@@ -328,8 +314,6 @@ class UnsignedOverflowSuite extends BaseDataSourceTest("test_data_type_unsigned_
       )
     )
     val jdbcErrorClass = classOf[java.lang.RuntimeException]
-    val jdbcErrorMsgStartWith =
-      "Error while encoding: java.lang.RuntimeException: java.lang.Integer is not a valid external type for schema of bigint\nif (assertnotnull(input[0, org.apache.spark.sql.Row, true]).isNullAt) null else validateexternaltype(getexternalrowfield(assertnotnull(input[0, org.apache.spark.sql.Row, true]), 0, c1), LongType) AS c1"
     val tidbErrorClass = classOf[java.lang.RuntimeException]
     val tidbErrorMsgStartWith =
       "Error while encoding: java.lang.RuntimeException: java.lang.Integer is not a valid external type for schema of bigint\nif (assertnotnull(input[0, org.apache.spark.sql.Row, true]).isNullAt) null else validateexternaltype(getexternalrowfield(assertnotnull(input[0, org.apache.spark.sql.Row, true]), 0, c1), LongType) AS c1"
@@ -338,7 +322,6 @@ class UnsignedOverflowSuite extends BaseDataSourceTest("test_data_type_unsigned_
       List(row),
       schema,
       jdbcErrorClass,
-      jdbcErrorMsgStartWith,
       tidbErrorClass,
       tidbErrorMsgStartWith,
       msgStartWith = true
@@ -372,7 +355,6 @@ class UnsignedOverflowSuite extends BaseDataSourceTest("test_data_type_unsigned_
       )
     )
     val jdbcErrorClass = classOf[java.sql.BatchUpdateException]
-    val jdbcErrorMsg = "Data truncation: Out of range value for column 'c1' at row 1"
     val tidbErrorClass = classOf[java.lang.NumberFormatException]
     val tidbErrorMsg = "Too large for unsigned long: 18446744073709551616"
 
@@ -380,7 +362,6 @@ class UnsignedOverflowSuite extends BaseDataSourceTest("test_data_type_unsigned_
       List(row),
       schema,
       jdbcErrorClass,
-      jdbcErrorMsg,
       tidbErrorClass,
       tidbErrorMsg
     )
@@ -413,7 +394,6 @@ class UnsignedOverflowSuite extends BaseDataSourceTest("test_data_type_unsigned_
       )
     )
     val jdbcErrorClass = classOf[java.sql.BatchUpdateException]
-    val jdbcErrorMsg = "Data truncation: Out of range value for column 'c1' at row 1"
     val tidbErrorClass = classOf[java.lang.NumberFormatException]
     val tidbErrorMsg = "-1"
 
@@ -421,7 +401,6 @@ class UnsignedOverflowSuite extends BaseDataSourceTest("test_data_type_unsigned_
       List(row),
       schema,
       jdbcErrorClass,
-      jdbcErrorMsg,
       tidbErrorClass,
       tidbErrorMsg
     )


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
close https://github.com/pingcap/tispark/issues/1251

tidb's error message changes, but we assert it in UT

### What is changed and how it works?

do not assert tidb's error message, cause it may change

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

