### PR TITLE
rewrite the logic of TiSpark reading data from TiFlash

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/TiStrategy.scala
+++ b/core/src/main/scala/org/apache/spark/sql/TiStrategy.scala
@@ -103,6 +103,9 @@ case class TiStrategy(getOrCreateTiContext: SparkSession => TiContext)(sparkSess
   private def isEnableChunk(): Boolean =
     sqlConf.getConfString(TiConfigConst.ENABLE_CHUNK, "true").toLowerCase.toBoolean
 
+  private def isUseTiFlash(): Boolean =
+    sqlConf.getConfString(TiConfigConst.USE_TIFLASH, "false").toLowerCase.toBoolean
+
   private def timeZoneOffsetInSeconds(): Int = {
     val tz = DateTimeZone.getDefault
     val instant = DateTime.now.getMillis
@@ -300,7 +303,7 @@ case class TiStrategy(getOrCreateTiContext: SparkSession => TiContext)(sparkSess
 
     scanBuilder.buildTiDAGReq(
       allowIndexRead(),
-      tiContext.tiConf.isUseTiFlash,
+      isUseTiFlash(),
       tiColumns.map { _.getColumnInfo }.asJava,
       tiFilters.asJava,
       source.table,

--- a/core/src/main/scala/org/apache/spark/sql/execution/CoprocessorRDD.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/CoprocessorRDD.scala
@@ -59,7 +59,7 @@ trait LeafColumnarExecRDD extends LeafExecNode {
       b.append(s"with dag request: $dagRequest")
       b.toString()
     } else {
-      val engine = if (dagRequest.getUseTiFlash) {
+      val engine = if (dagRequest.isUseTiFlash) {
         "TiFlash"
       } else {
         "TiKV"

--- a/core/src/main/scala/org/apache/spark/sql/execution/CoprocessorRDD.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/CoprocessorRDD.scala
@@ -33,7 +33,7 @@ import org.apache.log4j.Logger
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{Attribute, UnsafeProjection}
+import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.plans.physical.{Partitioning, UnknownPartitioning}
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
 import org.apache.spark.sql.tispark.TiRDD

--- a/tikv-client/src/main/java/com/pingcap/tikv/meta/TiDAGRequest.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/meta/TiDAGRequest.java
@@ -158,7 +158,7 @@ public class TiDAGRequest implements Serializable {
     this.useTiFlash = useTiFlash;
   }
 
-  public boolean getUseTiFlash() {
+  public boolean isUseTiFlash() {
     return useTiFlash;
   }
 

--- a/tikv-client/src/main/java/com/pingcap/tikv/operation/iterator/CoprocessorIterator.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/operation/iterator/CoprocessorIterator.java
@@ -80,7 +80,8 @@ public abstract class CoprocessorIterator<T> implements Iterator<T> {
         regionTasks,
         session,
         SchemaInfer.create(dagRequest),
-        dagRequest.getPushDownType()) {
+        dagRequest.getPushDownType(),
+        dagRequest.isUseTiFlash()) {
       @Override
       public Row next() {
         return rowReader.readRow(schemaInfer.getTypes().toArray(new DataType[0]));
@@ -108,7 +109,8 @@ public abstract class CoprocessorIterator<T> implements Iterator<T> {
         regionTasks,
         session,
         SchemaInfer.create(dagRequest),
-        dagRequest.getPushDownType()) {
+        dagRequest.getPushDownType(),
+        dagRequest.isUseTiFlash()) {
       @Override
       public TiChunk next() {
         // TODO make it configurable
@@ -161,7 +163,8 @@ public abstract class CoprocessorIterator<T> implements Iterator<T> {
         regionTasks,
         session,
         SchemaInfer.create(req, true),
-        req.getPushDownType()) {
+        req.getPushDownType(),
+        req.isUseTiFlash()) {
       @Override
       public Long next() {
         return rowReader.readRow(handleTypes).getLong(handleTypes.length - 1);

--- a/tikv-client/src/main/java/com/pingcap/tikv/operation/iterator/DAGIterator.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/operation/iterator/DAGIterator.java
@@ -249,6 +249,13 @@ public abstract class DAGIterator<T> extends CoprocessorIterator<T> {
       }
     }
 
+    session.getRegionManager().onRegionStale(region.getId());
+    TiRegion newRegion = session.getRegionManager().getRegionById(region.getId());
+
+    if (!newRegion.equals(region)) {
+      return getTiFlashStore(newRegion);
+    }
+
     throw new TiClientInternalException("cannot find valid tiflash replica");
   }
 

--- a/tikv-client/src/main/java/com/pingcap/tikv/region/RegionManager.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/region/RegionManager.java
@@ -43,6 +43,8 @@ import org.tikv.kvproto.Metapb.StoreState;
 @SuppressWarnings("UnstableApiUsage")
 public class RegionManager {
   private static final Logger logger = Logger.getLogger(RegionManager.class);
+  // TODO: the region cache logic need rewrite.
+  // https://github.com/pingcap/tispark/issues/1170
   private final RegionCache cache;
 
   private Function<CacheInvalidateEvent, Void> cacheInvalidateCallback;

--- a/tikv-client/src/main/java/com/pingcap/tikv/region/TiRegion.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/region/TiRegion.java
@@ -87,8 +87,7 @@ public class TiRegion implements Serializable {
   }
 
   public List<Peer> getLearnerList() {
-    int peerCnt = getMeta().getPeersCount();
-    List<Peer> peers = new ArrayList<Peer>();
+    List<Peer> peers = new ArrayList<>();
     for (Peer peer : getMeta().getPeersList()) {
       if (peer.getIsLearner()) {
         peers.add(peer);


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
This PR rewrite the logic of TiSpark reading data from TiFlash. Original approach did not consider outdated region cache. 


