### PR TITLE
add scala version on artifactId

### DIFF
--- a/.ci/integration_test.groovy
+++ b/.ci/integration_test.groovy
@@ -10,11 +10,9 @@ def call(ghprbActualCommit, ghprbCommentBody, ghprbPullId, ghprbPullTitle, ghprb
     def PARALLEL_NUMBER = 18
     def MVN_PROFILE = ""
     def MVN_PROFILE_SCALA_2_12 = "-Pspark-2.4-scala-2.12"
-    def MVN_TEST_PROFILE1_SCALA_2_12 = "-Pjenkins-test-spark-3.0"
-    def MVN_TEST_PROFILE2_SCALA_2_12 = "-Pjenkins-test-spark-2.4"
+    def MVN_PROFILE_SCALA_2_12_TEST = ["-Pjenkins-test-spark-3.0", "-Pjenkins-test-spark-2.4"]
     def MVN_PROFILE_SCALA_2_11 = "-Pspark-2.3-scala-2.11"
-    def MVN_TEST_PROFILE1_SCALA_2_11 = "-Pjenkins-test-spark-2.4"
-    def MVN_TEST_PROFILE2_SCALA_2_11 = "-Pjenkins-test-spark-2.3"
+    def MVN_PROFILE_SCALA_2_11_TEST = ["-Pjenkins-test-spark-2.4", "-Pjenkins-test-spark-2.3"]
     
     // parse tidb branch
     def m1 = ghprbCommentBody =~ /tidb\s*=\s*([^\s\\]+)(\s|\\|$)/
@@ -155,13 +153,22 @@ def call(ghprbActualCommit, ghprbCommentBody, ghprbPullId, ghprbPullTitle, ghprb
                         archive_url=http://fileserver.pingcap.net/download/builds/pingcap/tispark/cache/tispark-m2-cache-latest.tar.gz
                         if [ ! "\$(ls -A /maven/.m2/repository)" ]; then curl -sL \$archive_url | tar -zx -C /maven || true; fi
                     """
-                    sh """
-                        export MAVEN_OPTS="-Xmx6G -XX:MaxPermSize=512M -XX:ReservedCodeCacheSize=51M"
-                        mvn clean test ${MVN_PROFILE} ${MVN_PROFILE_SCALA_2_11} ${MVN_TEST_PROFILE1_SCALA_2_11} -Dtest=moo ${mvnStr}
-                        mvn clean test ${MVN_PROFILE} ${MVN_PROFILE_SCALA_2_11} ${MVN_TEST_PROFILE2_SCALA_2_11} -Dtest=moo ${mvnStr}
-                        mvn clean test ${MVN_PROFILE} ${MVN_PROFILE_SCALA_2_12} ${MVN_TEST_PROFILE1_SCALA_2_12} -Dtest=moo ${mvnStr}
-                        mvn clean test ${MVN_PROFILE} ${MVN_PROFILE_SCALA_2_12} ${MVN_TEST_PROFILE2_SCALA_2_12} -Dtest=moo ${mvnStr}
-                    """
+
+                    MVN_PROFILE_SCALA_2_12_TEST.each { MVN_TEST_PROFILE ->
+                        sh """
+                            export MAVEN_OPTS="-Xmx6G -XX:MaxPermSize=512M -XX:ReservedCodeCacheSize=51M"
+                            mvn clean test ${MVN_PROFILE} ${MVN_PROFILE_SCALA_2_12} ${MVN_TEST_PROFILE} -Dtest=moo ${mvnStr}
+                        """
+                    }
+
+                    sh "./dev/change-scala-version.sh 2.11"
+
+                    MVN_PROFILE_SCALA_2_11_TEST.each { MVN_TEST_PROFILE ->
+                        sh """
+                            export MAVEN_OPTS="-Xmx6G -XX:MaxPermSize=512M -XX:ReservedCodeCacheSize=51M"
+                            mvn clean test ${MVN_PROFILE} ${MVN_PROFILE_SCALA_2_11} ${MVN_TEST_PROFILE} -Dtest=moo ${mvnStr}
+                        """
+                    }
                 }
             }
 

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -4,12 +4,12 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.pingcap.tispark</groupId>
-        <artifactId>tispark-parent</artifactId>
+        <artifactId>tispark-parent_2.12</artifactId>
         <version>2.3.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <artifactId>tispark-assembly</artifactId>
+    <artifactId>tispark-assembly_2.12</artifactId>
     <packaging>pom</packaging>
     <name>TiSpark Project Assembly</name>
     <url>http://github.copm/pingcap/tispark</url>
@@ -17,12 +17,12 @@
     <dependencies>
         <dependency>
             <groupId>com.pingcap.tispark</groupId>
-            <artifactId>tispark-core-internal</artifactId>
+            <artifactId>tispark-core-internal_2.12</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
         <dependency>
             <groupId>com.pingcap.tikv</groupId>
-            <artifactId>tikv-client</artifactId>
+            <artifactId>tikv-client_2.12</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
         <dependency>

--- a/assembly/src/main/assembly/assembly.xml
+++ b/assembly/src/main/assembly/assembly.xml
@@ -10,7 +10,7 @@
     <dependencySets>
         <dependencySet>
             <includes>
-                <include>com.pingcap.tispark:tispark-core-internal:jar</include>
+                <include>com.pingcap.tispark:tispark-core-internal_2.12:jar</include>
                 <include>com.pingcap.tikv:tikv-client:jar</include>
                 <include>mysql:mysql-connector-java:jar</include>
             </includes>
@@ -23,7 +23,7 @@
             <directory>
                 ${project.parent.basedir}/spark-wrapper/spark-2.3/target/classes/
             </directory>
-            <outputDirectory>resources/spark-wrapper-spark-2.3</outputDirectory>
+            <outputDirectory>resources/spark-wrapper-spark-2.3_2.12</outputDirectory>
             <includes>
                 <include>**/*</include>
             </includes>
@@ -32,7 +32,7 @@
             <directory>
                 ${project.parent.basedir}/spark-wrapper/spark-2.4/target/classes/
             </directory>
-            <outputDirectory>resources/spark-wrapper-spark-2.4</outputDirectory>
+            <outputDirectory>resources/spark-wrapper-spark-2.4_2.12</outputDirectory>
             <includes>
                 <include>**/*</include>
             </includes>
@@ -41,7 +41,7 @@
             <directory>
                 ${project.parent.basedir}/spark-wrapper/spark-3.0/target/classes/
             </directory>
-            <outputDirectory>resources/spark-wrapper-spark-3.0</outputDirectory>
+            <outputDirectory>resources/spark-wrapper-spark-3.0_2.12</outputDirectory>
             <includes>
                 <include>**/*</include>
             </includes>

--- a/core-test/pom.xml
+++ b/core-test/pom.xml
@@ -4,12 +4,12 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.pingcap.tispark</groupId>
-        <artifactId>tispark-parent</artifactId>
+        <artifactId>tispark-parent_2.12</artifactId>
         <version>2.3.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <artifactId>tispark-core-test</artifactId>
+    <artifactId>tispark-core-test_2.12</artifactId>
     <packaging>jar</packaging>
     <name>TiSpark Project Core Test</name>
     <url>http://github.copm/pingcap/tispark</url>
@@ -21,7 +21,7 @@
     <dependencies>
         <dependency>
             <groupId>com.pingcap.tispark</groupId>
-            <artifactId>tispark-core-internal</artifactId>
+            <artifactId>tispark-core-internal_2.12</artifactId>
             <version>${project.parent.version}</version>
             <exclusions>
                 <exclusion>
@@ -52,7 +52,7 @@
         </dependency>
         <dependency>
             <groupId>com.pingcap.tikv</groupId>
-            <artifactId>tikv-client</artifactId>
+            <artifactId>tikv-client_2.12</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
         <dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -4,12 +4,12 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.pingcap.tispark</groupId>
-        <artifactId>tispark-parent</artifactId>
+        <artifactId>tispark-parent_2.12</artifactId>
         <version>2.3.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <artifactId>tispark-core-internal</artifactId>
+    <artifactId>tispark-core-internal_2.12</artifactId>
     <packaging>jar</packaging>
     <name>TiSpark Project Core Internal</name>
     <url>http://github.copm/pingcap/tispark</url>
@@ -21,7 +21,7 @@
     <dependencies>
         <dependency>
             <groupId>com.pingcap.tikv</groupId>
-            <artifactId>tikv-client</artifactId>
+            <artifactId>tikv-client_2.12</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
         <dependency>

--- a/dev/change-scala-version.sh
+++ b/dev/change-scala-version.sh
@@ -1,0 +1,64 @@
+#!/bin/sh
+#
+#   Copyright 2019 PingCAP, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+set -e
+
+VALID_VERSIONS=( 2.11 2.12 )
+
+usage() {
+  echo "Usage: $(basename $0) [-h|--help] <version>
+where :
+  -h| --help Display this help text
+  valid version values : ${VALID_VERSIONS[*]}
+" 1>&2
+  exit 1
+}
+
+if [[ ($# -ne 1) || ( $1 == "--help") ||  $1 == "-h" ]]; then
+  usage
+fi
+
+TO_VERSION=$1
+
+check_scala_version() {
+  for i in ${VALID_VERSIONS[*]}; do [ $i = "$1" ] && return 0; done
+  echo "Invalid Scala version: $1. Valid versions: ${VALID_VERSIONS[*]}" 1>&2
+  exit 1
+}
+
+check_scala_version "$TO_VERSION"
+
+if [ $TO_VERSION = "2.11" ]; then
+  FROM_VERSION="2.12"
+else
+  FROM_VERSION="2.11"
+fi
+
+sed_i() {
+  sed -e "$1" "$2" > "$2.tmp" && mv "$2.tmp" "$2"
+}
+
+export -f sed_i
+
+BASEDIR=$(dirname $0)/..
+find "$BASEDIR" -name 'pom.xml' -not -path '*target*' -print \
+  -exec bash -c "sed_i 's/\(artifactId.*\)_'$FROM_VERSION'/\1_'$TO_VERSION'/g' {}" \;
+
+# Also update <scala.binary.version> in assembly.xml
+ASSEMBLY="$BASEDIR/assembly/src/main/assembly/assembly.xml"
+echo "$ASSEMBLY"
+sed_i 's/\(spark-wrapper-spark-.*\)_'$FROM_VERSION'/\1_'$TO_VERSION'/g' "$ASSEMBLY"
+sed_i 's/\(tispark-core-internal.*\)_'$FROM_VERSION'/\1_'$TO_VERSION'/g' "$ASSEMBLY"

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <groupId>com.pingcap.tispark</groupId>
-    <artifactId>tispark-parent</artifactId>
+    <artifactId>tispark-parent_2.12</artifactId>
     <version>2.3.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>TiSpark Project Parent POM</name>

--- a/spark-wrapper/spark-2.3/pom.xml
+++ b/spark-wrapper/spark-2.3/pom.xml
@@ -4,12 +4,12 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.pingcap.tispark</groupId>
-        <artifactId>tispark-parent</artifactId>
+        <artifactId>tispark-parent_2.12</artifactId>
         <version>2.3.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
-    <artifactId>spark-wrapper-spark-2.3</artifactId>
+    <artifactId>spark-wrapper-spark-2.3_2.12</artifactId>
     <packaging>jar</packaging>
     <name>TiSpark Project Spark Wrapper Spark-2.3</name>
     <url>http://github.copm/pingcap/tispark</url>
@@ -21,7 +21,7 @@
     <dependencies>
         <dependency>
             <groupId>com.pingcap.tispark</groupId>
-            <artifactId>tispark-core-internal</artifactId>
+            <artifactId>tispark-core-internal_2.12</artifactId>
             <version>${project.parent.version}</version>
             <exclusions>
                 <exclusion>

--- a/spark-wrapper/spark-2.4/pom.xml
+++ b/spark-wrapper/spark-2.4/pom.xml
@@ -4,12 +4,12 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.pingcap.tispark</groupId>
-        <artifactId>tispark-parent</artifactId>
+        <artifactId>tispark-parent_2.12</artifactId>
         <version>2.3.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
-    <artifactId>spark-wrapper-spark-2.4</artifactId>
+    <artifactId>spark-wrapper-spark-2.4_2.12</artifactId>
     <packaging>jar</packaging>
     <name>TiSpark Project Spark Wrapper Spark-2.4</name>
     <url>http://github.copm/pingcap/tispark</url>
@@ -21,7 +21,7 @@
     <dependencies>
         <dependency>
             <groupId>com.pingcap.tispark</groupId>
-            <artifactId>tispark-core-internal</artifactId>
+            <artifactId>tispark-core-internal_2.12</artifactId>
             <version>${project.parent.version}</version>
             <exclusions>
                 <exclusion>

--- a/spark-wrapper/spark-3.0/pom.xml
+++ b/spark-wrapper/spark-3.0/pom.xml
@@ -4,12 +4,12 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.pingcap.tispark</groupId>
-        <artifactId>tispark-parent</artifactId>
+        <artifactId>tispark-parent_2.12</artifactId>
         <version>2.3.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
-    <artifactId>spark-wrapper-spark-3.0</artifactId>
+    <artifactId>spark-wrapper-spark-3.0_2.12</artifactId>
     <packaging>jar</packaging>
     <name>TiSpark Project Spark Wrapper Spark-3.0</name>
     <url>http://github.copm/pingcap/tispark</url>
@@ -21,7 +21,7 @@
     <dependencies>
         <dependency>
             <groupId>com.pingcap.tispark</groupId>
-            <artifactId>tispark-core-internal</artifactId>
+            <artifactId>tispark-core-internal_2.12</artifactId>
             <version>${project.parent.version}</version>
             <exclusions>
                 <exclusion>

--- a/tikv-client/pom.xml
+++ b/tikv-client/pom.xml
@@ -4,13 +4,13 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.pingcap.tispark</groupId>
-        <artifactId>tispark-parent</artifactId>
+        <artifactId>tispark-parent_2.12</artifactId>
         <version>2.3.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <groupId>com.pingcap.tikv</groupId>
-    <artifactId>tikv-client</artifactId>
+    <artifactId>tikv-client_2.12</artifactId>
     <packaging>jar</packaging>
     <name>TiSpark Project TiKV Java Client</name>
 


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
support both scala-2.11 and scala-2.12 which are binary incompatible

### What is changed and how it works?
- add scala version on artifactId
- release two versions jars: `tispark-assembly_2.11-2.3.0-SNAPSHOT.jar` and `tispark-assembly_2.12-2.3.0-SNAPSHOT.jar` 

