### PR TITLE
support partition pruning on range columns partition 

### DIFF
--- a/tikv-client/src/main/java/com/pingcap/tikv/expression/FuncCallExprEval.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/expression/FuncCallExprEval.java
@@ -32,7 +32,7 @@ public class FuncCallExprEval {
             return Constant.create(date.getYear(), IntegerType.INT);
           }
           throw new UnsupportedOperationException(
-              String.format("cannot apply year to %s", type.getClass().getSimpleName()));
+              String.format("cannot apply year on %s", type.getName()));
         });
 
     // for newly adding type, please also adds the corresponding logic here.

--- a/tikv-client/src/main/java/com/pingcap/tikv/expression/PartitionPruner.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/expression/PartitionPruner.java
@@ -1,205 +1,63 @@
-/*
- * Copyright 2019 PingCAP, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.pingcap.tikv.expression;
 
-import com.google.common.collect.RangeSet;
-import com.pingcap.tikv.exception.UnsupportedPartitionExprException;
-import com.pingcap.tikv.exception.UnsupportedSyntaxException;
-import com.pingcap.tikv.expression.visitor.PartAndFilterExprRewriter;
-import com.pingcap.tikv.expression.visitor.PrunedPartitionBuilder;
-import com.pingcap.tikv.key.TypedKey;
 import com.pingcap.tikv.meta.TiPartitionDef;
 import com.pingcap.tikv.meta.TiPartitionInfo;
 import com.pingcap.tikv.meta.TiPartitionInfo.PartitionType;
 import com.pingcap.tikv.meta.TiTableInfo;
 import com.pingcap.tikv.parser.TiParser;
-import com.pingcap.tikv.predicates.PredicateUtils;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 
-@SuppressWarnings("UnstableApiUsage")
 public class PartitionPruner {
-  private Expression partExpr;
-  private Set<ColumnRef> partExprColRefs = new HashSet<>();
-  private List<Expression> partExprs;
-  private PrunedPartitionBuilder rangeBuilder;
-  private final TiPartitionInfo partInfo;
-  private final PartitionType type;
-  private boolean isRangeCol = false;
-  private final boolean partitionEnabled;
-  private boolean foundUnsupportedPartExpr;
-
-  public PartitionPruner(TiTableInfo tableInfo) {
-    this.type = TiPartitionInfo.toPartType((int) tableInfo.getPartitionInfo().getType());
-    this.partInfo = tableInfo.getPartitionInfo();
-    this.partitionEnabled = tableInfo.isPartitionEnabled();
-    List<String> columnInfos = this.partInfo.getColumns();
-    if (this.type == PartitionType.RangePartition) {
-      this.isRangeCol = Objects.requireNonNull(columnInfos).size() > 0;
-      try {
-        this.partExprs = generateRangePartExprs(tableInfo);
-        this.rangeBuilder = new PrunedPartitionBuilder(partExprColRefs);
-      } catch (UnsupportedSyntaxException | UnsupportedPartitionExprException e) {
-        foundUnsupportedPartExpr = true;
+  public static List<Expression> extractLogicalOrComparisonExpr(List<Expression> filters) {
+    List<Expression> filteredFilters = new ArrayList<>();
+    for (Expression expr : filters) {
+      if (expr instanceof LogicalBinaryExpression || expr instanceof ComparisonBinaryExpression) {
+        filteredFilters.add(expr);
       }
     }
+    return filteredFilters;
   }
 
-  // pruneListPart will prune list partition that where conditions never access.
-  private List<TiPartitionDef> pruneListPart(List<Expression> filters) {
-    return partInfo.getDefs();
-  }
-
-  // pruneHashPart will prune hash partition that where conditions never access.
-  private List<TiPartitionDef> pruneHashPart(List<Expression> filters) {
-    return partInfo.getDefs();
-  }
-
-  private List<TiPartitionDef> pruneRangeColumnPart(Expression cnfExpr) {
-    RangeSet<TypedKey> filterRange = rangeBuilder.buildRange(cnfExpr);
-
-    List<TiPartitionDef> pDefs = new ArrayList<>();
-    for (int i = 0; i < partExprs.size(); i++) {
-      Expression partExpr = partExprs.get(i);
-      // when we build range, we still need rewrite partition expression.
-      // If we have a year(purchased) < 1995 which cannot be normalized, we need
-      // to rewrite it into purchased < 1995 to let RangeSetBuilder be happy.
-      RangeSet<TypedKey> partRange = rangeBuilder.buildRange(partExpr);
-      partRange.removeAll(filterRange.complement());
-      if (!partRange.isEmpty()) {
-        // part range is empty indicates this partition can be pruned.
-        pDefs.add(partInfo.getDefs().get(i));
-      }
-    }
-    return pDefs;
-  }
-
-  private List<TiPartitionDef> pruneRangeNormalPart(Expression cnfExpr) {
-    Objects.requireNonNull(cnfExpr, "cnf expression cannot be null at pruning stage");
-
-    // we need rewrite filter expression. This step is designed to  deal with
-    // y < '1885-10-10' where y is a date type. Rewrite will apply partition expression
-    // on the constant part. After rewriting, it becomes y < 1995;
-    PartAndFilterExprRewriter expressionRewriter = new PartAndFilterExprRewriter(partExpr);
-    cnfExpr = expressionRewriter.rewrite(cnfExpr);
-    // if we find an unsupported partition function, we downgrade to scan all partitions.
-    if (expressionRewriter.isUnsupportedPartFnFound()) {
-      return partInfo.getDefs();
-    }
-    RangeSet<TypedKey> filterRange = rangeBuilder.buildRange(cnfExpr);
-
-    List<TiPartitionDef> pDefs = new ArrayList<>();
-    for (int i = 0; i < partExprs.size(); i++) {
-      Expression partExpr = partExprs.get(i);
-      // when we build range, we still need rewrite partition expression.
-      // If we have a year(purchased) < 1995 which cannot be normalized, we need
-      // to rewrite it into purchased < 1995 to let RangeSetBuilder be happy.
-      RangeSet<TypedKey> partRange = rangeBuilder.buildRange(expressionRewriter.rewrite(partExpr));
-      partRange.removeAll(filterRange.complement());
-      if (!partRange.isEmpty()) {
-        // part range is empty indicates this partition can be pruned.
-        pDefs.add(partInfo.getDefs().get(i));
-      }
-    }
-    return pDefs;
-  }
-
-  /**
-   * When table is a partition table and its type is range. We use this method to do the pruning.
-   * Range partition has two types: 1. range 2. range column. If it is the first case,
-   * pruneRangeNormalPart will be called. Otherwise pruneRangeColPart will be called. For now, we
-   * simply skip range column partition case. TODO: support partition pruning on range column later.
-   *
-   * @param filters is where condition belong to a select statement.
-   * @return a pruned partition for scanning.
-   */
-  // pruneRangePart will prune range partition that where conditions never access.
-  private List<TiPartitionDef> pruneRangePart(List<Expression> filters) {
-    filters = extractLogicalOrComparisonExpr(filters);
-    Expression cnfExpr = PredicateUtils.mergeCNFExpressions(filters);
-    if (isRangeCol) {
-      return pruneRangeColumnPart(cnfExpr);
-    } else {
-      // pruning can also be performed for WHERE conditions that involve comparisons of the
-      // preceding types on multiple columns for tables that use RANGE COLUMNS or LIST COLUMNS
-      // partitioning.
-      // This type of optimization can be applied whenever the partitioning expression consists
-      // of an equality or a range which can be reduced to a set of equalities, or when
-      // the partitioning expression represents an increasing or decreasing relationship.
-      // Pruning can also be applied for tables partitioned on a DATE or DATETIME column
-      // when the partitioning expression uses the YEAR() or TO_DAYS() function.
-      // Pruning can also be applied for such tables when the partitioning expression uses
-      // the TO_SECONDS() function
-      if (!canBePruned(cnfExpr)) {
-        return this.partInfo.getDefs();
-      }
-
-      return pruneRangeNormalPart(cnfExpr);
-    }
-  }
-
-  // say we have a partitioned table with the following partition definitions with year(y) as
-  // partition expression:
-  // 1. p0 less than 1995
-  // 2. p1 less than 1996
-  // 3. p2 less than maxvalue
-  // Above infos, after this function, will become the following:
-  // 1. p0: year(y) < 1995
-  // 2. p1: 1995 <= year(y) and year(y) < 1996
-  // 3. p2: 1996 <= year(y) and true
-  // true will become {@Code Constant} 1.
-  private List<Expression> generateRangePartExprs(TiTableInfo tableInfo) {
-    TiPartitionInfo partInfo = tableInfo.getPartitionInfo();
-    List<Expression> partExprs = new ArrayList<>();
-    TiParser parser = new TiParser(tableInfo);
-    // check year expression
-    // rewrite filter condition
-    // purchased > '1995-10-10'
-    // year(purchased) > year('1995-10-10')
-    // purchased > 1995
-    String partExprStr = tableInfo.getPartitionInfo().getExpr();
-    if (!partExprStr.isEmpty()) {
-      // when it is not range column case, only first element stores useful info.
-      generateRangeExprs(partInfo, partExprs, parser, partExprStr, 0);
-    } else {
-      for (int i = 0; i < partInfo.getColumns().size(); i++) {
-        generateRangeExprs(partInfo, partExprs, parser, partInfo.getColumns().get(i), i);
-      }
+  public static List<TiPartitionDef> prune(TiTableInfo tableInfo, List<Expression> filters) {
+    PartitionType type = tableInfo.getPartitionInfo().getType();
+    if (!tableInfo.isPartitionEnabled()) {
+      return tableInfo.getPartitionInfo().getDefs();
     }
 
-    return partExprs;
+    boolean isRangeCol =
+        Objects.requireNonNull(tableInfo.getPartitionInfo().getColumns()).size() > 0;
+
+    switch (type) {
+      case RangePartition:
+        if (!isRangeCol) {
+          // TiDB only supports partition pruning on range partition on single column
+          // If we meet range partition on multiple columns, we simply return all parts.
+          if (tableInfo.getPartitionInfo().getColumns().size() > 1) {
+            return tableInfo.getPartitionInfo().getDefs();
+          }
+          RangePartitionPruner prunner = new RangePartitionPruner(tableInfo);
+          return prunner.prune(filters);
+        } else {
+          RangeColumnPartitionPruner pruner = new RangeColumnPartitionPruner(tableInfo);
+          return pruner.prune(filters);
+        }
+      case ListPartition:
+      case HashPartition:
+        return tableInfo.getPartitionInfo().getDefs();
+    }
+
+    throw new UnsupportedOperationException("cannot prune under invalid partition table");
   }
 
-  private void generateRangeExprs(
+  static void generateRangeExprs(
       TiPartitionInfo partInfo,
       List<Expression> partExprs,
       TiParser parser,
       String partExprStr,
       int lessThanIdx) {
-    partExpr = parser.parseExpression(partExprStr);
-    // when partExpr is null, it indicates partition expression
-    // is not supported for now
-    if (partExpr == null) {
-      throw new UnsupportedPartitionExprException(
-          String.format("%s is not supported", partExprStr));
-    }
-    partExprColRefs.addAll(PredicateUtils.extractColumnRefFromExpression(partExpr));
+    // partExprColRefs.addAll(PredicateUtils.extractColumnRefFromExpression(partExpr));
     for (int i = 0; i < partInfo.getDefs().size(); i++) {
       TiPartitionDef pDef = partInfo.getDefs().get(i);
       String current = pDef.getLessThan().get(lessThanIdx);
@@ -217,51 +75,5 @@ public class PartitionPruner {
         partExprs.add(parser.parseExpression(and));
       }
     }
-  }
-
-  private static List<Expression> extractLogicalOrComparisonExpr(List<Expression> filters) {
-    List<Expression> filteredFilters = new ArrayList<>();
-    for (Expression expr : filters) {
-      if (expr instanceof LogicalBinaryExpression || expr instanceof ComparisonBinaryExpression) {
-        filteredFilters.add(expr);
-      }
-    }
-    return filteredFilters;
-  }
-
-  public List<TiPartitionDef> prune(List<Expression> filters) {
-    switch (type) {
-      case RangePartition:
-        return pruneRangePart(filters);
-      case ListPartition:
-        return pruneListPart(filters);
-      case HashPartition:
-        return pruneHashPart(filters);
-    }
-
-    throw new UnsupportedOperationException("cannot prune under invalid partition table");
-  }
-
-  /**
-   * return false if table cannot be pruning or partition table is not enabled. Return true if
-   * partition pruning can be applied.
-   *
-   * @param filter is a where condition. It must be a cnf and does not contain not or isnull.
-   * @return true if partition pruning can apply on filter.
-   */
-  public boolean canBePruned(Expression filter) {
-    if (!partitionEnabled) {
-      return false;
-    }
-
-    if (this.type != PartitionType.RangePartition) {
-      return false;
-    }
-
-    if (foundUnsupportedPartExpr) {
-      return false;
-    }
-    // if query is select * from t, then filter will be null.
-    return filter != null;
   }
 }

--- a/tikv-client/src/main/java/com/pingcap/tikv/expression/PartitionPruner.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/expression/PartitionPruner.java
@@ -1,0 +1,267 @@
+/*
+ * Copyright 2019 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pingcap.tikv.expression;
+
+import com.google.common.collect.RangeSet;
+import com.pingcap.tikv.exception.UnsupportedPartitionExprException;
+import com.pingcap.tikv.exception.UnsupportedSyntaxException;
+import com.pingcap.tikv.expression.visitor.PartAndFilterExprRewriter;
+import com.pingcap.tikv.expression.visitor.PrunedPartitionBuilder;
+import com.pingcap.tikv.key.TypedKey;
+import com.pingcap.tikv.meta.TiPartitionDef;
+import com.pingcap.tikv.meta.TiPartitionInfo;
+import com.pingcap.tikv.meta.TiPartitionInfo.PartitionType;
+import com.pingcap.tikv.meta.TiTableInfo;
+import com.pingcap.tikv.parser.TiParser;
+import com.pingcap.tikv.predicates.PredicateUtils;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+@SuppressWarnings("UnstableApiUsage")
+public class PartitionPruner {
+  private Expression partExpr;
+  private Set<ColumnRef> partExprColRefs = new HashSet<>();
+  private List<Expression> partExprs;
+  private PrunedPartitionBuilder rangeBuilder;
+  private final TiPartitionInfo partInfo;
+  private final PartitionType type;
+  private boolean isRangeCol = false;
+  private final boolean partitionEnabled;
+  private boolean foundUnsupportedPartExpr;
+
+  public PartitionPruner(TiTableInfo tableInfo) {
+    this.type = TiPartitionInfo.toPartType((int) tableInfo.getPartitionInfo().getType());
+    this.partInfo = tableInfo.getPartitionInfo();
+    this.partitionEnabled = tableInfo.isPartitionEnabled();
+    List<String> columnInfos = this.partInfo.getColumns();
+    if (this.type == PartitionType.RangePartition) {
+      this.isRangeCol = Objects.requireNonNull(columnInfos).size() > 0;
+      try {
+        this.partExprs = generateRangePartExprs(tableInfo);
+        this.rangeBuilder = new PrunedPartitionBuilder(partExprColRefs);
+      } catch (UnsupportedSyntaxException | UnsupportedPartitionExprException e) {
+        foundUnsupportedPartExpr = true;
+      }
+    }
+  }
+
+  // pruneListPart will prune list partition that where conditions never access.
+  private List<TiPartitionDef> pruneListPart(List<Expression> filters) {
+    return partInfo.getDefs();
+  }
+
+  // pruneHashPart will prune hash partition that where conditions never access.
+  private List<TiPartitionDef> pruneHashPart(List<Expression> filters) {
+    return partInfo.getDefs();
+  }
+
+  private List<TiPartitionDef> pruneRangeColumnPart(Expression cnfExpr) {
+    RangeSet<TypedKey> filterRange = rangeBuilder.buildRange(cnfExpr);
+
+    List<TiPartitionDef> pDefs = new ArrayList<>();
+    for (int i = 0; i < partExprs.size(); i++) {
+      Expression partExpr = partExprs.get(i);
+      // when we build range, we still need rewrite partition expression.
+      // If we have a year(purchased) < 1995 which cannot be normalized, we need
+      // to rewrite it into purchased < 1995 to let RangeSetBuilder be happy.
+      RangeSet<TypedKey> partRange = rangeBuilder.buildRange(partExpr);
+      partRange.removeAll(filterRange.complement());
+      if (!partRange.isEmpty()) {
+        // part range is empty indicates this partition can be pruned.
+        pDefs.add(partInfo.getDefs().get(i));
+      }
+    }
+    return pDefs;
+  }
+
+  private List<TiPartitionDef> pruneRangeNormalPart(Expression cnfExpr) {
+    Objects.requireNonNull(cnfExpr, "cnf expression cannot be null at pruning stage");
+
+    // we need rewrite filter expression. This step is designed to  deal with
+    // y < '1885-10-10' where y is a date type. Rewrite will apply partition expression
+    // on the constant part. After rewriting, it becomes y < 1995;
+    PartAndFilterExprRewriter expressionRewriter = new PartAndFilterExprRewriter(partExpr);
+    cnfExpr = expressionRewriter.rewrite(cnfExpr);
+    // if we find an unsupported partition function, we downgrade to scan all partitions.
+    if (expressionRewriter.isUnsupportedPartFnFound()) {
+      return partInfo.getDefs();
+    }
+    RangeSet<TypedKey> filterRange = rangeBuilder.buildRange(cnfExpr);
+
+    List<TiPartitionDef> pDefs = new ArrayList<>();
+    for (int i = 0; i < partExprs.size(); i++) {
+      Expression partExpr = partExprs.get(i);
+      // when we build range, we still need rewrite partition expression.
+      // If we have a year(purchased) < 1995 which cannot be normalized, we need
+      // to rewrite it into purchased < 1995 to let RangeSetBuilder be happy.
+      RangeSet<TypedKey> partRange = rangeBuilder.buildRange(expressionRewriter.rewrite(partExpr));
+      partRange.removeAll(filterRange.complement());
+      if (!partRange.isEmpty()) {
+        // part range is empty indicates this partition can be pruned.
+        pDefs.add(partInfo.getDefs().get(i));
+      }
+    }
+    return pDefs;
+  }
+
+  /**
+   * When table is a partition table and its type is range. We use this method to do the pruning.
+   * Range partition has two types: 1. range 2. range column. If it is the first case,
+   * pruneRangeNormalPart will be called. Otherwise pruneRangeColPart will be called. For now, we
+   * simply skip range column partition case. TODO: support partition pruning on range column later.
+   *
+   * @param filters is where condition belong to a select statement.
+   * @return a pruned partition for scanning.
+   */
+  // pruneRangePart will prune range partition that where conditions never access.
+  private List<TiPartitionDef> pruneRangePart(List<Expression> filters) {
+    filters = extractLogicalOrComparisonExpr(filters);
+    Expression cnfExpr = PredicateUtils.mergeCNFExpressions(filters);
+    if (isRangeCol) {
+      return pruneRangeColumnPart(cnfExpr);
+    } else {
+      // pruning can also be performed for WHERE conditions that involve comparisons of the
+      // preceding types on multiple columns for tables that use RANGE COLUMNS or LIST COLUMNS
+      // partitioning.
+      // This type of optimization can be applied whenever the partitioning expression consists
+      // of an equality or a range which can be reduced to a set of equalities, or when
+      // the partitioning expression represents an increasing or decreasing relationship.
+      // Pruning can also be applied for tables partitioned on a DATE or DATETIME column
+      // when the partitioning expression uses the YEAR() or TO_DAYS() function.
+      // Pruning can also be applied for such tables when the partitioning expression uses
+      // the TO_SECONDS() function
+      if (!canBePruned(cnfExpr)) {
+        return this.partInfo.getDefs();
+      }
+
+      return pruneRangeNormalPart(cnfExpr);
+    }
+  }
+
+  // say we have a partitioned table with the following partition definitions with year(y) as
+  // partition expression:
+  // 1. p0 less than 1995
+  // 2. p1 less than 1996
+  // 3. p2 less than maxvalue
+  // Above infos, after this function, will become the following:
+  // 1. p0: year(y) < 1995
+  // 2. p1: 1995 <= year(y) and year(y) < 1996
+  // 3. p2: 1996 <= year(y) and true
+  // true will become {@Code Constant} 1.
+  private List<Expression> generateRangePartExprs(TiTableInfo tableInfo) {
+    TiPartitionInfo partInfo = tableInfo.getPartitionInfo();
+    List<Expression> partExprs = new ArrayList<>();
+    TiParser parser = new TiParser(tableInfo);
+    // check year expression
+    // rewrite filter condition
+    // purchased > '1995-10-10'
+    // year(purchased) > year('1995-10-10')
+    // purchased > 1995
+    String partExprStr = tableInfo.getPartitionInfo().getExpr();
+    if (!partExprStr.isEmpty()) {
+      // when it is not range column case, only first element stores useful info.
+      generateRangeExprs(partInfo, partExprs, parser, partExprStr, 0);
+    } else {
+      for (int i = 0; i < partInfo.getColumns().size(); i++) {
+        generateRangeExprs(partInfo, partExprs, parser, partInfo.getColumns().get(i), i);
+      }
+    }
+
+    return partExprs;
+  }
+
+  private void generateRangeExprs(
+      TiPartitionInfo partInfo,
+      List<Expression> partExprs,
+      TiParser parser,
+      String partExprStr,
+      int lessThanIdx) {
+    partExpr = parser.parseExpression(partExprStr);
+    // when partExpr is null, it indicates partition expression
+    // is not supported for now
+    if (partExpr == null) {
+      throw new UnsupportedPartitionExprException(
+          String.format("%s is not supported", partExprStr));
+    }
+    partExprColRefs.addAll(PredicateUtils.extractColumnRefFromExpression(partExpr));
+    for (int i = 0; i < partInfo.getDefs().size(); i++) {
+      TiPartitionDef pDef = partInfo.getDefs().get(i);
+      String current = pDef.getLessThan().get(lessThanIdx);
+      String leftHand;
+      if (current.equals("MAXVALUE")) {
+        leftHand = "true";
+      } else {
+        leftHand = String.format("%s < %s", partExprStr, current);
+      }
+      if (i == 0) {
+        partExprs.add(parser.parseExpression(leftHand));
+      } else {
+        String previous = partInfo.getDefs().get(i - 1).getLessThan().get(lessThanIdx);
+        String and = String.format("%s and %s", partExprStr + ">=" + previous, leftHand);
+        partExprs.add(parser.parseExpression(and));
+      }
+    }
+  }
+
+  private static List<Expression> extractLogicalOrComparisonExpr(List<Expression> filters) {
+    List<Expression> filteredFilters = new ArrayList<>();
+    for (Expression expr : filters) {
+      if (expr instanceof LogicalBinaryExpression || expr instanceof ComparisonBinaryExpression) {
+        filteredFilters.add(expr);
+      }
+    }
+    return filteredFilters;
+  }
+
+  public List<TiPartitionDef> prune(List<Expression> filters) {
+    switch (type) {
+      case RangePartition:
+        return pruneRangePart(filters);
+      case ListPartition:
+        return pruneListPart(filters);
+      case HashPartition:
+        return pruneHashPart(filters);
+    }
+
+    throw new UnsupportedOperationException("cannot prune under invalid partition table");
+  }
+
+  /**
+   * return false if table cannot be pruning or partition table is not enabled. Return true if
+   * partition pruning can be applied.
+   *
+   * @param filter is a where condition. It must be a cnf and does not contain not or isnull.
+   * @return true if partition pruning can apply on filter.
+   */
+  public boolean canBePruned(Expression filter) {
+    if (!partitionEnabled) {
+      return false;
+    }
+
+    if (this.type != PartitionType.RangePartition) {
+      return false;
+    }
+
+    if (foundUnsupportedPartExpr) {
+      return false;
+    }
+    // if query is select * from t, then filter will be null.
+    return filter != null;
+  }
+}

--- a/tikv-client/src/main/java/com/pingcap/tikv/expression/PartitionPruner.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/expression/PartitionPruner.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.pingcap.tikv.expression;
 
 import com.pingcap.tikv.meta.TiPartitionDef;

--- a/tikv-client/src/main/java/com/pingcap/tikv/expression/RangeColumnPartitionPruner.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/expression/RangeColumnPartitionPruner.java
@@ -83,7 +83,10 @@ public class RangeColumnPartitionPruner
   @Override
   protected Set<Integer> visit(ComparisonBinaryExpression node, LogicalBinaryExpression parent) {
     NormalizedPredicate predicate = node.normalize();
-    // TODO check can we normalize ComparisonBinaryExpression.
+    if (predicate == null) {
+      throw new UnsupportedOperationException(
+          String.format("ComparisonBinaryExpression %s cannot be normalized", node.toString()));
+    }
     String colRefName = predicate.getColumnRef().getName();
     List<Expression> partExprs = partExprsPerColumnRef.get(colRefName);
     Set<Integer> partDefs = new HashSet<>();

--- a/tikv-client/src/main/java/com/pingcap/tikv/expression/RangeColumnPartitionPruner.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/expression/RangeColumnPartitionPruner.java
@@ -1,0 +1,118 @@
+package com.pingcap.tikv.expression;
+
+import static com.pingcap.tikv.expression.PartitionPruner.extractLogicalOrComparisonExpr;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.RangeSet;
+import com.google.common.collect.TreeRangeSet;
+import com.pingcap.tikv.expression.ComparisonBinaryExpression.NormalizedPredicate;
+import com.pingcap.tikv.expression.visitor.DefaultVisitor;
+import com.pingcap.tikv.expression.visitor.PrunedPartitionBuilder;
+import com.pingcap.tikv.key.TypedKey;
+import com.pingcap.tikv.meta.TiPartitionDef;
+import com.pingcap.tikv.meta.TiPartitionInfo;
+import com.pingcap.tikv.meta.TiTableInfo;
+import com.pingcap.tikv.parser.TiParser;
+import com.pingcap.tikv.predicates.PredicateUtils;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+@SuppressWarnings("UnstableApiUsage")
+public class RangeColumnPartitionPruner
+    extends DefaultVisitor<Set<Integer>, LogicalBinaryExpression> {
+  private Map<String, List<Expression>> partExprsPerColumnRef;
+  private final int partsSize;
+  private final TiPartitionInfo partInfo;
+
+  RangeColumnPartitionPruner(TiTableInfo tableInfo) {
+    this.partExprsPerColumnRef = new HashMap<>();
+    this.partInfo = tableInfo.getPartitionInfo();
+    TiParser parser = new TiParser(tableInfo);
+    for (int i = 0; i < partInfo.getColumns().size(); i++) {
+      List<Expression> partExprs = new ArrayList<>();
+      String colRefName = partInfo.getColumns().get(i);
+      PartitionPruner.generateRangeExprs(partInfo, partExprs, parser, colRefName, i);
+      partExprsPerColumnRef.put(colRefName, partExprs);
+    }
+    this.partsSize = tableInfo.getPartitionInfo().getDefs().size();
+  }
+
+  @Override
+  protected Set<Integer> visit(LogicalBinaryExpression node, LogicalBinaryExpression parent) {
+    Expression left = node.getLeft();
+    Expression right = node.getRight();
+    Set<Integer> partsIsCoveredByLeft = left.accept(this, node);
+    Set<Integer> partsIsCoveredByRight = right.accept(this, node);
+    switch (node.getCompType()) {
+      case OR:
+        partsIsCoveredByLeft.addAll(partsIsCoveredByRight);
+        return partsIsCoveredByLeft;
+      case AND:
+        Set<Integer> partsIsCoveredByBoth = new HashSet<>();
+        for (int i = 0; i < partsSize; i++) {
+          if (partsIsCoveredByLeft.contains(i) && partsIsCoveredByRight.contains(i)) {
+            partsIsCoveredByBoth.add(i);
+          }
+        }
+        return partsIsCoveredByBoth;
+    }
+
+    throw new UnsupportedOperationException("cannot access here");
+  }
+
+  @Override
+  protected Set<Integer> visit(ComparisonBinaryExpression node, LogicalBinaryExpression parent) {
+    NormalizedPredicate predicate = node.normalize();
+    // TODO check can we normalize ComparisonBinaryExpression.
+    String colRefName = predicate.getColumnRef().getName();
+    List<Expression> partExprs = partExprsPerColumnRef.get(colRefName);
+    Set<Integer> partDefs = new HashSet<>();
+    if (partExprs == null) {
+      switch (parent.getCompType()) {
+        case OR:
+          return partDefs;
+        case AND:
+          for (int i = 0; i < partsSize; i++) {
+            partDefs.add(i);
+          }
+          return partDefs;
+      }
+    }
+    Objects.requireNonNull(partExprs, "partition expression cannot be null");
+    for (int i = 0; i < partsSize; i++) {
+      PrunedPartitionBuilder rangeBuilder =
+          new PrunedPartitionBuilder(ImmutableSet.of(predicate.getColumnRef()));
+      RangeSet<TypedKey> partExprRange = rangeBuilder.buildRange(partExprs.get(i));
+      RangeSet<TypedKey> filterRange = rangeBuilder.buildRange(node);
+      RangeSet<TypedKey> copy = TreeRangeSet.create(partExprRange);
+      copy.removeAll(filterRange.complement());
+      // part expr and filter is connected
+      if (!copy.isEmpty()) {
+        partDefs.add(i);
+      }
+    }
+    return partDefs;
+  }
+
+  public List<TiPartitionDef> prune(List<Expression> filters) {
+    filters = extractLogicalOrComparisonExpr(filters);
+    Expression cnfExpr = PredicateUtils.mergeCNFExpressions(filters);
+    if (cnfExpr == null) {
+      return partInfo.getDefs();
+    }
+    Set<Integer> partsIdx = cnfExpr.accept(this, null);
+    List<TiPartitionDef> pDefs = new ArrayList<>();
+    for (int i = 0; i < partsSize; i++) {
+      if (partsIdx.contains(i)) {
+        // part range is empty indicates this partition can be pruned.
+        pDefs.add(partInfo.getDefs().get(i));
+      }
+    }
+    return pDefs;
+  }
+}

--- a/tikv-client/src/main/java/com/pingcap/tikv/expression/RangeColumnPartitionPruner.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/expression/RangeColumnPartitionPruner.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.pingcap.tikv.expression;
 
 import static com.pingcap.tikv.expression.PartitionPruner.extractLogicalOrComparisonExpr;

--- a/tikv-client/src/main/java/com/pingcap/tikv/expression/RangePartitionPruner.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/expression/RangePartitionPruner.java
@@ -56,9 +56,10 @@ public class RangePartitionPruner {
   private List<TiPartitionDef> pruneRangeNormalPart(Expression cnfExpr) {
     Objects.requireNonNull(cnfExpr, "cnf expression cannot be null at pruning stage");
 
-    // we need rewrite filter expression. This step is designed to  deal with
-    // y < '1885-10-10' where y is a date type. Rewrite will apply partition expression
-    // on the constant part. After rewriting, it becomes y < 1995;
+    // we need rewrite filter expression if partition expression is a Year expression.
+    // This step is designed to deal with y < '1885-10-10' where y is a date type.
+    // Rewrite will apply partition expression on the constant part.
+    // After rewriting, it becomes y < 1995;
     PartAndFilterExprRewriter expressionRewriter = new PartAndFilterExprRewriter(partExpr);
     cnfExpr = expressionRewriter.rewrite(cnfExpr);
     // if we find an unsupported partition function, we downgrade to scan all partitions.

--- a/tikv-client/src/main/java/com/pingcap/tikv/expression/RangePartitionPruner.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/expression/RangePartitionPruner.java
@@ -57,7 +57,8 @@ public class RangePartitionPruner {
     Objects.requireNonNull(cnfExpr, "cnf expression cannot be null at pruning stage");
 
     // we need rewrite filter expression if partition expression is a Year expression.
-    // This step is designed to deal with y < '1885-10-10' where y is a date type.
+    // This step is designed to deal with y < '1995-10-10'(in filter condition and also a part of
+    // partition expression) where y is a date type.
     // Rewrite will apply partition expression on the constant part.
     // After rewriting, it becomes y < 1995;
     PartAndFilterExprRewriter expressionRewriter = new PartAndFilterExprRewriter(partExpr);
@@ -123,7 +124,7 @@ public class RangePartitionPruner {
    * When table is a partition table and its type is range. We use this method to do the pruning.
    * Range partition has two types: 1. range 2. range column. If it is the first case,
    * pruneRangeNormalPart will be called. Otherwise pruneRangeColPart will be called. For now, we
-   * simply skip range column partition case. TODO: support partition pruning on range column later.
+   * simply skip range column partition case.
    *
    * @param filters is where condition belong to a select statement.
    * @return a pruned partition for scanning.

--- a/tikv-client/src/main/java/com/pingcap/tikv/expression/RangePartitionPruner.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/expression/RangePartitionPruner.java
@@ -59,8 +59,7 @@ public class RangePartitionPruner {
     // we need rewrite filter expression if partition expression is a Year expression.
     // This step is designed to deal with y < '1995-10-10'(in filter condition and also a part of
     // partition expression) where y is a date type.
-    // Rewrite will apply partition expression on the constant part.
-    // After rewriting, it becomes y < 1995;
+    // Rewriting only applies partition expression on the constant part, resulting year(y) < 1995.
     PartAndFilterExprRewriter expressionRewriter = new PartAndFilterExprRewriter(partExpr);
     cnfExpr = expressionRewriter.rewrite(cnfExpr);
     // if we find an unsupported partition function, we downgrade to scan all partitions.

--- a/tikv-client/src/main/java/com/pingcap/tikv/expression/RangePartitionPruner.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/expression/RangePartitionPruner.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2019 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pingcap.tikv.expression;
+
+import static com.pingcap.tikv.expression.PartitionPruner.extractLogicalOrComparisonExpr;
+
+import com.google.common.collect.RangeSet;
+import com.pingcap.tikv.exception.UnsupportedPartitionExprException;
+import com.pingcap.tikv.exception.UnsupportedSyntaxException;
+import com.pingcap.tikv.expression.visitor.PartAndFilterExprRewriter;
+import com.pingcap.tikv.expression.visitor.PrunedPartitionBuilder;
+import com.pingcap.tikv.key.TypedKey;
+import com.pingcap.tikv.meta.TiPartitionDef;
+import com.pingcap.tikv.meta.TiPartitionInfo;
+import com.pingcap.tikv.meta.TiTableInfo;
+import com.pingcap.tikv.parser.TiParser;
+import com.pingcap.tikv.predicates.PredicateUtils;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+@SuppressWarnings("UnstableApiUsage")
+public class RangePartitionPruner {
+  private Expression partExpr;
+  private Set<ColumnRef> partExprColRefs = new HashSet<>();
+  private List<Expression> partExprs;
+  private PrunedPartitionBuilder rangeBuilder;
+  private final TiPartitionInfo partInfo;
+  private boolean foundUnsupportedPartExpr;
+
+  RangePartitionPruner(TiTableInfo tableInfo) {
+    this.partInfo = tableInfo.getPartitionInfo();
+    try {
+      this.partExprs = generateRangePartExprs(tableInfo);
+      this.rangeBuilder = new PrunedPartitionBuilder(partExprColRefs);
+    } catch (UnsupportedSyntaxException | UnsupportedPartitionExprException e) {
+      foundUnsupportedPartExpr = true;
+    }
+  }
+
+  private List<TiPartitionDef> pruneRangeNormalPart(Expression cnfExpr) {
+    Objects.requireNonNull(cnfExpr, "cnf expression cannot be null at pruning stage");
+
+    // we need rewrite filter expression. This step is designed to  deal with
+    // y < '1885-10-10' where y is a date type. Rewrite will apply partition expression
+    // on the constant part. After rewriting, it becomes y < 1995;
+    PartAndFilterExprRewriter expressionRewriter = new PartAndFilterExprRewriter(partExpr);
+    cnfExpr = expressionRewriter.rewrite(cnfExpr);
+    // if we find an unsupported partition function, we downgrade to scan all partitions.
+    if (expressionRewriter.isUnsupportedPartFnFound()) {
+      return partInfo.getDefs();
+    }
+    RangeSet<TypedKey> filterRange = rangeBuilder.buildRange(cnfExpr);
+
+    List<TiPartitionDef> pDefs = new ArrayList<>();
+    for (int i = 0; i < partExprs.size(); i++) {
+      Expression partExpr = partExprs.get(i);
+      // when we build range, we still need rewrite partition expression.
+      // If we have a year(purchased) < 1995 which cannot be normalized, we need
+      // to rewrite it into purchased < 1995 to let RangeSetBuilder be happy.
+      RangeSet<TypedKey> partRange = rangeBuilder.buildRange(expressionRewriter.rewrite(partExpr));
+      partRange.removeAll(filterRange.complement());
+      if (!partRange.isEmpty()) {
+        // part range is empty indicates this partition can be pruned.
+        pDefs.add(partInfo.getDefs().get(i));
+      }
+    }
+    return pDefs;
+  }
+
+  // say we have a partitioned table with the following partition definitions with year(y) as
+  // partition expression:
+  // 1. p0 less than 1995
+  // 2. p1 less than 1996
+  // 3. p2 less than maxvalue
+  // Above infos, after this function, will become the following:
+  // 1. p0: year(y) < 1995
+  // 2. p1: 1995 <= year(y) and year(y) < 1996
+  // 3. p2: 1996 <= year(y) and true
+  // true will become {@Code Constant} 1.
+  private List<Expression> generateRangePartExprs(TiTableInfo tableInfo) {
+    TiPartitionInfo partInfo = tableInfo.getPartitionInfo();
+    List<Expression> partExprs = new ArrayList<>();
+    TiParser parser = new TiParser(tableInfo);
+    // check year expression
+    // rewrite filter condition
+    // purchased > '1995-10-10'
+    // year(purchased) > year('1995-10-10')
+    // purchased > 1995
+    String partExprStr = tableInfo.getPartitionInfo().getExpr();
+
+    partExpr = parser.parseExpression(partExprStr);
+    // when partExpr is null, it indicates partition expression
+    // is not supported for now
+    if (partExpr == null) {
+      throw new UnsupportedPartitionExprException(
+          String.format("%s is not supported", partExprStr));
+    } // when it is not range column case, only first element stores useful info.
+
+    partExprColRefs.addAll(PredicateUtils.extractColumnRefFromExpression(partExpr));
+    PartitionPruner.generateRangeExprs(partInfo, partExprs, parser, partExprStr, 0);
+
+    return partExprs;
+  }
+
+  /**
+   * When table is a partition table and its type is range. We use this method to do the pruning.
+   * Range partition has two types: 1. range 2. range column. If it is the first case,
+   * pruneRangeNormalPart will be called. Otherwise pruneRangeColPart will be called. For now, we
+   * simply skip range column partition case. TODO: support partition pruning on range column later.
+   *
+   * @param filters is where condition belong to a select statement.
+   * @return a pruned partition for scanning.
+   */
+  public List<TiPartitionDef> prune(List<Expression> filters) {
+    filters = extractLogicalOrComparisonExpr(filters);
+    Expression cnfExpr = PredicateUtils.mergeCNFExpressions(filters);
+    if (!canBePruned(cnfExpr)) {
+      return this.partInfo.getDefs();
+    }
+
+    return pruneRangeNormalPart(cnfExpr);
+  }
+
+  /**
+   * return false if table cannot be pruning or partition table is not enabled. Return true if
+   * partition pruning can be applied.
+   *
+   * @param filter is a where condition. It must be a cnf and does not contain not or isnull.
+   * @return true if partition pruning can apply on filter.
+   */
+  public boolean canBePruned(Expression filter) {
+    if (foundUnsupportedPartExpr) {
+      return false;
+    }
+    // if query is select * from t, then filter will be null.
+    return filter != null;
+  }
+}

--- a/tikv-client/src/main/java/com/pingcap/tikv/expression/visitor/PartAndFilterExprRewriter.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/expression/visitor/PartAndFilterExprRewriter.java
@@ -21,7 +21,7 @@ public class PartAndFilterExprRewriter extends DefaultVisitor<Expression, Void> 
 
   private boolean unsupportedPartFnFound;
 
-  PartAndFilterExprRewriter(Expression partExpr) {
+  public PartAndFilterExprRewriter(Expression partExpr) {
     Objects.requireNonNull(partExpr, "partition expression cannot be null");
     this.partExpr = partExpr;
     this.columnRefs = PredicateUtils.extractColumnRefFromExpression(partExpr);
@@ -91,11 +91,11 @@ public class PartAndFilterExprRewriter extends DefaultVisitor<Expression, Void> 
     return new ComparisonBinaryExpression(node.getComparisonType(), left, right);
   }
 
-  Expression rewrite(Expression target) {
+  public Expression rewrite(Expression target) {
     return target.accept(this, null);
   }
 
-  boolean isUnsupportedPartFnFound() {
+  public boolean isUnsupportedPartFnFound() {
     return unsupportedPartFnFound;
   }
 }

--- a/tikv-client/src/main/java/com/pingcap/tikv/expression/visitor/PrunedPartitionBuilder.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/expression/visitor/PrunedPartitionBuilder.java
@@ -17,19 +17,12 @@ package com.pingcap.tikv.expression.visitor;
 
 import com.google.common.collect.RangeSet;
 import com.google.common.collect.TreeRangeSet;
-import com.pingcap.tikv.exception.UnsupportedPartitionExprException;
-import com.pingcap.tikv.exception.UnsupportedSyntaxException;
-import com.pingcap.tikv.expression.*;
+import com.pingcap.tikv.expression.ColumnRef;
+import com.pingcap.tikv.expression.ComparisonBinaryExpression;
 import com.pingcap.tikv.expression.ComparisonBinaryExpression.NormalizedPredicate;
-import com.pingcap.tikv.meta.TiPartitionDef;
-import com.pingcap.tikv.meta.TiPartitionInfo;
-import com.pingcap.tikv.meta.TiPartitionInfo.PartitionType;
-import com.pingcap.tikv.meta.TiTableInfo;
-import com.pingcap.tikv.parser.TiParser;
-import com.pingcap.tikv.predicates.PredicateUtils;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
+import com.pingcap.tikv.expression.Constant;
+import com.pingcap.tikv.expression.Expression;
+import com.pingcap.tikv.key.TypedKey;
 import java.util.Set;
 
 /**
@@ -38,61 +31,23 @@ import java.util.Set;
  * only range partition pruning is supported(range column on multiple columns is not supported at
  * TiDB side, so we can't optimize this yet).
  */
-public class PrunedPartitionBuilder extends RangeSetBuilder<Long> {
+@SuppressWarnings("UnstableApiUsage")
+public class PrunedPartitionBuilder extends RangeSetBuilder<TypedKey> {
+  private final Set<ColumnRef> partExprColRefs;
 
-  private static Expression partExpr;
-  private static Set<ColumnRef> partExprColRefs;
-  private static List<Expression> partExprs;
+  public PrunedPartitionBuilder(Set<ColumnRef> partExprColRefs) {
+    this.partExprColRefs = partExprColRefs;
+  }
 
-  protected RangeSet<Long> process(Expression node, Void context) {
+  protected RangeSet<TypedKey> process(Expression node, Void context) {
     throwOnError(node);
     return null;
   }
 
-  /**
-   * return false if table cannot be pruning or partition table is not enabled. Return true if
-   * partition pruning can be applied.
-   *
-   * @param tblInfo is table info which is used for creating columnRef.
-   * @param filter is a where condition. It must be a cnf and does not contain not or isnull.
-   * @return true if partition pruning can apply on filter.
-   */
-  private static boolean canBePruned(TiTableInfo tblInfo, Expression filter) {
-    if (!tblInfo.isPartitionEnabled()) {
-      return false;
-    }
-
-    if (TiPartitionInfo.toPartType((int) tblInfo.getPartitionInfo().getType())
-        != PartitionType.RangePartition) {
-      return false;
-    }
-
-    // if query is select * from t, then filter will be null.
-    if (filter == null) return false;
-
-    try {
-      partExprs = generateRangePartExprs(tblInfo);
-    } catch (UnsupportedSyntaxException | UnsupportedPartitionExprException e) {
-      return false;
-    }
-
-    return true;
-  }
-
-  private static List<Expression> extractLogicalOrComparisonExpr(List<Expression> filters) {
-    List<Expression> filteredFilters = new ArrayList<>();
-    for (Expression expr : filters) {
-      if (expr instanceof LogicalBinaryExpression || expr instanceof ComparisonBinaryExpression) {
-        filteredFilters.add(expr);
-      }
-    }
-    return filteredFilters;
-  }
-
   @Override
   // This deals with partition definition's 'lessthan' is "maxvalue".
-  protected RangeSet<Long> visit(Constant node, Void context) {
-    RangeSet<Long> ranges = TreeRangeSet.create();
+  protected RangeSet<TypedKey> visit(Constant node, Void context) {
+    RangeSet<TypedKey> ranges = TreeRangeSet.create();
     if (node.getValue() instanceof Number) {
       long val = ((Number) node.getValue()).longValue();
       if (val == 1) {
@@ -104,161 +59,16 @@ public class PrunedPartitionBuilder extends RangeSetBuilder<Long> {
   }
 
   @Override
-  protected RangeSet<Long> visit(ComparisonBinaryExpression node, Void context) {
+  protected RangeSet<TypedKey> visit(ComparisonBinaryExpression node, Void context) {
     NormalizedPredicate predicate = node.normalize();
     // when meet a comparison binary expression cannot be normalized
     // which indicates it cannot be pruned such as a > b + 1
     // TODO: make this code better or normalization better.
-    if (predicate == null) return TreeRangeSet.<Long>create().complement();
+    if (predicate == null) return TreeRangeSet.<TypedKey>create().complement();
     if (!partExprColRefs.contains(predicate.getColumnRef()))
-      return TreeRangeSet.<Long>create().complement();
-    Long literal;
-    if (predicate.getValue().getValue() instanceof Number) {
-      literal = ((Number) predicate.getValue().getValue()).longValue();
-      return visitComparisonBinaryExpr(node, context, literal, false);
-    }
-    return TreeRangeSet.create();
-  }
-
-  public List<TiPartitionDef> prune(TiTableInfo tableInfo, List<Expression> filters) {
-    switch (TiPartitionInfo.toPartType((int) tableInfo.getPartitionInfo().getType())) {
-      case RangePartition:
-        return pruneRangePart(tableInfo, filters);
-      case ListPartition:
-        return pruneListPart(tableInfo, filters);
-      case HashPartition:
-        return pruneHashPart(tableInfo, filters);
-    }
-
-    throw new UnsupportedOperationException("cannot prune under invalid partition table");
-  }
-
-  // pruneListPart will prune list partition that where conditions never access.
-  private List<TiPartitionDef> pruneListPart(TiTableInfo tableInfo, List<Expression> filters) {
-    return tableInfo.getPartitionInfo().getDefs();
-  }
-
-  // pruneHashPart will prune hash partition that where conditions never access.
-  private List<TiPartitionDef> pruneHashPart(TiTableInfo tableInfo, List<Expression> filters) {
-    return tableInfo.getPartitionInfo().getDefs();
-  }
-
-  private List<TiPartitionDef> pruneRangeNormalPart(TiTableInfo tableInfo, Expression cnfExpr) {
-    TiPartitionInfo partInfo = tableInfo.getPartitionInfo();
-    Objects.requireNonNull(cnfExpr, "cnf expression cannot be null at pruning stage");
-
-    // we need rewrite filter expression. This step is designed to  deal with
-    // y < '1885-10-10' where y is a date type. Rewrite will apply partition expression
-    // on the constant part. After rewriting, it becomes y < 1995;
-    PartAndFilterExprRewriter expressionRewriter = new PartAndFilterExprRewriter(partExpr);
-    cnfExpr = expressionRewriter.rewrite(cnfExpr);
-    // if we find an unsupported partition function, we downgrade to scan all partitions.
-    if (expressionRewriter.isUnsupportedPartFnFound()) {
-      return partInfo.getDefs();
-    }
-
-    RangeSet<Long> filterRange = buildRange(cnfExpr);
-
-    List<TiPartitionDef> pDefs = new ArrayList<>();
-    for (int i = 0; i < partExprs.size(); i++) {
-      Expression partExpr = partExprs.get(i);
-      // when we build range, we still need rewrite partition expression.
-      // If we have a year(purchased) < 1995 which cannot be normalized, we need
-      // to rewrite it into purchased < 1995 to let RangeSetBuilder be happy.
-      RangeSet<Long> partRange = buildRange(expressionRewriter.rewrite(partExpr));
-      partRange.removeAll(filterRange.complement());
-      if (!partRange.isEmpty()) {
-        // part range is empty indicates this partition can be pruned.
-        pDefs.add(partInfo.getDefs().get(i));
-      }
-    }
-    return pDefs;
-  }
-
-  /**
-   * When table is a partition table and its type is range. We use this method to do the pruning.
-   * Range partition has two types: 1. range 2. range column. If it is the first case,
-   * pruneRangeNormalPart will be called. Otherwise pruneRangeColPart will be called. For now, we
-   * simply skip range column partition case. TODO: support partition pruning on range column later.
-   *
-   * @param tableInfo is used when we resolve column. See {@code ColumnRef}
-   * @param filters is where condition belong to a select statement.
-   * @return a pruned partition for scanning.
-   */
-  // pruneRangePart will prune range partition that where conditions never access.
-  private List<TiPartitionDef> pruneRangePart(TiTableInfo tableInfo, List<Expression> filters) {
-    filters = extractLogicalOrComparisonExpr(filters);
-    Expression cnfExpr = PredicateUtils.mergeCNFExpressions(filters);
-    if (!canBePruned(tableInfo, cnfExpr)) {
-      return tableInfo.getPartitionInfo().getDefs();
-    }
-
-    List<String> columnInfos = tableInfo.getPartitionInfo().getColumns();
-    boolean isRangeCol = columnInfos != null & columnInfos.size() > 0;
-    if (isRangeCol) {
-      // TODO: range column partition pruning will be support later.
-      // pruning can also be performed for WHERE conditions that involve comparisons of the
-      // preceding types on multiple columns for tables that use RANGE COLUMNS or LIST COLUMNS
-      // partitioning.
-      // This type of optimization can be applied whenever the partitioning expression consists
-      // of an equality or a range which can be reduced to a set of equalities, or when
-      // the partitioning expression represents an increasing or decreasing relationship.
-      // Pruning can also be applied for tables partitioned on a DATE or DATETIME column
-      // when the partitioning expression uses the YEAR() or TO_DAYS() function.
-      // Pruning can also be applied for such tables when the partitioning expression uses
-      // the TO_SECONDS() function
-      return tableInfo.getPartitionInfo().getDefs();
-    }
-
-    return pruneRangeNormalPart(tableInfo, cnfExpr);
-  }
-
-  // say we have a partitioned table with the following partition definitions with year(y) as
-  // partition expression:
-  // 1. p0 less than 1995
-  // 2. p1 less than 1996
-  // 3. p2 less than maxvalue
-  // Above infos, after this function, will become the following:
-  // 1. p0: year(y) < 1995
-  // 2. p1: 1995 <= year(y) and year(y) < 1996
-  // 3. p2: 1996 <= year(y) and true
-  // true will become {@Code Constant} 1.
-  private static List<Expression> generateRangePartExprs(TiTableInfo tableInfo) {
-    TiPartitionInfo partInfo = tableInfo.getPartitionInfo();
-    List<Expression> partExprs = new ArrayList<>();
-    TiParser parser = new TiParser(tableInfo);
-    // check year expression
-    // rewrite filter condition
-    // purchased > '1995-10-10'
-    // year(purchased) > year('1995-10-10')
-    // purchased > 1995
-    String partExprStr = tableInfo.getPartitionInfo().getExpr();
-    partExpr = parser.parseExpression(partExprStr);
-    // when partExpr is null, it indicates partition expression
-    // is not supported for now
-    if (partExpr == null) {
-      throw new UnsupportedPartitionExprException(
-          String.format("%s is not supported", partExprStr));
-    }
-    partExprColRefs = PredicateUtils.extractColumnRefFromExpression(partExpr);
-    // when it is not range column case, only first element stores useful info.
-    for (int i = 0; i < partInfo.getDefs().size(); i++) {
-      TiPartitionDef pDef = partInfo.getDefs().get(i);
-      String current = pDef.getLessThan().get(0);
-      String leftHand;
-      if (current.equals("MAXVALUE")) {
-        leftHand = "true";
-      } else {
-        leftHand = String.format("%s < %s", partExprStr, current);
-      }
-      if (i == 0) {
-        partExprs.add(parser.parseExpression(leftHand));
-      } else {
-        String previous = partInfo.getDefs().get(i - 1).getLessThan().get(0);
-        String and = String.format("%s and %s", partExprStr + ">=" + previous, leftHand);
-        partExprs.add(parser.parseExpression(and));
-      }
-    }
-    return partExprs;
+      return TreeRangeSet.<TypedKey>create().complement();
+    TypedKey literal;
+    literal = predicate.getTypedLiteral(-1);
+    return visitComparisonBinaryExpr(node, context, literal, false);
   }
 }

--- a/tikv-client/src/main/java/com/pingcap/tikv/expression/visitor/PrunedPartitionBuilder.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/expression/visitor/PrunedPartitionBuilder.java
@@ -63,7 +63,6 @@ public class PrunedPartitionBuilder extends RangeSetBuilder<TypedKey> {
     NormalizedPredicate predicate = node.normalize();
     // when meet a comparison binary expression cannot be normalized
     // which indicates it cannot be pruned such as a > b + 1
-    // TODO: make this code better or normalization better.
     if (predicate == null) return TreeRangeSet.<TypedKey>create().complement();
     if (!partExprColRefs.contains(predicate.getColumnRef()))
       return TreeRangeSet.<TypedKey>create().complement();

--- a/tikv-client/src/main/java/com/pingcap/tikv/meta/TiPartitionInfo.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/meta/TiPartitionInfo.java
@@ -26,8 +26,8 @@ import java.util.List;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class TiPartitionInfo implements Serializable {
 
-  public long getType() {
-    return type;
+  public PartitionType getType() {
+    return toPartType((int) type);
   }
 
   public enum PartitionType {
@@ -43,7 +43,7 @@ public class TiPartitionInfo implements Serializable {
   private final boolean enable;
   private final List<TiPartitionDef> defs;
 
-  public static PartitionType toPartType(int tp) {
+  private PartitionType toPartType(int tp) {
     switch (tp) {
       case 1:
         return PartitionType.RangePartition;

--- a/tikv-client/src/main/java/com/pingcap/tikv/parser/AstBuilder.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/parser/AstBuilder.java
@@ -120,7 +120,7 @@ public class AstBuilder extends MySqlParserBaseVisitor<Expression> {
       for (TerminalNode str : ctx.STRING_LITERAL()) {
         sb.append(str.getSymbol().getText());
       }
-      return Constant.create(sb.toString());
+      return Constant.create(sb.toString().replace("\"", ""));
     }
     throw new UnsupportedSyntaxException(ctx.toString() + " is not supported yet");
   }

--- a/tikv-client/src/main/java/com/pingcap/tikv/predicates/TiKVScanAnalyzer.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/predicates/TiKVScanAnalyzer.java
@@ -26,8 +26,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Range;
 import com.pingcap.tikv.exception.TiClientInternalException;
 import com.pingcap.tikv.expression.Expression;
+import com.pingcap.tikv.expression.PartitionPruner;
 import com.pingcap.tikv.expression.visitor.IndexMatcher;
-import com.pingcap.tikv.expression.visitor.PrunedPartitionBuilder;
 import com.pingcap.tikv.key.IndexScanKeyRangeBuilder;
 import com.pingcap.tikv.key.Key;
 import com.pingcap.tikv.key.RowKey;
@@ -278,8 +278,8 @@ public class TiKVScanAnalyzer {
     List<TiPartitionDef> prunedParts = null;
     // apply partition pruning here.
     if (table.getPartitionInfo() != null) {
-      PrunedPartitionBuilder prunedPartBuilder = new PrunedPartitionBuilder();
-      prunedParts = prunedPartBuilder.prune(table, conditions);
+      PartitionPruner partitionPruner = new PartitionPruner(table);
+      prunedParts = partitionPruner.prune(conditions);
     }
 
     // table name and columns

--- a/tikv-client/src/main/java/com/pingcap/tikv/predicates/TiKVScanAnalyzer.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/predicates/TiKVScanAnalyzer.java
@@ -278,8 +278,7 @@ public class TiKVScanAnalyzer {
     List<TiPartitionDef> prunedParts = null;
     // apply partition pruning here.
     if (table.getPartitionInfo() != null) {
-      PartitionPruner partitionPruner = new PartitionPruner(table);
-      prunedParts = partitionPruner.prune(conditions);
+      prunedParts = PartitionPruner.prune(table, conditions);
     }
 
     // table name and columns

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/Converter.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/Converter.java
@@ -272,6 +272,7 @@ public class Converter {
         throw new TypeException(String.format("Error parsing string %s to date", val), e);
       }
     } else if (val instanceof Integer) {
+      // when the val is a Integer, it is only have year part of a Date.
       return new Date((Integer) val, 0, 0);
     } else if (val instanceof Long) {
       return new Date((long) val);

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/Converter.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/Converter.java
@@ -271,6 +271,8 @@ public class Converter {
       } catch (Exception e) {
         throw new TypeException(String.format("Error parsing string %s to date", val), e);
       }
+    } else if (val instanceof Integer) {
+      return new Date((Integer) val, 0, 0);
     } else if (val instanceof Long) {
       return new Date((long) val);
     } else if (val instanceof Timestamp) {

--- a/tikv-client/src/test/java/com/pingcap/tikv/parser/TiParserTest.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/parser/TiParserTest.java
@@ -126,7 +126,7 @@ public class TiParserTest {
 
     sql = "\"abc\"";
     stringLiteral = parser.parseExpression(sql);
-    Assert.assertEquals(stringLiteral, Constant.create("\"abc\""));
+    Assert.assertEquals(stringLiteral, Constant.create("abc"));
   }
 
   private TiTableInfo createTaleInfoWithParts() {


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
This PR wants to support partition pruning on range column. 

### What is changed and how it works?
When a partition is range column, `lessThan` of `PartitionDefitions` will be at least one. The `expr` of `PartitionInfo` is an empty string. We cannot generate partition expression by only looking at `expr` like we said early: it is empty string. We need iterate all `columns` and `lessThan` to generate partition expression. 

Range Columns partition cannot accept expression but column's name. Additionally, the type of column is limited to int, or datetime related types. In order to build range, I change the logic of building range from building a long range to `typedKey` range. 

### Check List <!--REMOVE the items that are not applicable-->
Tests <!-- At least one of them must be included. -->
 - Integration test

