### PR TITLE
fix partition pruning

### DIFF
--- a/tikv-client/src/main/java/com/pingcap/tikv/expression/visitor/PrunedPartitionBuilder.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/expression/visitor/PrunedPartitionBuilder.java
@@ -198,7 +198,7 @@ public class PrunedPartitionBuilder extends RangeSetBuilder<Long> {
     }
 
     List<String> columnInfos = tableInfo.getPartitionInfo().getColumns();
-    boolean isRangeCol = columnInfos != null & columnInfos.size() > 0;
+    boolean isRangeCol = columnInfos != null && columnInfos.size() > 0;
     if (isRangeCol) {
       // TODO: range column partition pruning will be support later.
       // pruning can also be performed for WHERE conditions that involve comparisons of the

--- a/tikv-client/src/main/java/com/pingcap/tikv/parser/AstBuilder.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/parser/AstBuilder.java
@@ -3,8 +3,6 @@ package com.pingcap.tikv.parser;
 import static com.pingcap.tikv.types.IntegerType.BOOLEAN;
 
 import com.google.common.primitives.Doubles;
-import com.google.common.primitives.Ints;
-import com.google.common.primitives.Longs;
 import com.pingcap.tikv.exception.UnsupportedSyntaxException;
 import com.pingcap.tikv.expression.ArithmeticBinaryExpression;
 import com.pingcap.tikv.expression.ColumnRef;
@@ -80,12 +78,12 @@ public class AstBuilder extends MySqlParserBaseVisitor<Expression> {
 
   private Expression parseIntOrLongOrDec(String val) {
     try {
-      return Constant.create(Ints.tryParse(val), IntegerType.INT);
+      return Constant.create(Integer.parseInt(val), IntegerType.INT);
     } catch (Exception e) {
       try {
-        return Constant.create(Longs.tryParse(val), IntegerType.BIGINT);
+        return Constant.create(Long.parseLong(val), IntegerType.BIGINT);
       } catch (Exception e2) {
-        return Constant.create(Doubles.tryParse(val), RealType.DOUBLE);
+        return Constant.create(Double.parseDouble(val), RealType.DOUBLE);
       }
     }
   }


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix partition pruning when partition definition contains biginteger.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `tidb-ansible` repository
 - Need to be included in the release note
