### PR TITLE
Fix DateTime test failure on CI

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/catalyst/expressions/ExprUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/catalyst/expressions/ExprUtils.scala
@@ -86,28 +86,28 @@ object ExprUtils {
             .newCall(AggregateFunction.FunctionType.Count, tiArg, fromSparkType(f.dataType))
         )
 
-      case f @ Min(BasicExpression(arg)) =>
+      case _ @Min(BasicExpression(arg)) =>
         MetaResolver.resolve(arg, meta)
         dagRequest
           .addAggregate(
             AggregateFunction
-              .newCall(AggregateFunction.FunctionType.Min, arg, fromSparkType(f.dataType))
+              .newCall(AggregateFunction.FunctionType.Min, arg)
           )
 
-      case f @ Max(BasicExpression(arg)) =>
+      case _ @Max(BasicExpression(arg)) =>
         MetaResolver.resolve(arg, meta)
         dagRequest
           .addAggregate(
             AggregateFunction
-              .newCall(AggregateFunction.FunctionType.Max, arg, fromSparkType(f.dataType))
+              .newCall(AggregateFunction.FunctionType.Max, arg)
           )
 
-      case f @ First(BasicExpression(arg), _) =>
+      case _ @First(BasicExpression(arg), _) =>
         MetaResolver.resolve(arg, meta)
         dagRequest
           .addAggregate(
             AggregateFunction
-              .newCall(AggregateFunction.FunctionType.First, arg, fromSparkType(f.dataType))
+              .newCall(AggregateFunction.FunctionType.First, arg)
           )
 
       case _ =>

--- a/tikv-client/src/main/java/com/pingcap/tikv/expression/AggregateFunction.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/expression/AggregateFunction.java
@@ -35,6 +35,10 @@ public class AggregateFunction extends Expression {
   private final FunctionType type;
   private final Expression argument;
 
+  public static AggregateFunction newCall(FunctionType type, Expression argument) {
+    return newCall(type, argument, argument.dataType);
+  }
+
   public static AggregateFunction newCall(
       FunctionType type, Expression argument, DataType dataType) {
     return new AggregateFunction(type, argument, dataType);


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix #1357 

Use original Data Type of expression rather than converted Spark Data Type when using `max()`, `min()`, `first()`, because Spark does not have DateTime type.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
