### PR TITLE
fix chblock decode bug

### DIFF
--- a/tikv-client/src/main/java/com/pingcap/tikv/columnar/TiBlockColumnVector.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/columnar/TiBlockColumnVector.java
@@ -194,14 +194,14 @@ public class TiBlockColumnVector extends TiColumnVector {
     if (type instanceof AbstractDateTimeType) {
       return getDateTime(rowId);
     }
-    if (fixedLength == 0) {
+    if (fixedLength == 1) {
       return getByte(rowId);
-    } else if (fixedLength == 1) {
-      return getShort(rowId);
     } else if (fixedLength == 2) {
+      return getShort(rowId);
+    } else if (fixedLength == 4) {
       return getInt(rowId);
-    } else if (fixedLength == 3) {
-      return MemoryUtil.getLong(dataAddr + (rowId << fixedLength));
+    } else if (fixedLength == 8) {
+      return MemoryUtil.getLong(dataAddr + (rowId * fixedLength));
     }
     throw new UnsupportedOperationException(
         String.format("getting long with fixed length %d", fixedLength));
@@ -213,7 +213,7 @@ public class TiBlockColumnVector extends TiColumnVector {
    */
   @Override
   public float getFloat(int rowId) {
-    return MemoryUtil.getFloat(dataAddr + (rowId << fixedLength));
+    return MemoryUtil.getFloat(dataAddr + (rowId * fixedLength));
   }
 
   /**
@@ -222,7 +222,7 @@ public class TiBlockColumnVector extends TiColumnVector {
    */
   @Override
   public double getDouble(int rowId) {
-    return MemoryUtil.getDouble(dataAddr + (rowId << fixedLength));
+    return MemoryUtil.getDouble(dataAddr + (rowId * fixedLength));
   }
 
   /**

--- a/tikv-client/src/main/java/com/pingcap/tikv/columnar/datatypes/CHTypeDate.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/columnar/datatypes/CHTypeDate.java
@@ -5,7 +5,7 @@ import com.pingcap.tikv.types.DateType;
 
 public class CHTypeDate extends CHType {
   public CHTypeDate() {
-    this.length = 8 << 1;
+    this.length = 2;
   }
 
   @Override

--- a/tikv-client/src/main/java/com/pingcap/tikv/columnar/datatypes/CHTypeDateTime.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/columnar/datatypes/CHTypeDateTime.java
@@ -5,7 +5,7 @@ import com.pingcap.tikv.types.DateTimeType;
 
 public class CHTypeDateTime extends CHType {
   public CHTypeDateTime() {
-    this.length = 8 << 2;
+    this.length = 4;
   }
 
   @Override

--- a/tikv-client/src/main/java/com/pingcap/tikv/columnar/datatypes/CHTypeMyDate.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/columnar/datatypes/CHTypeMyDate.java
@@ -5,7 +5,7 @@ import com.pingcap.tikv.types.DateType;
 
 public class CHTypeMyDate extends CHType {
   public CHTypeMyDate() {
-    this.length = 8 << 3;
+    this.length = 8;
   }
 
   @Override

--- a/tikv-client/src/main/java/com/pingcap/tikv/columnar/datatypes/CHTypeMyDateTime.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/columnar/datatypes/CHTypeMyDateTime.java
@@ -5,7 +5,7 @@ import com.pingcap.tikv.types.DateTimeType;
 
 public class CHTypeMyDateTime extends CHType {
   public CHTypeMyDateTime() {
-    this.length = 8 << 3;
+    this.length = 8;
   }
 
   @Override

--- a/tikv-client/src/main/java/com/pingcap/tikv/columnar/datatypes/CHTypeNumber.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/columnar/datatypes/CHTypeNumber.java
@@ -24,7 +24,7 @@ public abstract class CHTypeNumber extends CHType {
 
   public static class CHTypeUInt16 extends CHTypeNumber {
     public CHTypeUInt16() {
-      this.length = 8 << 1;
+      this.length = 2;
     }
 
     @Override
@@ -35,7 +35,7 @@ public abstract class CHTypeNumber extends CHType {
 
   public static class CHTypeUInt32 extends CHTypeNumber {
     public CHTypeUInt32() {
-      this.length = 8 << 2;
+      this.length = 4;
     }
 
     @Override
@@ -46,7 +46,7 @@ public abstract class CHTypeNumber extends CHType {
 
   public static class CHTypeUInt64 extends CHTypeNumber {
     public CHTypeUInt64() {
-      this.length = 8 << 3;
+      this.length = 8;
     }
 
     @Override
@@ -74,7 +74,7 @@ public abstract class CHTypeNumber extends CHType {
   public static class CHTypeInt16 extends CHTypeNumber {
 
     public CHTypeInt16() {
-      this.length = 8 << 1;
+      this.length = 2;
     }
 
     @Override
@@ -85,7 +85,7 @@ public abstract class CHTypeNumber extends CHType {
 
   public static class CHTypeInt32 extends CHTypeNumber {
     public CHTypeInt32() {
-      this.length = 8 << 2;
+      this.length = 4;
     }
 
     @Override
@@ -96,7 +96,7 @@ public abstract class CHTypeNumber extends CHType {
 
   public static class CHTypeInt64 extends CHTypeNumber {
     public CHTypeInt64() {
-      this.length = 8 << 3;
+      this.length = 8;
     }
 
     @Override
@@ -107,7 +107,7 @@ public abstract class CHTypeNumber extends CHType {
 
   public static class CHTypeFloat32 extends CHTypeNumber {
     public CHTypeFloat32() {
-      this.length = 8 << 2;
+      this.length = 4;
     }
 
     @Override
@@ -118,7 +118,7 @@ public abstract class CHTypeNumber extends CHType {
 
   public static class CHTypeFloat64 extends CHTypeNumber {
     public CHTypeFloat64() {
-      this.length = 8 << 3;
+      this.length = 8;
     }
 
     @Override


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
fix chblock decode bug

### What is changed and how it works?
`length` in `CHType` is now defined as the data length in byte for the given CHType, fix all the decoding logical related to the data length 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
