### PR TITLE
Add ci argument for region size

### DIFF
--- a/.ci/integration_test.groovy
+++ b/.ci/integration_test.groovy
@@ -9,6 +9,7 @@ def call(ghprbActualCommit, ghprbCommentBody, ghprbPullId, ghprbPullTitle, ghprb
     def MVN_PROFILE = "-Pjenkins"
     def TEST_MODE = "simple"
     def PARALLEL_NUMBER = 18
+    def TEST_REGION_SIZE = "normal"
     
     // parse tidb branch
     def m1 = ghprbCommentBody =~ /tidb\s*=\s*([^\s\\]+)(\s|\\|$)/
@@ -41,6 +42,12 @@ def call(ghprbActualCommit, ghprbCommentBody, ghprbPullId, ghprbPullTitle, ghprb
     def m5 = ghprbCommentBody =~ /mode\s*=\s*([^\s\\]+)(\s|\\|$)/
     if (m5) {
         TEST_MODE = "${m5[0][1]}"
+    }
+
+    // parse test region size
+    def m6 = ghprbCommentBody =~ /region\s*=\s*([^\s\\]+)(\s|\\|$)/
+    if (m6) {
+        TEST_REGION_SIZE = "${m6[0][1]}"
     }
     
     def readfile = { filename ->
@@ -96,6 +103,12 @@ def call(ghprbActualCommit, ghprbCommentBody, ghprbPullId, ghprbPullTitle, ghprb
                         shuf test -o  test2
                         mv test2 test
                         """
+
+                        if(TEST_REGION_SIZE  != "normal") {
+                            sh "sed -i 's/\\# region-max-size = \\\"2MB\\\"/region-max-size = \\\"2MB\\\"/' config/tikv.toml"
+                            sh "sed -i 's/\\# region-split-size = \\\"1MB\\\"/region-split-size = \\\"1MB\\\"/' config/tikv.toml"
+                            sh "cat config/tikv.toml"
+                        }
 
                         if(TEST_MODE != "simple") {
                             sh """

--- a/config/tikv.toml
+++ b/config/tikv.toml
@@ -148,7 +148,8 @@ capacity = "8G"
 # bit smaller.
 # region-max-size = "144MB"
 # region-split-size = "96MB"
-region-split-size = "1MB"
+# region-max-size = "2MB"
+# region-split-size = "1MB"
 
 [rocksdb]
 # Maximum number of concurrent background jobs (compactions and flushes)


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
add a new argument for `/run-all-tests` to let tikv choose conf from
```
region-max-size = "144MB"
region-split-size = "96MB"
```
and
```
region-max-size = "2MB"
region-split-size = "1MB"
```

### What is changed and how it works?
`/run-all-tests region=small` or `/run-all-tests region=normal`

default = `/run-all-tests region=normal`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code
