### PR TITLE
[cherry-pick] disable set and enum push down for release 2.1

### DIFF
--- a/core/src/main/scala/com/pingcap/tispark/utils/TiUtil.scala
+++ b/core/src/main/scala/com/pingcap/tispark/utils/TiUtil.scala
@@ -34,6 +34,7 @@ import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.aggregate.SortAggregateExec
 import org.apache.spark.sql.types.{DataType, DataTypes, Decimal, MetadataBuilder, StructField, StructType}
 import org.apache.spark.{sql, SparkConf}
+import org.apache.spark.sql.types.{MetadataBuilder, StructField, StructType}
 import org.tikv.kvproto.Kvrpcpb.{CommandPri, IsolationLevel}
 
 import scala.collection.JavaConversions._
@@ -82,10 +83,9 @@ object TiUtil {
 
     if (expr.children.isEmpty) {
       expr match {
-        // bit/duration type is not allowed to be pushed down
+        // bit, duration, set, and enum type is not allowed to be pushed down
         case attr: AttributeReference if nameTypeMap.contains(attr.name) =>
-          val head = nameTypeMap.get(attr.name).head
-          return !head.isInstanceOf[BitType]
+          return nameTypeMap.get(attr.name).head.isPushDownSupported
         // TODO:Currently we do not support literal null type push down
         // when Constant is ready to support literal null or we have other
         // options, remove this.
@@ -103,6 +103,11 @@ object TiUtil {
 
     true
   }
+
+  def isSupportedOrderBy(expr: Expression,
+                         source: TiDBRelation,
+                         blacklist: ExpressionBlacklist): Boolean =
+    isSupportedBasicExpression(expr, source, blacklist) && isPushDownSupported(expr, source)
 
   def isSupportedFilter(expr: Expression,
                         source: TiDBRelation,

--- a/core/src/main/scala/org/apache/spark/sql/TiStrategy.scala
+++ b/core/src/main/scala/org/apache/spark/sql/TiStrategy.scala
@@ -28,6 +28,7 @@ import com.pingcap.tikv.statistics.TableStatistics
 import com.pingcap.tispark.utils.TiUtil._
 import com.pingcap.tispark.statistics.StatisticsManager
 import com.pingcap.tispark.utils.TiUtil
+import com.pingcap.tispark.utils.ReflectionUtil._
 import com.pingcap.tispark.{BasicExpression, TiConfigConst, TiDBRelation}
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.analysis.CleanupAliases
@@ -306,6 +307,7 @@ case class TiStrategy(getOrCreateTiContext: SparkSession => TiContext)(sparkSess
     val request = new TiDAGRequest(pushDownType(), timeZoneOffset())
     request.setLimit(limit)
     addSortOrder(request, sortOrder)
+
     pruneFilterProject(projectList, filterPredicates, source, request)
   }
 
@@ -378,7 +380,7 @@ case class TiStrategy(getOrCreateTiContext: SparkSession => TiContext)(sparkSess
       }
     }
     if (refinedSortOrder.exists(
-          order => !TiUtil.isSupportedBasicExpression(order.child, source, blacklist)
+          order => !isSupportedOrderBy(order.child, source, blacklist)
         )) {
       Option.empty
     } else {

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/BitType.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/BitType.java
@@ -81,4 +81,9 @@ public class BitType extends IntegerType {
     }
     return result;
   }
+
+  @Override
+  public boolean isPushDownSupported() {
+    return false;
+  }
 }

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/DataType.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/DataType.java
@@ -216,6 +216,11 @@ public abstract class DataType implements Serializable {
    */
   public abstract Object getOriginDefaultValueNonNull(String value, long version);
 
+  /** @return true if this type can be pushed down to TiKV or TiFLASH */
+  public boolean isPushDownSupported() {
+    return true;
+  }
+
   public Object getOriginDefaultValue(String value, long version) {
     if (value == null) return null;
     return getOriginDefaultValueNonNull(value, version);

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/EnumType.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/EnumType.java
@@ -76,4 +76,9 @@ public class EnumType extends DataType {
   public Object getOriginDefaultValueNonNull(String value, long version) {
     return value;
   }
+
+  @Override
+  public boolean isPushDownSupported() {
+    return false;
+  }
 }

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/JsonType.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/JsonType.java
@@ -301,4 +301,9 @@ public class JsonType extends DataType {
   public Object getOriginDefaultValueNonNull(String value, long version) {
     throw new AssertionError("json can't have a default value");
   }
+
+  @Override
+  public boolean isPushDownSupported() {
+    return false;
+  }
 }

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/SetType.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/SetType.java
@@ -113,4 +113,9 @@ public class SetType extends DataType {
   public Object getOriginDefaultValueNonNull(String value, long version) {
     return value;
   }
+
+  @Override
+  public boolean isPushDownSupported() {
+    return false;
+  }
 }


### PR DESCRIPTION
This PR just cherry-pick #1242 to release 2.1