### PR TITLE
support get json when we use TypeChunk coedc format. 

### DIFF
--- a/core/src/test/scala/org/apache/spark/sql/types/SpecialTiDBTypeTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/types/SpecialTiDBTypeTestSuite.scala
@@ -103,7 +103,7 @@ class SpecialTiDBTypeTestSuite extends BaseTiSparkTest {
 
   // TODO, getting json value is not implemented correctly.
   // https://github.com/pingcap/tispark/issues/1256
-  ignore("adding json support") {
+  test("adding json support") {
     tidbStmt.execute("drop table if exists t")
     tidbStmt.execute("create table t(json_doc json)")
     tidbStmt.execute(

--- a/core/src/test/scala/org/apache/spark/sql/types/SpecialTiDBTypeTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/types/SpecialTiDBTypeTestSuite.scala
@@ -101,8 +101,6 @@ class SpecialTiDBTypeTestSuite extends BaseTiSparkTest {
     judge("select * from enum_t where priority = 'High'")
   }
 
-  // TODO, getting json value is not implemented correctly.
-  // https://github.com/pingcap/tispark/issues/1256
   test("adding json support") {
     tidbStmt.execute("drop table if exists t")
     tidbStmt.execute("create table t(json_doc json)")

--- a/tikv-client/src/main/java/com/pingcap/tikv/columnar/TiChunkColumnVector.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/columnar/TiChunkColumnVector.java
@@ -15,8 +15,10 @@
 package com.pingcap.tikv.columnar;
 
 import com.google.common.primitives.UnsignedLong;
+import com.pingcap.tikv.codec.CodecDataInput;
 import com.pingcap.tikv.codec.MyDecimal;
 import com.pingcap.tikv.types.*;
+import com.pingcap.tikv.util.JsonUtils;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.sql.Timestamp;
@@ -228,10 +230,21 @@ public class TiChunkColumnVector extends TiColumnVector {
     return new String(getRawBinary(start + 8, end));
   }
 
+  private String getJsonString(int rowId) {
+    long start = this.offsets[rowId];
+    long end = this.offsets[rowId + 1];
+    return JsonUtils.parseJson(new CodecDataInput(getRawBinary(start, end))).toString();
+  }
+
   public String getUTF8String(int rowId) {
     if (type instanceof EnumType) {
       return getEnumString(rowId);
     }
+
+    if (type instanceof JsonType) {
+      return getJsonString(rowId);
+    }
+
     return new String(getBinary(rowId));
   }
 

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/JsonType.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/JsonType.java
@@ -1,49 +1,20 @@
 package com.pingcap.tikv.types;
 
-import com.google.common.io.ByteArrayDataInput;
-import com.google.common.io.ByteStreams;
 import com.google.gson.*;
 import com.pingcap.tidb.tipb.ExprType;
+import com.pingcap.tikv.codec.Codec;
 import com.pingcap.tikv.codec.CodecDataInput;
 import com.pingcap.tikv.codec.CodecDataOutput;
 import com.pingcap.tikv.exception.ConvertNotSupportException;
 import com.pingcap.tikv.exception.ConvertOverflowException;
+import com.pingcap.tikv.exception.InvalidCodecFormatException;
 import com.pingcap.tikv.meta.TiColumnInfo;
-import java.io.DataInput;
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.charset.StandardCharsets;
-import javax.annotation.Nullable;
+import com.pingcap.tikv.util.JsonUtils;
 
 public class JsonType extends DataType {
 
   public static final JsonType JSON = new JsonType(MySQLType.TypeJSON);
-  private static final int KEY_ENTRY_LENGTH = 6;
-  private static final int VALUE_ENTRY_SIZE = 5;
 
-  // TypeCodeObject indicates the JSON is an object.
-  private static final byte TYPE_CODE_OBJECT = 0x01;
-  // TypeCodeArray indicates the JSON is an array.
-  private static final byte TYPE_CODE_ARRAY = 0x03;
-  // TypeCodeLiteral indicates the JSON is a literal.
-  private static final byte TYPE_CODE_LITERAL = 0x04;
-  // TypeCodeInt64 indicates the JSON is a signed integer.
-  private static final byte TYPE_CODE_INT64 = 0x09;
-  // TypeCodeUint64 indicates the JSON is a unsigned integer.
-  private static final byte TYPE_CODE_UINT64 = 0x0a;
-  // TypeCodeFloat64 indicates the JSON is a double float number.
-  private static final byte TYPE_CODE_FLOAT64 = 0x0b;
-  // TypeCodeString indicates the JSON is a string.
-  private static final byte TYPE_CODE_STRING = 0x0c;
-
-  // LiteralNil represents JSON null.
-  private static final byte LITERAL_NIL = 0x00;
-  // LiteralTrue represents JSON true.
-  private static final byte LITERAL_TRUE = 0x01;
-  // LiteralFalse represents JSON false.
-  private static final byte LITERAL_FALSE = 0x02;
-  private static final JsonPrimitive JSON_FALSE = new JsonPrimitive(false);
-  private static final JsonPrimitive JSON_TRUE = new JsonPrimitive(true);
   public static MySQLType[] subTypes = new MySQLType[] {MySQLType.TypeJSON};
 
   protected JsonType(TiColumnInfo.InternalTypeHolder holder) {
@@ -60,309 +31,17 @@ public class JsonType extends DataType {
 
   @Override
   protected Object decodeNotNull(int flag, CodecDataInput cdi) {
-    byte type = readByte(cdi);
-    return parseValue(type, cdi).toString();
+    if (flag != Codec.JSON_FLAG) {
+      throw new InvalidCodecFormatException(
+          "Invalid Flag type for " + getClass().getSimpleName() + ": " + flag);
+    }
+    return JsonUtils.parseJson(cdi).toString();
   }
 
   @Override
   protected Object doConvertToTiDBType(Object value)
       throws ConvertNotSupportException, ConvertOverflowException {
     throw new ConvertNotSupportException(value.getClass().getName(), this.getClass().getName());
-  }
-
-  /**
-   * The binary JSON format from MySQL 5.7 is as follows:
-   *
-   * <pre>{@code
-   * JsonFormat {
-   *      JSON doc ::= type value
-   *      type ::=
-   *          0x01 |       // large JSON object
-   *          0x03 |       // large JSON array
-   *          0x04 |       // literal (true/false/null)
-   *          0x05 |       // int16
-   *          0x06 |       // uint16
-   *          0x07 |       // int32
-   *          0x08 |       // uint32
-   *          0x09 |       // int64
-   *          0x0a |       // uint64
-   *          0x0b |       // double
-   *          0x0c |       // utf8mb4 string
-   *      value ::=
-   *          object  |
-   *          array   |
-   *          literal |
-   *          number  |
-   *          string  |
-   *      object ::= element-count size key-entry* value-entry* key* value*
-   *      array ::= element-count size value-entry* value*
-   *      // number of members in object or number of elements in array
-   *      element-count ::= uint32
-   *      // number of bytes in the binary representation of the object or array
-   *      size ::= uint32
-   *      key-entry ::= key-offset key-length
-   *      key-offset ::= uint32
-   *      key-length ::= uint16    // key length must be less than 64KB
-   *      value-entry ::= type offset-or-inlined-value
-   *      // This field holds either the offset to where the value is stored,
-   *      // or the value itself if it is small enough to be inlined (that is,
-   *      // if it is a JSON literal or a small enough [u]int).
-   *      offset-or-inlined-value ::= uint32
-   *      key ::= utf8mb4-data
-   *      literal ::=
-   *          0x00 |   // JSON null literal
-   *          0x01 |   // JSON true literal
-   *          0x02 |   // JSON false literal
-   *      number ::=  ....    // little-endian format for [u]int(16|32|64), whereas
-   *                          // double is stored in a platform-independent, eight-byte
-   *                          // format using float8store()
-   *      string ::= data-length utf8mb4-data
-   *      data-length ::= uint8*    // If the high bit of a byte is 1, the length
-   *                                // field is continued in the next byte,
-   *                                // otherwise it is the last byte of the length
-   *                                // field. So we need 1 byte to represent
-   *                                // lengths up to 127, 2 bytes to represent
-   *                                // lengths up to 16383, and so on...
-   * }
-   * }</pre>
-   *
-   * @param type type byte
-   * @param di codec data input
-   * @return Json element parsed
-   */
-  private JsonElement parseValue(byte type, DataInput di) {
-    switch (type) {
-      case TYPE_CODE_OBJECT:
-        return parseObject(di);
-      case TYPE_CODE_ARRAY:
-        return parseArray(di);
-      case TYPE_CODE_LITERAL:
-        return parseLiteralJson(di);
-      case TYPE_CODE_INT64:
-        return new JsonPrimitive(parseInt64(di));
-      case TYPE_CODE_UINT64:
-        return new JsonPrimitive(parseUint64(di));
-      case TYPE_CODE_FLOAT64:
-        return new JsonPrimitive(parseDouble(di));
-      case TYPE_CODE_STRING:
-        long length = parseDataLength(di);
-        return new JsonPrimitive(parseString(di, length));
-      default:
-        throw new AssertionError("error type|type=" + (int) type);
-    }
-  }
-
-  // * notice use this as a unsigned long
-  private long parseUint64(DataInput cdi) {
-    byte[] readBuffer = new byte[8];
-    readFully(cdi, readBuffer, 0, 8);
-
-    return ((long) (readBuffer[7]) << 56)
-        + ((long) (readBuffer[6] & 255) << 48)
-        + ((long) (readBuffer[5] & 255) << 40)
-        + ((long) (readBuffer[4] & 255) << 32)
-        + ((long) (readBuffer[3] & 255) << 24)
-        + ((readBuffer[2] & 255) << 16)
-        + ((readBuffer[1] & 255) << 8)
-        + ((readBuffer[0] & 255) << 0);
-  }
-
-  private void readFully(DataInput cdi, byte[] readBuffer, final int off, final int len) {
-    try {
-      cdi.readFully(readBuffer, off, len);
-    } catch (IOException e) {
-      throw new UncheckedIOException(e);
-    }
-  }
-
-  private long parseInt64(DataInput cdi) {
-    byte[] readBuffer = new byte[8];
-    readFully(cdi, readBuffer);
-    return ((long) readBuffer[7] << 56)
-        + ((long) (readBuffer[6] & 255) << 48)
-        + ((long) (readBuffer[5] & 255) << 40)
-        + ((long) (readBuffer[4] & 255) << 32)
-        + ((long) (readBuffer[3] & 255) << 24)
-        + ((readBuffer[2] & 255) << 16)
-        + ((readBuffer[1] & 255) << 8)
-        + ((readBuffer[0] & 255) << 0);
-  }
-
-  private long parseUint32(DataInput cdi) {
-    byte[] readBuffer = new byte[4];
-    readFully(cdi, readBuffer);
-
-    return ((long) (readBuffer[3] & 255) << 24)
-        + ((readBuffer[2] & 255) << 16)
-        + ((readBuffer[1] & 255) << 8)
-        + ((readBuffer[0] & 255) << 0);
-  }
-
-  private double parseDouble(DataInput cdi) {
-    byte[] readBuffer = new byte[8];
-    readFully(cdi, readBuffer);
-    return Double.longBitsToDouble(
-        ((long) readBuffer[7] << 56)
-            + ((long) (readBuffer[6] & 255) << 48)
-            + ((long) (readBuffer[5] & 255) << 40)
-            + ((long) (readBuffer[4] & 255) << 32)
-            + ((long) (readBuffer[3] & 255) << 24)
-            + ((readBuffer[2] & 255) << 16)
-            + ((readBuffer[1] & 255) << 8)
-            + ((readBuffer[0] & 255) << 0));
-  }
-
-  private int parseUint16(DataInput cdi) {
-    byte[] readBuffer = new byte[2];
-    readFully(cdi, readBuffer);
-
-    return ((readBuffer[1] & 255) << 8) + ((readBuffer[0] & 255) << 0);
-  }
-
-  private String parseString(DataInput di, long length) {
-
-    byte[] buffer = new byte[Math.toIntExact(length)];
-    readFully(di, buffer);
-    return new String(buffer, StandardCharsets.UTF_8);
-  }
-
-  /**
-   * func Uvarint(buf []byte) (uint64, int) { var x uint64 var s uint for i, b := range buf { if b <
-   * 0x80 { if i > 9 || i == 9 && b > 1 { return 0, -(i + 1) // overflow } return x | uint64(b)<<s,
-   * i + 1 * } x |= uint64(b&0x7f) << s s += 7 } return 0, 0 }
-   *
-   * @param di
-   * @return
-   */
-  private long parseDataLength(DataInput di) {
-    long x = 0;
-    byte b;
-    int i = 0;
-    int s = 0;
-    while ((b = readByte(di)) < 0) {
-      if (i == 9) {
-        throw new IllegalArgumentException("overflow: found >=9 leading bytes");
-      }
-      x |= ((long) (b & 0x7f)) << s;
-      s += 7;
-      i++;
-    }
-
-    if (i == 9 && b > 1) {
-      throw new IllegalArgumentException("overflow: 8 leading byte and last one > 1");
-    }
-    x |= ((long) b) << s;
-    return x;
-  }
-
-  private @Nullable Boolean parseLiteral(DataInput cdi) {
-    byte type;
-    type = readByte(cdi);
-    switch (type) {
-      case LITERAL_FALSE:
-        return Boolean.FALSE;
-      case LITERAL_NIL:
-        return null;
-      case LITERAL_TRUE:
-        return Boolean.TRUE;
-      default:
-        throw new AssertionError("unknown literal type|" + (int) type);
-    }
-  }
-
-  private byte readByte(DataInput cdi) {
-    byte type;
-    try {
-      type = cdi.readByte();
-    } catch (IOException e) {
-      throw new UncheckedIOException(e);
-    }
-    return type;
-  }
-
-  private JsonArray parseArray(DataInput di) {
-    long elementCount = parseUint32(di);
-    long size = parseUint32(di);
-    byte[] buffer = new byte[Math.toIntExact(size - 8)];
-    readFully(di, buffer);
-    JsonArray jsonArray = new JsonArray();
-    for (int i = 0; i < elementCount; i++) {
-      JsonElement value = parseValueEntry(buffer, VALUE_ENTRY_SIZE * i);
-      jsonArray.add(value);
-    }
-    return jsonArray;
-  }
-
-  private JsonObject parseObject(DataInput di) {
-    long elementCount = parseUint32(di);
-    long size = parseUint32(di);
-
-    byte[] buffer = new byte[Math.toIntExact(size - 8)];
-    readFully(di, buffer);
-    JsonObject jsonObject = new JsonObject();
-    for (int i = 0; i < elementCount; i++) {
-      KeyEntry keyEntry = parseKeyEntry(ByteStreams.newDataInput(buffer, i * KEY_ENTRY_LENGTH));
-      String key =
-          parseString(
-              ByteStreams.newDataInput(buffer, Math.toIntExact(keyEntry.keyOffset - 8)),
-              keyEntry.keyLength);
-      long valueEntryOffset = elementCount * KEY_ENTRY_LENGTH + i * VALUE_ENTRY_SIZE;
-      JsonElement value = parseValueEntry(buffer, valueEntryOffset);
-      jsonObject.add(key, value);
-    }
-    return jsonObject;
-  }
-
-  private JsonElement parseValueEntry(byte[] buffer, long valueEntryOffset) {
-    byte valueType = buffer[Math.toIntExact(valueEntryOffset)];
-    JsonElement value;
-    ByteArrayDataInput bs = ByteStreams.newDataInput(buffer, Math.toIntExact(valueEntryOffset + 1));
-    switch (valueType) {
-      case TYPE_CODE_LITERAL:
-        value = parseLiteralJson(bs);
-        break;
-      default:
-        long valueOffset = parseUint32(bs);
-        value =
-            parseValue(
-                valueType, ByteStreams.newDataInput(buffer, Math.toIntExact(valueOffset - 8)));
-    }
-    return value;
-  }
-
-  private JsonElement parseLiteralJson(DataInput di) {
-    JsonElement value;
-    Boolean bool = parseLiteral(di);
-    if (bool == null) {
-      value = JsonNull.INSTANCE;
-    } else if (bool) {
-      value = JSON_TRUE;
-    } else {
-      value = JSON_FALSE;
-    }
-    return value;
-  }
-
-  private KeyEntry parseKeyEntry(DataInput di) {
-    return new KeyEntry(parseUint32(di), parseUint16(di));
-  }
-
-  static class KeyEntry {
-    long keyOffset;
-    int keyLength;
-
-    public KeyEntry(long keyOffset, int keyLength) {
-      this.keyOffset = keyOffset;
-      this.keyLength = keyLength;
-    }
-  }
-
-  private void readFully(DataInput di, byte[] buffer) {
-    try {
-      di.readFully(buffer);
-    } catch (IOException e) {
-      throw new UncheckedIOException(e);
-    }
   }
 
   @Override

--- a/tikv-client/src/main/java/com/pingcap/tikv/util/JsonUtils.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/util/JsonUtils.java
@@ -1,0 +1,333 @@
+package com.pingcap.tikv.util;
+
+import com.google.common.io.ByteArrayDataInput;
+import com.google.common.io.ByteStreams;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import java.io.DataInput;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import javax.annotation.Nullable;
+
+public class JsonUtils {
+  private static final int KEY_ENTRY_LENGTH = 6;
+  private static final int VALUE_ENTRY_SIZE = 5;
+
+  // TypeCodeObject indicates the JSON is an object.
+  private static final byte TYPE_CODE_OBJECT = 0x01;
+  // TypeCodeArray indicates the JSON is an array.
+  private static final byte TYPE_CODE_ARRAY = 0x03;
+  // TypeCodeLiteral indicates the JSON is a literal.
+  private static final byte TYPE_CODE_LITERAL = 0x04;
+  // TypeCodeInt64 indicates the JSON is a signed integer.
+  private static final byte TYPE_CODE_INT64 = 0x09;
+  // TypeCodeUint64 indicates the JSON is a unsigned integer.
+  private static final byte TYPE_CODE_UINT64 = 0x0a;
+  // TypeCodeFloat64 indicates the JSON is a double float number.
+  private static final byte TYPE_CODE_FLOAT64 = 0x0b;
+  // TypeCodeString indicates the JSON is a string.
+  private static final byte TYPE_CODE_STRING = 0x0c;
+
+  // LiteralNil represents JSON null.
+  private static final byte LITERAL_NIL = 0x00;
+  // LiteralTrue represents JSON true.
+  private static final byte LITERAL_TRUE = 0x01;
+  // LiteralFalse represents JSON false.
+  private static final byte LITERAL_FALSE = 0x02;
+  private static final JsonPrimitive JSON_FALSE = new JsonPrimitive(false);
+  private static final JsonPrimitive JSON_TRUE = new JsonPrimitive(true);
+
+  public static JsonElement parseJson(DataInput di) {
+    return parseValue(readByte(di), di);
+  }
+  /**
+   * The binary JSON format from MySQL 5.7 is as follows:
+   *
+   * <pre>{@code
+   * JsonFormat {
+   *      JSON doc ::= type value
+   *      type ::=
+   *          0x01 |       // large JSON object
+   *          0x03 |       // large JSON array
+   *          0x04 |       // literal (true/false/null)
+   *          0x05 |       // int16
+   *          0x06 |       // uint16
+   *          0x07 |       // int32
+   *          0x08 |       // uint32
+   *          0x09 |       // int64
+   *          0x0a |       // uint64
+   *          0x0b |       // double
+   *          0x0c |       // utf8mb4 string
+   *      value ::=
+   *          object  |
+   *          array   |
+   *          literal |
+   *          number  |
+   *          string  |
+   *      object ::= element-count size key-entry* value-entry* key* value*
+   *      array ::= element-count size value-entry* value*
+   *      // number of members in object or number of elements in array
+   *      element-count ::= uint32
+   *      // number of bytes in the binary representation of the object or array
+   *      size ::= uint32
+   *      key-entry ::= key-offset key-length
+   *      key-offset ::= uint32
+   *      key-length ::= uint16    // key length must be less than 64KB
+   *      value-entry ::= type offset-or-inlined-value
+   *      // This field holds either the offset to where the value is stored,
+   *      // or the value itself if it is small enough to be inlined (that is,
+   *      // if it is a JSON literal or a small enough [u]int).
+   *      offset-or-inlined-value ::= uint32
+   *      key ::= utf8mb4-data
+   *      literal ::=
+   *          0x00 |   // JSON null literal
+   *          0x01 |   // JSON true literal
+   *          0x02 |   // JSON false literal
+   *      number ::=  ....    // little-endian format for [u]int(16|32|64), whereas
+   *                          // double is stored in a platform-independent, eight-byte
+   *                          // format using float8store()
+   *      string ::= data-length utf8mb4-data
+   *      data-length ::= uint8*    // If the high bit of a byte is 1, the length
+   *                                // field is continued in the next byte,
+   *                                // otherwise it is the last byte of the length
+   *                                // field. So we need 1 byte to represent
+   *                                // lengths up to 127, 2 bytes to represent
+   *                                // lengths up to 16383, and so on...
+   * }
+   * }</pre>
+   *
+   * @param type type byte
+   * @param di codec data input
+   * @return Json element parsed
+   */
+  private static JsonElement parseValue(byte type, DataInput di) {
+    switch (type) {
+      case TYPE_CODE_OBJECT:
+        return parseObject(di);
+      case TYPE_CODE_ARRAY:
+        return parseArray(di);
+      case TYPE_CODE_LITERAL:
+        return parseLiteralJson(di);
+      case TYPE_CODE_INT64:
+        return new JsonPrimitive(parseInt64(di));
+      case TYPE_CODE_UINT64:
+        return new JsonPrimitive(parseUint64(di));
+      case TYPE_CODE_FLOAT64:
+        return new JsonPrimitive(parseDouble(di));
+      case TYPE_CODE_STRING:
+        long length = parseDataLength(di);
+        return new JsonPrimitive(parseString(di, length));
+      default:
+        throw new AssertionError("error type|type=" + (int) type);
+    }
+  }
+
+  // * notice use this as a unsigned long
+  private static long parseUint64(DataInput cdi) {
+    byte[] readBuffer = new byte[8];
+    readFully(cdi, readBuffer, 0, 8);
+
+    return ((long) (readBuffer[7]) << 56)
+        + ((long) (readBuffer[6] & 255) << 48)
+        + ((long) (readBuffer[5] & 255) << 40)
+        + ((long) (readBuffer[4] & 255) << 32)
+        + ((long) (readBuffer[3] & 255) << 24)
+        + ((readBuffer[2] & 255) << 16)
+        + ((readBuffer[1] & 255) << 8)
+        + ((readBuffer[0] & 255));
+  }
+
+  private static void readFully(DataInput di, byte[] buffer) {
+    try {
+      di.readFully(buffer);
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  private static void readFully(DataInput cdi, byte[] readBuffer, final int off, final int len) {
+    try {
+      cdi.readFully(readBuffer, off, len);
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  private static long parseInt64(DataInput cdi) {
+    byte[] readBuffer = new byte[8];
+    readFully(cdi, readBuffer);
+    return bytesToLong(readBuffer);
+  }
+
+  private static long parseUint32(DataInput cdi) {
+    byte[] readBuffer = new byte[4];
+    readFully(cdi, readBuffer);
+
+    return ((long) (readBuffer[3] & 255) << 24)
+        + ((readBuffer[2] & 255) << 16)
+        + ((readBuffer[1] & 255) << 8)
+        + ((readBuffer[0] & 255));
+  }
+
+  private static long bytesToLong(byte[] readBuffer) {
+    return ((long) readBuffer[7] << 56)
+        + ((long) (readBuffer[6] & 255) << 48)
+        + ((long) (readBuffer[5] & 255) << 40)
+        + ((long) (readBuffer[4] & 255) << 32)
+        + ((long) (readBuffer[3] & 255) << 24)
+        + ((readBuffer[2] & 255) << 16)
+        + ((readBuffer[1] & 255) << 8)
+        + ((readBuffer[0] & 255));
+  }
+
+  private static double parseDouble(DataInput cdi) {
+    byte[] readBuffer = new byte[8];
+    readFully(cdi, readBuffer);
+    return Double.longBitsToDouble(bytesToLong(readBuffer));
+  }
+
+  private static int parseUint16(DataInput cdi) {
+    byte[] readBuffer = new byte[2];
+    readFully(cdi, readBuffer);
+
+    return ((readBuffer[1] & 255) << 8) + ((readBuffer[0] & 255));
+  }
+
+  private static String parseString(DataInput di, long length) {
+
+    byte[] buffer = new byte[Math.toIntExact(length)];
+    readFully(di, buffer);
+    return new String(buffer, StandardCharsets.UTF_8);
+  }
+
+  /**
+   * @param di data input
+   * @return length of data.
+   */
+  private static long parseDataLength(DataInput di) {
+    long x = 0;
+    byte b;
+    int i = 0;
+    int s = 0;
+    while ((b = readByte(di)) < 0) {
+      if (i == 9) {
+        throw new IllegalArgumentException("overflow: found >=9 leading bytes");
+      }
+      x |= ((long) (b & 0x7f)) << s;
+      s += 7;
+      i++;
+    }
+
+    if (i == 9 && b > 1) {
+      throw new IllegalArgumentException("overflow: 8 leading byte and last one > 1");
+    }
+    x |= ((long) b) << s;
+    return x;
+  }
+
+  private @Nullable static Boolean parseLiteral(DataInput cdi) {
+    byte type;
+    type = readByte(cdi);
+    switch (type) {
+      case LITERAL_FALSE:
+        return Boolean.FALSE;
+      case LITERAL_NIL:
+        return null;
+      case LITERAL_TRUE:
+        return Boolean.TRUE;
+      default:
+        throw new AssertionError("unknown literal type|" + (int) type);
+    }
+  }
+
+  private static byte readByte(DataInput cdi) {
+    byte type;
+    try {
+      type = cdi.readByte();
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+    return type;
+  }
+
+  private static JsonArray parseArray(DataInput di) {
+    long elementCount = parseUint32(di);
+    long size = parseUint32(di);
+    byte[] buffer = new byte[Math.toIntExact(size - 8)];
+    readFully(di, buffer);
+    JsonArray jsonArray = new JsonArray();
+    for (int i = 0; i < elementCount; i++) {
+      JsonElement value = parseValueEntry(buffer, VALUE_ENTRY_SIZE * i);
+      jsonArray.add(value);
+    }
+    return jsonArray;
+  }
+
+  private static JsonObject parseObject(DataInput di) {
+    long elementCount = parseUint32(di);
+    long size = parseUint32(di);
+
+    byte[] buffer = new byte[Math.toIntExact(size - 8)];
+    readFully(di, buffer);
+    JsonObject jsonObject = new JsonObject();
+    for (int i = 0; i < elementCount; i++) {
+      KeyEntry keyEntry = parseKeyEntry(ByteStreams.newDataInput(buffer, i * KEY_ENTRY_LENGTH));
+      String key =
+          parseString(
+              ByteStreams.newDataInput(buffer, Math.toIntExact(keyEntry.keyOffset - 8)),
+              keyEntry.keyLength);
+      long valueEntryOffset = elementCount * KEY_ENTRY_LENGTH + i * VALUE_ENTRY_SIZE;
+      JsonElement value = parseValueEntry(buffer, valueEntryOffset);
+      jsonObject.add(key, value);
+    }
+    return jsonObject;
+  }
+
+  private static JsonElement parseValueEntry(byte[] buffer, long valueEntryOffset) {
+    byte valueType = buffer[Math.toIntExact(valueEntryOffset)];
+    JsonElement value;
+    ByteArrayDataInput bs = ByteStreams.newDataInput(buffer, Math.toIntExact(valueEntryOffset + 1));
+    switch (valueType) {
+      case TYPE_CODE_LITERAL:
+        value = parseLiteralJson(bs);
+        break;
+      default:
+        long valueOffset = parseUint32(bs);
+        value =
+            parseValue(
+                valueType, ByteStreams.newDataInput(buffer, Math.toIntExact(valueOffset - 8)));
+    }
+    return value;
+  }
+
+  private static JsonElement parseLiteralJson(DataInput di) {
+    JsonElement value;
+    Boolean bool = parseLiteral(di);
+    if (bool == null) {
+      value = JsonNull.INSTANCE;
+    } else if (bool) {
+      value = JSON_TRUE;
+    } else {
+      value = JSON_FALSE;
+    }
+    return value;
+  }
+
+  private static KeyEntry parseKeyEntry(DataInput di) {
+    return new KeyEntry(parseUint32(di), parseUint16(di));
+  }
+
+  static class KeyEntry {
+    long keyOffset;
+    int keyLength;
+
+    KeyEntry(long keyOffset, int keyLength) {
+      this.keyOffset = keyOffset;
+      this.keyLength = keyLength;
+    }
+  }
+}


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
This PR closes #1256. 

### What is changed and how it works?
Before this PR, the logic of parsing json is at `JsonType`. We cannot invoke it if we do not have a json type. In this PR, we move the logic to a helper class. `JsonType` class can invoke it through the public method `parseJson`. `TiChunkColumnVector` also can invoke it using the same way. 