### PR TITLE
fix increasing pd connections bug

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/TiExtensions.scala
+++ b/core/src/main/scala/org/apache/spark/sql/TiExtensions.scala
@@ -1,21 +1,21 @@
 package org.apache.spark.sql
 
+import com.pingcap.tispark.utils.TiUtil
 import org.apache.spark.sql.extensions.{TiDDLRule, TiParser, TiResolutionRule}
 
 import scala.collection.mutable
 
 class TiExtensions extends (SparkSessionExtensions => Unit) {
-  private val tiContextMap = mutable.HashMap.empty[SparkSession, TiContext]
 
-  def getOrCreateTiContext(sparkSession: SparkSession): TiContext = synchronized {
-    tiContextMap.get(sparkSession) match {
-      case Some(tiContext) => tiContext
-      case None            =>
-        // TODO: make Meta and RegionManager independent to sparkSession
-        val tiContext = new TiContext(sparkSession)
-        tiContextMap.put(sparkSession, tiContext)
-        tiContext
+  private var tiContext: TiContext = _
+
+  def getOrCreateTiContext(sparkSession: SparkSession): TiContext = {
+    TiUtil.registerUDFs(sparkSession)
+
+    if (tiContext == null) {
+      tiContext = new TiContext(sparkSession)
     }
+    tiContext
   }
 
   override def apply(e: SparkSessionExtensions): Unit = {


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
Each session will make one TCP connection to `PD`, when using `thrift server`.
The connection to `PD`  will not be closed.

### What is changed and how it works?
Let different sessions share the same TCP connection to `PD`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

