### PR TITLE
Replace groupByKey by reduceByKey in shuffleKeysToSameRegion

### DIFF
--- a/core/src/main/scala/com/pingcap/tispark/TiBatchWrite.scala
+++ b/core/src/main/scala/com/pingcap/tispark/TiBatchWrite.scala
@@ -589,6 +589,7 @@ class TiBatchWrite(@transient val df: DataFrame,
 
     rdd
       .map(obj => (obj.encodedKey, obj))
+      // remove duplicate rows if key equals (should not happen, cause already deduplicated)
       .reduceByKey(
         tiRegionPartitioner,
         (a: SimplifiedWrappedEncodedRow, _: SimplifiedWrappedEncodedRow) => a

--- a/core/src/main/scala/com/pingcap/tispark/TiBatchWrite.scala
+++ b/core/src/main/scala/com/pingcap/tispark/TiBatchWrite.scala
@@ -314,8 +314,9 @@ class TiBatchWrite(@transient val df: DataFrame,
       wrappedEncodedRdd
     }
 
-    val simplifiedWrappedEncodedRowRdd = encodedTiRowRDD.map(row =>
-        SimplifiedWrappedEncodedRow(row.handle, row.encodedKey, row.encodedValue))
+    val simplifiedWrappedEncodedRowRdd = encodedTiRowRDD.map(
+      row => SimplifiedWrappedEncodedRow(row.handle, row.encodedKey, row.encodedValue)
+    )
     // shuffle data in same task which belong to same region
     val shuffledRDD = shuffleKeyToSameRegion(simplifiedWrappedEncodedRowRdd).cache()
 
@@ -347,7 +348,6 @@ class TiBatchWrite(@transient val df: DataFrame,
       ConcreteBackOffer.newCustomBackOff(BackOffer.BATCH_PREWRITE_BACKOFF)
     ti2PCClient.prewritePrimaryKey(prewritePrimaryBackoff, primaryKey.bytes, primaryRow)
 
-    df.repartition(10)
     // executors secondary pre-write
     finalWriteRDD.foreachPartition { iterator =>
       val ti2PCClientOnExecutor =
@@ -581,7 +581,9 @@ class TiBatchWrite(@transient val df: DataFrame,
   }
 
   @throws(classOf[NoSuchTableException])
-  private def shuffleKeyToSameRegion(rdd: RDD[SimplifiedWrappedEncodedRow]): RDD[SimplifiedWrappedEncodedRow] = {
+  private def shuffleKeyToSameRegion(
+    rdd: RDD[SimplifiedWrappedEncodedRow]
+  ): RDD[SimplifiedWrappedEncodedRow] = {
     val regions = getRegions
     val tiRegionPartitioner = new TiRegionPartitioner(regions, options.writeConcurrency)
 
@@ -912,12 +914,12 @@ case class WrappedEncodedRow(row: TiRow,
   override def compare(that: WrappedEncodedRow): Int = this.handle.toInt - that.handle.toInt
 }
 
-case class SimplifiedWrappedEncodedRow(
-                             handle: Long,
-                             encodedKey: SerializableKey,
-                             encodedValue: Array[Byte])
-  extends Ordered[SimplifiedWrappedEncodedRow] {
-  override def compare(that: SimplifiedWrappedEncodedRow): Int = this.handle.toInt - that.handle.toInt
+case class SimplifiedWrappedEncodedRow(handle: Long,
+                                       encodedKey: SerializableKey,
+                                       encodedValue: Array[Byte])
+    extends Ordered[SimplifiedWrappedEncodedRow] {
+  override def compare(that: SimplifiedWrappedEncodedRow): Int =
+    this.handle.toInt - that.handle.toInt
 }
 
 class SerializableKey(val bytes: Array[Byte]) extends Serializable {

--- a/core/src/main/scala/com/pingcap/tispark/TiBatchWrite.scala
+++ b/core/src/main/scala/com/pingcap/tispark/TiBatchWrite.scala
@@ -314,8 +314,10 @@ class TiBatchWrite(@transient val df: DataFrame,
       wrappedEncodedRdd
     }
 
+    val simplifiedWrappedEncodedRowRdd = encodedTiRowRDD.map(row =>
+        SimplifiedWrappedEncodedRow(row.handle, row.encodedKey, row.encodedValue))
     // shuffle data in same task which belong to same region
-    val shuffledRDD = shuffleKeyToSameRegion(encodedTiRowRDD).cache()
+    val shuffledRDD = shuffleKeyToSameRegion(simplifiedWrappedEncodedRowRdd).cache()
 
     // take one row as primary key
     val (primaryKey: SerializableKey, primaryRow: Array[Byte]) = {
@@ -345,6 +347,7 @@ class TiBatchWrite(@transient val df: DataFrame,
       ConcreteBackOffer.newCustomBackOff(BackOffer.BATCH_PREWRITE_BACKOFF)
     ti2PCClient.prewritePrimaryKey(prewritePrimaryBackoff, primaryKey.bytes, primaryRow)
 
+    df.repartition(10)
     // executors secondary pre-write
     finalWriteRDD.foreachPartition { iterator =>
       val ti2PCClientOnExecutor =
@@ -578,7 +581,7 @@ class TiBatchWrite(@transient val df: DataFrame,
   }
 
   @throws(classOf[NoSuchTableException])
-  private def shuffleKeyToSameRegion(rdd: RDD[WrappedEncodedRow]): RDD[WrappedEncodedRow] = {
+  private def shuffleKeyToSameRegion(rdd: RDD[SimplifiedWrappedEncodedRow]): RDD[SimplifiedWrappedEncodedRow] = {
     val regions = getRegions
     val tiRegionPartitioner = new TiRegionPartitioner(regions, options.writeConcurrency)
 
@@ -907,6 +910,14 @@ case class WrappedEncodedRow(row: TiRow,
                              remove: Boolean)
     extends Ordered[WrappedEncodedRow] {
   override def compare(that: WrappedEncodedRow): Int = this.handle.toInt - that.handle.toInt
+}
+
+case class SimplifiedWrappedEncodedRow(
+                             handle: Long,
+                             encodedKey: SerializableKey,
+                             encodedValue: Array[Byte])
+  extends Ordered[SimplifiedWrappedEncodedRow] {
+  override def compare(that: SimplifiedWrappedEncodedRow): Int = this.handle.toInt - that.handle.toInt
 }
 
 class SerializableKey(val bytes: Array[Byte]) extends Serializable {

--- a/core/src/main/scala/com/pingcap/tispark/TiBatchWrite.scala
+++ b/core/src/main/scala/com/pingcap/tispark/TiBatchWrite.scala
@@ -589,12 +589,11 @@ class TiBatchWrite(@transient val df: DataFrame,
 
     rdd
       .map(obj => (obj.encodedKey, obj))
-      .groupByKey(tiRegionPartitioner)
-      .map {
-        case (_, iterable) =>
-          // remove duplicate rows if key equals (should not happen, cause already deduplicated)
-          iterable.head
-      }
+      .reduceByKey(
+        tiRegionPartitioner,
+        (a: SimplifiedWrappedEncodedRow, _: SimplifiedWrappedEncodedRow) => a
+      )
+      .map(_._2)
   }
 
   private def getRegions: List[TiRegion] = {


### PR DESCRIPTION
Per this [post](https://stackoverflow.com/questions/27977182/spark-groupby-taking-lot-of-time), `groupByKey` is not recommended. In this PR, we propose to replace `groupByKey` by `reduceByKey`