### PR TITLE
[TISPARK-488] Fix TiFlash region cache 

### DIFF
--- a/tikv-client/src/main/java/com/pingcap/tikv/region/RegionManager.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/region/RegionManager.java
@@ -214,6 +214,10 @@ public class RegionManager {
           }
         }
       }
+      if (store == null) {
+        // clear the region cache so we may get the learner peer next time
+        cache.invalidateRegion(region.getId());
+      }
     }
 
     if (store == null) {


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix the issue that when first read request is performed on TiFlash, its region cache might not be refreshed.