### PR TITLE
implement hashCode in wrapped encoded row

### DIFF
--- a/core/src/main/scala/com/pingcap/tispark/TiBatchWrite.scala
+++ b/core/src/main/scala/com/pingcap/tispark/TiBatchWrite.scala
@@ -912,6 +912,8 @@ case class WrappedEncodedRow(row: TiRow,
                              remove: Boolean)
     extends Ordered[WrappedEncodedRow] {
   override def compare(that: WrappedEncodedRow): Int = this.handle.toInt - that.handle.toInt
+
+  override def hashCode(): Int = encodedKey.hashCode()
 }
 
 case class SimplifiedWrappedEncodedRow(handle: Long,
@@ -920,6 +922,8 @@ case class SimplifiedWrappedEncodedRow(handle: Long,
     extends Ordered[SimplifiedWrappedEncodedRow] {
   override def compare(that: SimplifiedWrappedEncodedRow): Int =
     this.handle.toInt - that.handle.toInt
+
+  override def hashCode(): Int = encodedKey.hashCode()
 }
 
 class SerializableKey(val bytes: Array[Byte]) extends Serializable {


### PR DESCRIPTION
Inside `WrappedEncodedRow` and `SimplifyWrappedEncodedRow`, `encodedKey` is unique. We can just hashCode `encodedKey`. 