### PR TITLE
fix agg push down on count(*)

### DIFF
--- a/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
@@ -28,13 +28,13 @@ class IssueTestSuite extends BaseTiSparkTest {
     val dagReq = TiUtil.extractDAGReq(df)
     dagReq.buildTableScan()
     val pushDownAggs = dagReq.getPushDownAggregates
-    if(pushDownAggs.size() != 1) {
+    if (pushDownAggs.size() != 1) {
       fail("count(1) is not pushed down to coprocessor")
     }
 
     val count = pushDownAggs.get(0).asInstanceOf[AggregateFunction]
 
-    if(!count.toString.equals("Count(1)")) {
+    if (!count.toString.equals("Count(1)")) {
       fail("count(1) is not pushed down to coprocessor")
     }
   }

--- a/tikv-client/src/main/java/com/pingcap/tikv/expression/visitor/ExpressionTypeCoercer.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/expression/visitor/ExpressionTypeCoercer.java
@@ -152,6 +152,10 @@ public class ExpressionTypeCoercer extends Visitor<Pair<DataType, Double>, DataT
   @Override
   protected Pair<DataType, Double> visit(Constant node, DataType targetType) {
     if (targetType == null) {
+      if(node.getType() == null) {
+        throw new UnsupportedOperationException("Constant does not come with a data type.");
+      }
+      typeMap.put(node, node.getType());
       return Pair.create(node.getType(), CONSTANT_CRED);
     } else {
       node.setType(targetType);

--- a/tikv-client/src/main/java/com/pingcap/tikv/expression/visitor/ExpressionTypeCoercer.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/expression/visitor/ExpressionTypeCoercer.java
@@ -152,7 +152,7 @@ public class ExpressionTypeCoercer extends Visitor<Pair<DataType, Double>, DataT
   @Override
   protected Pair<DataType, Double> visit(Constant node, DataType targetType) {
     if (targetType == null) {
-      if(node.getType() == null) {
+      if (node.getType() == null) {
         throw new UnsupportedOperationException("Constant does not come with a data type.");
       }
       typeMap.put(node, node.getType());

--- a/tikv-client/src/main/java/com/pingcap/tikv/expression/visitor/SupportedExpressionValidator.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/expression/visitor/SupportedExpressionValidator.java
@@ -17,6 +17,7 @@ package com.pingcap.tikv.expression.visitor;
 
 import com.pingcap.tikv.expression.Expression;
 import com.pingcap.tikv.expression.ExpressionBlacklist;
+import com.pingcap.tikv.types.DataType;
 
 public class SupportedExpressionValidator extends DefaultVisitor<Boolean, ExpressionBlacklist> {
   private static final SupportedExpressionValidator validator = new SupportedExpressionValidator();
@@ -27,7 +28,8 @@ public class SupportedExpressionValidator extends DefaultVisitor<Boolean, Expres
     }
     try {
       ExpressionTypeCoercer coercer = new ExpressionTypeCoercer();
-      coercer.infer(node);
+      DataType type = coercer.infer(node);
+      coercer.getTypeMap().put(node, type);
       ProtoConverter protoConverter = new ProtoConverter(coercer.getTypeMap(), false);
       if (node.accept(protoConverter, null) == null) {
         return false;

--- a/tikv-client/src/main/java/com/pingcap/tikv/expression/visitor/SupportedExpressionValidator.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/expression/visitor/SupportedExpressionValidator.java
@@ -28,8 +28,7 @@ public class SupportedExpressionValidator extends DefaultVisitor<Boolean, Expres
     }
     try {
       ExpressionTypeCoercer coercer = new ExpressionTypeCoercer();
-      DataType type = coercer.infer(node);
-      coercer.getTypeMap().put(node, type);
+      coercer.infer(node);
       ProtoConverter protoConverter = new ProtoConverter(coercer.getTypeMap(), false);
       if (node.accept(protoConverter, null) == null) {
         return false;

--- a/tikv-client/src/main/java/com/pingcap/tikv/expression/visitor/SupportedExpressionValidator.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/expression/visitor/SupportedExpressionValidator.java
@@ -17,7 +17,6 @@ package com.pingcap.tikv.expression.visitor;
 
 import com.pingcap.tikv.expression.Expression;
 import com.pingcap.tikv.expression.ExpressionBlacklist;
-import com.pingcap.tikv.types.DataType;
 
 public class SupportedExpressionValidator extends DefaultVisitor<Boolean, ExpressionBlacklist> {
   private static final SupportedExpressionValidator validator = new SupportedExpressionValidator();

--- a/tikv-client/src/main/java/com/pingcap/tikv/meta/TiDAGRequest.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/meta/TiDAGRequest.java
@@ -1066,8 +1066,7 @@ public class TiDAGRequest implements Serializable {
       Joiner.on(", ").skipNulls().appendTo(sb, getDowngradeFilters());
     }
 
-    if (!isIndexScan && getPushDownFilters().isEmpty() &&
-        !getFilters().isEmpty()) {
+    if (!isIndexScan && getPushDownFilters().isEmpty() && !getFilters().isEmpty()) {
       sb.append(", Residual Filter: ");
       Joiner.on(", ").skipNulls().appendTo(sb, getFilters());
     }

--- a/tikv-client/src/main/java/com/pingcap/tikv/meta/TiDAGRequest.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/meta/TiDAGRequest.java
@@ -1066,7 +1066,8 @@ public class TiDAGRequest implements Serializable {
       Joiner.on(", ").skipNulls().appendTo(sb, getDowngradeFilters());
     }
 
-    if (!isIndexScan && !getFilters().isEmpty()) {
+    if (!isIndexScan && getPushDownFilters().isEmpty() &&
+        !getFilters().isEmpty()) {
       sb.append(", Residual Filter: ");
       Joiner.on(", ").skipNulls().appendTo(sb, getFilters());
     }


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

We determine an expression can be pushed down to coprocessor by suing `isSupportedExpression` of `SupportedExpressionValidator`. After phase of `infer`, we forget to add `DataType` to typeMap. This PR fixes this. 