### PR TITLE
fix chblock decode bug for type int8/uint8

### DIFF
--- a/tikv-client/src/main/java/com/pingcap/tikv/columnar/datatypes/CHTypeNumber.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/columnar/datatypes/CHTypeNumber.java
@@ -13,7 +13,7 @@ public abstract class CHTypeNumber extends CHType {
 
   public static class CHTypeUInt8 extends CHTypeNumber {
     public CHTypeUInt8() {
-      this.length = 8;
+      this.length = 1;
     }
 
     @Override
@@ -62,7 +62,7 @@ public abstract class CHTypeNumber extends CHType {
 
   public static class CHTypeInt8 extends CHTypeNumber {
     public CHTypeInt8() {
-      this.length = 8;
+      this.length = 1;
     }
 
     @Override


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
fix chblock decode for int8/uint8 datatype

### What is changed and how it works?
currently, in chblock decoder, the length of int8/uint8 is set to 8, which is wrong,  and this pr set the length of int8/uint8 to 1

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)