### PR TITLE
eanble key ranges for flash dag request

### DIFF
--- a/tikv-client/src/main/java/com/pingcap/tikv/predicates/TiKVScanAnalyzer.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/predicates/TiKVScanAnalyzer.java
@@ -219,13 +219,12 @@ public class TiKVScanAnalyzer {
       TableStatistics tableStatistics,
       TiTimestamp ts,
       TiDAGRequest dagRequest) {
-    TiKVScanPlan minPlan = buildTableScan(conditions, table, tableStatistics, isUseTiFlash);
+    TiKVScanPlan minPlan = buildTableScan(conditions, table, tableStatistics);
     if (allowIndexScan && !isUseTiFlash) {
       minPlan.getFilters().forEach(dagRequest::addDowngradeFilter);
       double minCost = minPlan.getCost();
       for (TiIndexInfo index : table.getIndices()) {
-        TiKVScanPlan plan =
-            buildIndexScan(columnList, conditions, index, table, tableStatistics, isUseTiFlash);
+        TiKVScanPlan plan = buildIndexScan(columnList, conditions, index, table, tableStatistics);
         if (plan.getCost() < minCost) {
           minPlan = plan;
           minCost = plan.getCost();
@@ -252,13 +251,9 @@ public class TiKVScanAnalyzer {
   }
 
   private TiKVScanPlan buildTableScan(
-      List<Expression> conditions,
-      TiTableInfo table,
-      TableStatistics tableStatistics,
-      boolean useTiFlash) {
+      List<Expression> conditions, TiTableInfo table, TableStatistics tableStatistics) {
     TiIndexInfo pkIndex = TiIndexInfo.generateFakePrimaryKeyIndex(table);
-    return buildIndexScan(
-        table.getColumns(), conditions, pkIndex, table, tableStatistics, useTiFlash);
+    return buildIndexScan(table.getColumns(), conditions, pkIndex, table, tableStatistics);
   }
 
   TiKVScanPlan buildIndexScan(
@@ -266,13 +261,12 @@ public class TiKVScanAnalyzer {
       List<Expression> conditions,
       TiIndexInfo index,
       TiTableInfo table,
-      TableStatistics tableStatistics,
-      boolean useTiFlash) {
+      TableStatistics tableStatistics) {
     requireNonNull(table, "Table cannot be null to encoding keyRange");
     requireNonNull(conditions, "conditions cannot be null to encoding keyRange");
 
     TiKVScanPlan.Builder planBuilder = TiKVScanPlan.Builder.newBuilder();
-    ScanSpec result = extractConditions(conditions, table, index, useTiFlash);
+    ScanSpec result = extractConditions(conditions, table, index);
 
     double cost = SelectivityCalculator.calcPseudoSelectivity(result);
     planBuilder.setCost(cost);
@@ -469,11 +463,6 @@ public class TiKVScanAnalyzer {
   @VisibleForTesting
   public static ScanSpec extractConditions(
       List<Expression> conditions, TiTableInfo table, TiIndexInfo index) {
-    return extractConditions(conditions, table, index, false);
-  }
-
-  public static ScanSpec extractConditions(
-      List<Expression> conditions, TiTableInfo table, TiIndexInfo index, boolean useTiFlash) {
     // 0. Different than TiDB implementation, here logic has been unified for TableScan and
     // IndexScan by
     // adding fake index on clustered table's pk
@@ -486,8 +475,7 @@ public class TiKVScanAnalyzer {
     // Equal conditions needs to be process first according to index sequence
     // When index is null, no access condition can be applied
     ScanSpec.Builder specBuilder = new ScanSpec.Builder(table, index);
-    // todo use the conditions to prune region
-    if (!useTiFlash && index != null) {
+    if (index != null) {
       Set<Expression> visited = new HashSet<>();
       IndexMatchingLoop:
       for (int i = 0; i < index.getIndexColumns().size(); i++) {

--- a/tikv-client/src/test/java/com/pingcap/tikv/predicates/TiKVScanAnalyzerTest.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/predicates/TiKVScanAnalyzerTest.java
@@ -271,8 +271,7 @@ public class TiKVScanAnalyzerTest {
     TiIndexInfo index = TiIndexInfo.generateFakePrimaryKeyIndex(table);
     TiKVScanAnalyzer scanBuilder = new TiKVScanAnalyzer();
     TiKVScanAnalyzer.TiKVScanPlan scanPlan =
-        scanBuilder.buildIndexScan(
-            ImmutableList.of(), ImmutableList.of(), index, table, null, false);
+        scanBuilder.buildIndexScan(ImmutableList.of(), ImmutableList.of(), index, table, null);
 
     ByteString startKey = RowKey.toRowKey(table.getId(), Long.MIN_VALUE).toByteString();
     ByteString endKey = RowKey.createBeyondMax(table.getId()).toByteString();


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
For TiFlash dag request, we convert key ranges to filter as TiFlash only support full range scan, now TiFlash already support key ranges in dag request(https://github.com/pingcap/tics/pull/417), so this pr revert the changes introduced by https://github.com/pingcap/tispark/pull/1377

### What is changed and how it works?
this pr revert https://github.com/pingcap/tispark/pull/1377

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)