### PR TITLE
[cherry-pick] disable set and enum push down for release 2.2

### DIFF
--- a/core/src/main/scala/com/pingcap/tispark/utils/TiUtil.scala
+++ b/core/src/main/scala/com/pingcap/tispark/utils/TiUtil.scala
@@ -75,10 +75,9 @@ object TiUtil {
 
     if (expr.children.isEmpty) {
       expr match {
-        // bit/duration type is not allowed to be pushed down
+        // bit, duration, set, and enum type is not allowed to be pushed down
         case attr: AttributeReference if nameTypeMap.contains(attr.name) =>
-          val head = nameTypeMap.get(attr.name).head
-          return !head.isInstanceOf[BitType]
+          return nameTypeMap.get(attr.name).head.isPushDownSupported
         // TODO:Currently we do not support literal null type push down
         // when Constant is ready to support literal null or we have other
         // options, remove this.
@@ -96,6 +95,11 @@ object TiUtil {
 
     true
   }
+
+  def isSupportedOrderBy(expr: Expression,
+                         source: TiDBRelation,
+                         blacklist: ExpressionBlacklist): Boolean =
+    isSupportedBasicExpression(expr, source, blacklist) && isPushDownSupported(expr, source)
 
   def isSupportedFilter(expr: Expression,
                         source: TiDBRelation,

--- a/core/src/main/scala/org/apache/spark/sql/TiStrategy.scala
+++ b/core/src/main/scala/org/apache/spark/sql/TiStrategy.scala
@@ -27,7 +27,7 @@ import com.pingcap.tikv.predicates.{PredicateUtils, TiKVScanAnalyzer}
 import com.pingcap.tikv.statistics.TableStatistics
 import com.pingcap.tispark.statistics.StatisticsManager
 import com.pingcap.tispark.utils.TiConverter._
-import com.pingcap.tispark.utils.TiUtil
+import com.pingcap.tispark.utils.{TiConverter, TiUtil}
 import com.pingcap.tispark.utils.ReflectionUtil._
 import com.pingcap.tispark.{BasicExpression, TiConfigConst, TiDBRelation}
 import org.apache.spark.internal.Logging
@@ -309,6 +309,7 @@ case class TiStrategy(getOrCreateTiContext: SparkSession => TiContext)(sparkSess
     val request = new TiDAGRequest(pushDownType(), timeZoneOffsetInSeconds())
     request.setLimit(limit)
     addSortOrder(request, sortOrder)
+
     pruneFilterProject(projectList, filterPredicates, source, request)
   }
 
@@ -381,7 +382,7 @@ case class TiStrategy(getOrCreateTiContext: SparkSession => TiContext)(sparkSess
       }
     }
     if (refinedSortOrder.exists(
-          order => !TiUtil.isSupportedBasicExpression(order.child, source, blacklist)
+          order => !TiUtil.isSupportedOrderBy(order.child, source, blacklist)
         )) {
       Option.empty
     } else {

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/BitType.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/BitType.java
@@ -97,4 +97,9 @@ public class BitType extends IntegerType {
     }
     return result;
   }
+
+  @Override
+  public boolean isPushDownSupported() {
+    return false;
+  }
 }

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/DataType.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/DataType.java
@@ -322,6 +322,11 @@ public abstract class DataType implements Serializable {
    */
   public abstract Object getOriginDefaultValueNonNull(String value, long version);
 
+  /** @return true if this type can be pushed down to TiKV or TiFLASH */
+  public boolean isPushDownSupported() {
+    return true;
+  }
+
   public Object getOriginDefaultValue(String value, long version) {
     if (value == null) return null;
     return getOriginDefaultValueNonNull(value, version);

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/EnumType.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/EnumType.java
@@ -140,4 +140,9 @@ public class EnumType extends DataType {
   public Object getOriginDefaultValueNonNull(String value, long version) {
     return value;
   }
+
+  @Override
+  public boolean isPushDownSupported() {
+    return false;
+  }
 }

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/JsonType.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/JsonType.java
@@ -389,4 +389,9 @@ public class JsonType extends DataType {
   public Object getOriginDefaultValueNonNull(String value, long version) {
     throw new AssertionError("json can't have a default value");
   }
+
+  @Override
+  public boolean isPushDownSupported() {
+    return false;
+  }
 }

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/SetType.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/SetType.java
@@ -121,4 +121,9 @@ public class SetType extends DataType {
   public Object getOriginDefaultValueNonNull(String value, long version) {
     return value;
   }
+
+  @Override
+  public boolean isPushDownSupported() {
+    return false;
+  }
 }

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/UninitializedType.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/UninitializedType.java
@@ -82,4 +82,10 @@ public class UninitializedType extends DataType {
     throw new UnsupportedOperationException(
         "UninitializedType cannot be applied in calculation process.");
   }
+
+  @Override
+  public boolean isPushDownSupported() {
+    throw new UnsupportedOperationException(
+        "UninitializedType cannot be applied in calculation process.");
+  }
 }


### PR DESCRIPTION
This PR only cherry-pick #1242 to release 2.2