### PR TITLE
Fix time zone tests with Spark+JDBC

### DIFF
--- a/core/src/test/scala/com/pingcap/tispark/datasource/BaseDataSourceTest.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/BaseDataSourceTest.scala
@@ -28,7 +28,6 @@ class BaseDataSourceTest(val table: String,
   override def beforeAll(): Unit = {
     enableTidbConfigPropertiesInjectedToSpark = _enableTidbConfigPropertiesInjectedToSpark
     super.beforeAllWithoutLoadData()
-    initializeTimeZone()
   }
 
   protected def jdbcUpdate(query: String): Unit =

--- a/core/src/test/scala/org/apache/spark/sql/BaseTiSparkTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/BaseTiSparkTest.scala
@@ -109,7 +109,7 @@ class BaseTiSparkTest extends QueryTest with SharedSQLContext {
           .exists(_.isInstanceOf[TiSessionCatalog])) {
       tidbConn.setCatalog(dbName)
       logger.info(s"set catalog to $dbName!")
-      initializeTimeZone()
+      initializeStatement()
       spark.sql(s"use `$dbPrefix$dbName`")
     } else {
       // should be an existing database in hive/meta_store

--- a/core/src/test/scala/org/apache/spark/sql/test/SharedSQLContext.scala
+++ b/core/src/test/scala/org/apache/spark/sql/test/SharedSQLContext.scala
@@ -219,10 +219,8 @@ trait SharedSQLContext extends SparkFunSuite with Eventually with Logging with S
     logger.info("Analyzing table finished.")
   }
 
-  protected def initializeTimeZone(): Unit = {
+  protected def initializeStatement(): Unit = {
     _statement = _tidbConnection.createStatement()
-    // Set default time zone to GMT-7
-    _statement.execute(s"SET time_zone = '$timeZoneOffset'")
   }
 
   protected def loadSQLFile(directory: String, file: String): Unit = {
@@ -235,7 +233,7 @@ trait SharedSQLContext extends SparkFunSuite with Eventually with Logging with S
       val queryString = source.mkString
       source.close()
       _tidbConnection.setCatalog("mysql")
-      initializeTimeZone()
+      initializeStatement()
       _statement.execute(queryString)
       logger.info(s"Load $fullFileName successfully.")
     } catch {
@@ -298,7 +296,7 @@ trait SharedSQLContext extends SparkFunSuite with Eventually with Logging with S
       s"jdbc:mysql://address=(protocol=tcp)(host=$tidbAddr)(port=$tidbPort)/?user=$tidbUser&password=$tidbPassword" +
         s"&useUnicode=true&characterEncoding=UTF-8&zeroDateTimeBehavior=round&useSSL=false" +
         s"&rewriteBatchedStatements=true&autoReconnect=true&failOverReadOnly=false&maxReconnects=10" +
-        s"&allowMultiQueries=true&serverTimezone=${timeZone.getDisplayName}"
+        s"&allowMultiQueries=true&serverTimezone=${timeZone.getDisplayName}&sessionVariables=time_zone='$timeZoneOffset'"
 
     _tidbConnection = TiDBUtils.createConnectionFactory(jdbcUrl)()
     _statement = _tidbConnection.createStatement()


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix incorrect timezone of Spark+JDBC tests, Close #1346. Previous result of JDBC tests are incorrect because it ignored the server timezone information we provided(which exact behavior needs to be reaffirmed). The issue is fixed by adding `sessionVariables=timezone=xxxx` in JDBC url string to manually set timezone information in session level.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test 

Related changes

 - Need to cherry-pick to the release branch
