### PR TITLE
add new resolve lock logic: use ttl on primary key

### DIFF
--- a/tikv-client/src/main/java/com/pingcap/tikv/StoreVersion.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/StoreVersion.java
@@ -57,6 +57,10 @@ public class StoreVersion {
     return toIntVersion() > other.toIntVersion();
   }
 
+  public static int compare(String v0, String v1) {
+    return new StoreVersion(v0).toIntVersion() - new StoreVersion(v1).toIntVersion();
+  }
+
   public static boolean minTiKVVersion(String version, PDClient pdClient) {
     StoreVersion storeVersion = new StoreVersion(version);
 

--- a/tikv-client/src/main/java/com/pingcap/tikv/StoreVersion.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/StoreVersion.java
@@ -25,9 +25,10 @@ import org.tikv.kvproto.Metapb;
 
 public class StoreVersion {
 
-  private int v0 = 0;
-  private int v1 = 0;
-  private int v2 = 0;
+  private static int scale = 10000;
+  private int v0 = 9999;
+  private int v1 = 9999;
+  private int v2 = 9999;
 
   private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
@@ -49,7 +50,6 @@ public class StoreVersion {
   }
 
   private int toIntVersion() {
-    int scale = 10000;
     return v0 * scale * scale + v1 * scale + v2;
   }
 

--- a/tikv-client/src/main/java/com/pingcap/tikv/StoreVersion.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/StoreVersion.java
@@ -57,7 +57,7 @@ public class StoreVersion {
     return toIntVersion() > other.toIntVersion();
   }
 
-  public static int compare(String v0, String v1) {
+  public static int compareTo(String v0, String v1) {
     return new StoreVersion(v0).toIntVersion() - new StoreVersion(v1).toIntVersion();
   }
 

--- a/tikv-client/src/main/java/com/pingcap/tikv/TiSession.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/TiSession.java
@@ -76,7 +76,7 @@ public class TiSession implements AutoCloseable {
         if (clientBuilder == null) {
           clientBuilder =
               new RegionStoreClient.RegionStoreClientBuilder(
-                  conf, this.channelFactory, this.getRegionManager());
+                  conf, this.channelFactory, this.getRegionManager(), this.getPDClient());
         }
         res = clientBuilder;
       }

--- a/tikv-client/src/main/java/com/pingcap/tikv/txn/AbstractLockResolverClient.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/txn/AbstractLockResolverClient.java
@@ -1,0 +1,96 @@
+/*
+ *
+ * Copyright 2020 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.pingcap.tikv.txn;
+
+import com.pingcap.tikv.PDClient;
+import com.pingcap.tikv.StoreVersion;
+import com.pingcap.tikv.TiConfiguration;
+import com.pingcap.tikv.exception.KeyException;
+import com.pingcap.tikv.region.RegionManager;
+import com.pingcap.tikv.region.TiRegion;
+import com.pingcap.tikv.util.BackOffer;
+import com.pingcap.tikv.util.ChannelFactory;
+import java.util.List;
+import org.tikv.kvproto.Kvrpcpb;
+import org.tikv.kvproto.Metapb;
+import org.tikv.kvproto.TikvGrpc;
+
+public interface AbstractLockResolverClient {
+  public static final String MIN_RESOLVE_LOCK_V3_VERSION = "3.0.5";
+
+  public String getVersion();
+
+  /**
+   * ResolveLocks tries to resolve Locks. The resolving process is in 3 steps: 1) Use the `lockTTL`
+   * to pick up all expired locks. Only locks that are old enough are considered orphan locks and
+   * will be handled later. If all locks are expired then all locks will be resolved so true will be
+   * returned, otherwise caller should sleep a while before retry. 2) For each lock, query the
+   * primary key to get txn(which left the lock)'s commit status. 3) Send `ResolveLock` cmd to the
+   * lock's region to resolve all locks belong to the same transaction.
+   *
+   * @param bo
+   * @param locks
+   * @return msBeforeTxnExpired: 0 means all locks are resolved
+   */
+  public long resolveLocks(BackOffer bo, List<Lock> locks);
+
+  public static Lock extractLockFromKeyErr(Kvrpcpb.KeyError keyError) {
+    if (keyError.hasLocked()) {
+      return new Lock(keyError.getLocked());
+    }
+
+    if (keyError.hasConflict()) {
+      Kvrpcpb.WriteConflict conflict = keyError.getConflict();
+      throw new KeyException(
+          String.format(
+              "scan meet key conflict on primary key %s at commit ts %s",
+              conflict.getPrimary(), conflict.getConflictTs()));
+    }
+
+    if (!keyError.getRetryable().isEmpty()) {
+      throw new KeyException(
+          String.format("tikv restart txn %s", keyError.getRetryableBytes().toStringUtf8()));
+    }
+
+    if (!keyError.getAbort().isEmpty()) {
+      throw new KeyException(
+          String.format("tikv abort txn %s", keyError.getAbortBytes().toStringUtf8()));
+    }
+
+    throw new KeyException(
+        String.format("unexpected key error meets and it is %s", keyError.toString()));
+  }
+
+  public static AbstractLockResolverClient getInstance(
+      Metapb.Store store,
+      TiConfiguration conf,
+      TiRegion region,
+      TikvGrpc.TikvBlockingStub blockingStub,
+      TikvGrpc.TikvStub asyncStub,
+      ChannelFactory channelFactory,
+      RegionManager regionManager,
+      PDClient pdClient) {
+    if (StoreVersion.compare(store.getVersion(), MIN_RESOLVE_LOCK_V3_VERSION) < 0) {
+      return new LockResolverClientV2(
+          conf, region, blockingStub, asyncStub, channelFactory, regionManager);
+    } else {
+      return new LockResolverClientV3(
+          conf, region, blockingStub, asyncStub, channelFactory, regionManager, pdClient);
+    }
+  }
+}

--- a/tikv-client/src/main/java/com/pingcap/tikv/txn/AbstractLockResolverClient.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/txn/AbstractLockResolverClient.java
@@ -85,7 +85,7 @@ public interface AbstractLockResolverClient {
       ChannelFactory channelFactory,
       RegionManager regionManager,
       PDClient pdClient) {
-    if (StoreVersion.compare(store.getVersion(), MIN_RESOLVE_LOCK_V3_VERSION) < 0) {
+    if (StoreVersion.compareTo(store.getVersion(), MIN_RESOLVE_LOCK_V3_VERSION) < 0) {
       return new LockResolverClientV2(
           conf, region, blockingStub, asyncStub, channelFactory, regionManager);
     } else {

--- a/tikv-client/src/main/java/com/pingcap/tikv/txn/Lock.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/txn/Lock.java
@@ -25,6 +25,7 @@ public class Lock {
   private final long ttl;
   private final ByteString key;
   private final ByteString primary;
+  private final long txnSize;
   private static final long defaultLockTTL = 3000;
 
   public Lock(Kvrpcpb.LockInfo l) {
@@ -32,6 +33,7 @@ public class Lock {
     key = l.getKey();
     primary = l.getPrimaryLock();
     ttl = l.getLockTtl() == 0 ? defaultLockTTL : l.getLockTtl();
+    txnSize = l.getTxnSize();
   }
 
   public long getTxnID() {
@@ -48,5 +50,9 @@ public class Lock {
 
   public ByteString getPrimary() {
     return primary;
+  }
+
+  public long getTxnSize() {
+    return txnSize;
   }
 }

--- a/tikv-client/src/main/java/com/pingcap/tikv/txn/LockResolverClientV3.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/txn/LockResolverClientV3.java
@@ -1,0 +1,287 @@
+/*
+ *
+ * Copyright 2020 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.pingcap.tikv.txn;
+
+import static com.pingcap.tikv.util.BackOffFunction.BackOffFuncType.BoRegionMiss;
+
+import com.google.protobuf.ByteString;
+import com.pingcap.tikv.PDClient;
+import com.pingcap.tikv.TiConfiguration;
+import com.pingcap.tikv.exception.KeyException;
+import com.pingcap.tikv.exception.RegionException;
+import com.pingcap.tikv.operation.KVErrorHandler;
+import com.pingcap.tikv.region.AbstractRegionStoreClient;
+import com.pingcap.tikv.region.RegionManager;
+import com.pingcap.tikv.region.TiRegion;
+import com.pingcap.tikv.region.TiRegion.RegionVerID;
+import com.pingcap.tikv.util.BackOffer;
+import com.pingcap.tikv.util.ChannelFactory;
+import com.pingcap.tikv.util.TsoUtils;
+import java.util.*;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Supplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.tikv.kvproto.Kvrpcpb;
+import org.tikv.kvproto.Kvrpcpb.CleanupRequest;
+import org.tikv.kvproto.Kvrpcpb.CleanupResponse;
+import org.tikv.kvproto.TikvGrpc;
+import org.tikv.kvproto.TikvGrpc.TikvBlockingStub;
+import org.tikv.kvproto.TikvGrpc.TikvStub;
+
+/** Since v3.0.5 TiDB ignores the ttl on secondary lock and will use the ttl on primary key. */
+
+// LockResolver resolves locks and also caches resolved txn status.
+public class LockResolverClientV3 extends AbstractRegionStoreClient
+    implements AbstractLockResolverClient {
+  // ResolvedCacheSize is max number of cached txn status.
+  private static final long RESOLVED_TXN_CACHE_SIZE = 2048;
+
+  // bigTxnThreshold : transaction involves keys exceed this threshold can be treated as `big
+  // transaction`.
+  private static final long BIG_TXN_THRESHOLD = 16;
+
+  private static final Logger logger = LoggerFactory.getLogger(LockResolverClientV3.class);
+
+  private final ReadWriteLock readWriteLock;
+  // Note: Because the internal of long is same as unsigned_long
+  // and Txn id are never changed. Be careful to compare between two tso
+  // the `resolved` mapping is as {@code Map<TxnId, TxnStatus>}
+  // TxnStatus represents a txn's final status. It should be Commit or Rollback.
+  // if TxnStatus > 0, means the commit ts, otherwise abort
+  private final Map<Long, TxnStatus> resolved;
+  // the list is chain of txn for O(1) lru cache
+  private final Queue<Long> recentResolved;
+
+  private final PDClient pdClient;
+
+  public LockResolverClientV3(
+      TiConfiguration conf,
+      TiRegion region,
+      TikvBlockingStub blockingStub,
+      TikvStub asyncStub,
+      ChannelFactory channelFactory,
+      RegionManager regionManager,
+      PDClient pdClient) {
+    super(conf, region, channelFactory, blockingStub, asyncStub, regionManager);
+    resolved = new HashMap<>();
+    recentResolved = new LinkedList<>();
+    readWriteLock = new ReentrantReadWriteLock();
+    this.pdClient = pdClient;
+  }
+
+  @Override
+  public String getVersion() {
+    return "V3";
+  }
+
+  @Override
+  public long resolveLocks(BackOffer bo, List<Lock> locks) {
+    TxnExpireTime msBeforeTxnExpired = new TxnExpireTime();
+
+    if (locks.isEmpty()) {
+      return msBeforeTxnExpired.value();
+    }
+
+    List<Lock> expiredLocks = new ArrayList<>();
+    for (Lock lock : locks) {
+      if (TsoUtils.isExpired(lock.getTxnID(), lock.getTtl())) {
+        expiredLocks.add(lock);
+      } else {
+        msBeforeTxnExpired.update(lock.getTtl());
+      }
+    }
+
+    if (expiredLocks.isEmpty()) {
+      return msBeforeTxnExpired.value();
+    }
+
+    Map<Long, Set<RegionVerID>> cleanTxns = new HashMap<>();
+    for (Lock l : expiredLocks) {
+      TxnStatus status = getTxnStatusFromLock(bo, l);
+
+      if (status.getTtl() == 0) {
+        Set<RegionVerID> cleanRegion =
+            cleanTxns.computeIfAbsent(l.getTxnID(), k -> new HashSet<>());
+
+        resolveLock(bo, l, status, cleanRegion);
+      } else {
+        long msBeforeLockExpired = TsoUtils.untilExpired(l.getTxnID(), status.getTtl());
+        msBeforeTxnExpired.update(msBeforeLockExpired);
+      }
+    }
+
+    return msBeforeTxnExpired.value();
+  }
+
+  private void resolveLock(
+      BackOffer bo, Lock lock, TxnStatus txnStatus, Set<RegionVerID> cleanRegion) {
+    boolean cleanWholeRegion = lock.getTxnSize() >= BIG_TXN_THRESHOLD;
+
+    while (true) {
+      region = regionManager.getRegionByKey(lock.getKey());
+
+      if (cleanRegion.contains(region.getVerID())) {
+        return;
+      }
+
+      Kvrpcpb.ResolveLockRequest.Builder builder =
+          Kvrpcpb.ResolveLockRequest.newBuilder()
+              .setContext(region.getContext())
+              .setStartVersion(lock.getTxnID());
+
+      if (txnStatus.isCommitted()) {
+        // txn is committed with commitTS txnStatus
+        builder.setCommitVersion(txnStatus.getCommitTS());
+      }
+
+      if (lock.getTxnSize() < BIG_TXN_THRESHOLD) {
+        // Only resolve specified keys when it is a small transaction,
+        // prevent from scanning the whole region in this case.
+        builder.addKeys(lock.getKey());
+      }
+
+      Supplier<Kvrpcpb.ResolveLockRequest> factory = builder::build;
+      KVErrorHandler<Kvrpcpb.ResolveLockResponse> handler =
+          new KVErrorHandler<>(
+              regionManager,
+              this,
+              this,
+              region,
+              resp -> resp.hasRegionError() ? resp.getRegionError() : null,
+              resp -> resp.hasError() ? resp.getError() : null);
+      Kvrpcpb.ResolveLockResponse resp =
+          callWithRetry(bo, TikvGrpc.METHOD_KV_RESOLVE_LOCK, factory, handler);
+
+      if (resp.hasError()) {
+        logger.error(
+            String.format("unexpected resolveLock err: %s, lock: %s", resp.getError(), lock));
+        throw new KeyException(resp.getError());
+      }
+
+      if (resp.hasRegionError()) {
+        bo.doBackOff(BoRegionMiss, new RegionException(resp.getRegionError()));
+        continue;
+      }
+
+      if (cleanWholeRegion) {
+        cleanRegion.add(region.getVerID());
+      }
+      return;
+    }
+  }
+
+  private TxnStatus getTxnStatusFromLock(BackOffer bo, Lock lock) {
+    // NOTE: l.TTL = 0 is a special protocol!!!
+    // When the pessimistic txn prewrite meets locks of a txn, it should rollback that txn
+    // **unconditionally**.
+    // In this case, TiKV set the lock TTL = 0, and TiDB use currentTS = 0 to call
+    // getTxnStatus, and getTxnStatus with currentTS = 0 would rollback the transaction.
+    if (lock.getTtl() == 0) {
+      return getTxnStatus(bo, lock.getTxnID(), lock.getPrimary(), 0L);
+    }
+
+    long currentTS = pdClient.getTimestamp(bo).getVersion();
+    return getTxnStatus(bo, lock.getTxnID(), lock.getPrimary(), currentTS);
+  }
+
+  private TxnStatus getTxnStatus(BackOffer bo, Long txnID, ByteString primary, Long currentTS) {
+    TxnStatus status = getResolved(txnID);
+    if (status != null) {
+      return status;
+    }
+
+    status = new TxnStatus();
+    while (true) {
+      // refresh region
+      region = regionManager.getRegionByKey(primary);
+
+      Supplier<CleanupRequest> factory =
+          () ->
+              CleanupRequest.newBuilder()
+                  .setContext(region.getContext())
+                  .setKey(primary)
+                  .setStartVersion(txnID)
+                  .setCurrentTs(currentTS)
+                  .build();
+      KVErrorHandler<CleanupResponse> handler =
+          new KVErrorHandler<>(
+              regionManager,
+              this,
+              this,
+              region,
+              resp -> resp.hasRegionError() ? resp.getRegionError() : null,
+              resp -> resp.hasError() ? resp.getError() : null);
+      CleanupResponse resp = callWithRetry(bo, TikvGrpc.METHOD_KV_CLEANUP, factory, handler);
+
+      if (resp.hasRegionError()) {
+        bo.doBackOff(BoRegionMiss, new RegionException(resp.getRegionError()));
+        continue;
+      }
+
+      if (resp.hasError()) {
+        Kvrpcpb.KeyError keyError = resp.getError();
+
+        // If the TTL of the primary lock is not outdated, the proto returns a ErrLocked contains
+        // the TTL.
+        if (keyError.hasLocked()) {
+          Kvrpcpb.LockInfo lockInfo = keyError.getLocked();
+          return new TxnStatus(lockInfo.getLockTtl(), 0L);
+        }
+
+        logger.error(String.format("unexpected cleanup err: %s, tid: %d", keyError, txnID));
+        throw new KeyException(keyError);
+      }
+
+      if (resp.getCommitVersion() != 0) {
+        status = new TxnStatus(0L, resp.getCommitVersion());
+      }
+
+      saveResolved(txnID, status);
+      return status;
+    }
+  }
+
+  private void saveResolved(long txnID, TxnStatus status) {
+    try {
+      readWriteLock.writeLock().lock();
+      if (resolved.containsKey(txnID)) {
+        return;
+      }
+
+      resolved.put(txnID, status);
+      recentResolved.add(txnID);
+      if (recentResolved.size() > RESOLVED_TXN_CACHE_SIZE) {
+        Long front = recentResolved.remove();
+        resolved.remove(front);
+      }
+    } finally {
+      readWriteLock.writeLock().unlock();
+    }
+  }
+
+  private TxnStatus getResolved(Long txnID) {
+    try {
+      readWriteLock.readLock().lock();
+      return resolved.get(txnID);
+    } finally {
+      readWriteLock.readLock().unlock();
+    }
+  }
+}

--- a/tikv-client/src/main/java/com/pingcap/tikv/txn/TxnExpireTime.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/txn/TxnExpireTime.java
@@ -1,0 +1,55 @@
+/*
+ *
+ * Copyright 2020 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.pingcap.tikv.txn;
+
+public class TxnExpireTime {
+
+  private boolean initialized = false;
+  private long txnExpire = 0;
+
+  public TxnExpireTime() {}
+
+  public TxnExpireTime(boolean initialized, long txnExpire) {
+    this.initialized = initialized;
+    this.txnExpire = txnExpire;
+  }
+
+  public void update(long lockExpire) {
+    if (lockExpire < 0) {
+      lockExpire = 0;
+    }
+
+    if (!this.initialized) {
+      this.txnExpire = lockExpire;
+      this.initialized = true;
+      return;
+    }
+
+    if (lockExpire < this.txnExpire) {
+      this.txnExpire = lockExpire;
+    }
+  }
+
+  public long value() {
+    if (!this.initialized) {
+      return 0L;
+    } else {
+      return this.txnExpire;
+    }
+  }
+}

--- a/tikv-client/src/main/java/com/pingcap/tikv/txn/TxnStatus.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/txn/TxnStatus.java
@@ -1,0 +1,60 @@
+/*
+ *
+ * Copyright 2020 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.pingcap.tikv.txn;
+
+/**
+ * ttl > 0: lock is not resolved
+ *
+ * <p>ttl = 0 && commitTS = 0: lock is deleted
+ *
+ * <p>ttl = 0 && commitTS > 0: lock is committed
+ */
+public class TxnStatus {
+  private long ttl;
+  private long commitTS;
+
+  public TxnStatus() {
+    this.ttl = 0L;
+    this.commitTS = 0L;
+  }
+
+  public TxnStatus(long ttl, long commitTS) {
+    this.ttl = ttl;
+    this.commitTS = commitTS;
+  }
+
+  public long getTtl() {
+    return ttl;
+  }
+
+  public void setTtl(long ttl) {
+    this.ttl = ttl;
+  }
+
+  public long getCommitTS() {
+    return commitTS;
+  }
+
+  public void setCommitTS(long commitTS) {
+    this.commitTS = commitTS;
+  }
+
+  public boolean isCommitted() {
+    return ttl == 0 && commitTS > 0;
+  }
+}

--- a/tikv-client/src/main/java/com/pingcap/tikv/util/BackOffer.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/util/BackOffer.java
@@ -56,5 +56,12 @@ public interface BackOffer {
    * doBackOff sleeps a while base on the BackOffType and records the error message. Will stop until
    * max back off time exceeded and throw an exception to the caller.
    */
-  void doBackOff(BackOffFunction.BackOffFuncType funcTypes, Exception err);
+  void doBackOff(BackOffFunction.BackOffFuncType funcType, Exception err);
+
+  /**
+   * BackoffWithMaxSleep sleeps a while base on the backoffType and records the error message and
+   * never sleep more than maxSleepMs for each sleep.
+   */
+  void doBackOffWithMaxSleep(
+      BackOffFunction.BackOffFuncType funcType, long maxSleepMs, Exception err);
 }

--- a/tikv-client/src/main/java/com/pingcap/tikv/util/ConcreteBackOffer.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/util/ConcreteBackOffer.java
@@ -117,11 +117,17 @@ public class ConcreteBackOffer implements BackOffer {
 
   @Override
   public void doBackOff(BackOffFunction.BackOffFuncType funcType, Exception err) {
+    doBackOffWithMaxSleep(funcType, -1, err);
+  }
+
+  @Override
+  public void doBackOffWithMaxSleep(
+      BackOffFunction.BackOffFuncType funcType, long maxSleepMs, Exception err) {
     BackOffFunction backOffFunction =
         backOffFunctionMap.computeIfAbsent(funcType, this::createBackOffFunc);
 
     // Back off will be done here
-    totalSleep += backOffFunction.doBackOff();
+    totalSleep += backOffFunction.doBackOff(maxSleepMs);
     logger.debug(
         String.format(
             "%s, retry later(totalSleep %dms, maxSleep %dms)",

--- a/tikv-client/src/main/java/com/pingcap/tikv/util/TsoUtils.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/util/TsoUtils.java
@@ -1,15 +1,15 @@
 package com.pingcap.tikv.util;
 
-public final class TsoUtils {
-  private static final long physicalShiftBits = 18;
+import com.pingcap.tikv.meta.TiTimestamp;
 
+public final class TsoUtils {
   public static boolean isExpired(long lockTS, long ttl) {
     // Because the UNIX time in milliseconds is in long style and will
     // not exceed to become the negative number, so the comparison is correct
-    return System.currentTimeMillis() >= extractPhysical(lockTS) + ttl;
+    return untilExpired(lockTS, ttl) <= 0;
   }
 
-  private static long extractPhysical(long ts) {
-    return ts >> physicalShiftBits;
+  public static long untilExpired(long lockTS, long ttl) {
+    return TiTimestamp.extractPhysical(lockTS) + ttl - System.currentTimeMillis();
   }
 }

--- a/tikv-client/src/test/java/com/pingcap/tikv/RegionStoreClientTest.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/RegionStoreClientTest.java
@@ -34,12 +34,21 @@ import org.tikv.kvproto.Metapb;
 
 public class RegionStoreClientTest extends MockServerTest {
 
-  private RegionStoreClient createClient() {
+  private RegionStoreClient createClientV2() {
+    return createClient("2.1.19");
+  }
+
+  private RegionStoreClient createClientV3() {
+    return createClient("3.0.12");
+  }
+
+  private RegionStoreClient createClient(String version) {
     Metapb.Store store =
         Metapb.Store.newBuilder()
             .setAddress(LOCAL_ADDR + ":" + port)
             .setId(1)
             .setState(Metapb.StoreState.Up)
+            .setVersion(version)
             .build();
 
     RegionStoreClient.RegionStoreClientBuilder builder = session.getRegionStoreClientBuilder();
@@ -49,7 +58,11 @@ public class RegionStoreClientTest extends MockServerTest {
 
   @Test
   public void getTest() throws Exception {
-    RegionStoreClient client = createClient();
+    doGetTest(createClientV2());
+    doGetTest(createClientV3());
+  }
+
+  private void doGetTest(RegionStoreClient client) {
     server.put("key1", "value1");
     ByteString value = client.get(defaultBackOff(), ByteString.copyFromUtf8("key1"), 1);
     assertEquals(ByteString.copyFromUtf8("value1"), value);
@@ -67,8 +80,11 @@ public class RegionStoreClientTest extends MockServerTest {
 
   @Test
   public void batchGetTest() throws Exception {
-    RegionStoreClient client = createClient();
+    doBatchGetTest(createClientV2());
+    doBatchGetTest(createClientV3());
+  }
 
+  private void doBatchGetTest(RegionStoreClient client) throws Exception {
     server.put("key1", "value1");
     server.put("key2", "value2");
     server.put("key4", "value4");
@@ -100,8 +116,11 @@ public class RegionStoreClientTest extends MockServerTest {
 
   @Test
   public void scanTest() throws Exception {
-    RegionStoreClient client = createClient();
+    doScanTest(createClientV2());
+    doScanTest(createClientV3());
+  }
 
+  private void doScanTest(RegionStoreClient client) throws Exception {
     server.put("key1", "value1");
     server.put("key2", "value2");
     server.put("key4", "value4");
@@ -130,8 +149,11 @@ public class RegionStoreClientTest extends MockServerTest {
 
   @Test
   public void coprocessTest() throws Exception {
-    RegionStoreClient client = createClient();
+    doCoprocessTest(createClientV2());
+    doCoprocessTest(createClientV3());
+  }
 
+  private void doCoprocessTest(RegionStoreClient client) throws Exception {
     server.put("key1", "value1");
     server.put("key2", "value2");
     server.put("key4", "value4");

--- a/tikv-client/src/test/java/com/pingcap/tikv/txn/LockResolverRCTest.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/txn/LockResolverRCTest.java
@@ -18,8 +18,6 @@ package com.pingcap.tikv.txn;
 import static junit.framework.TestCase.*;
 
 import com.google.protobuf.ByteString;
-import com.pingcap.tikv.TiConfiguration;
-import com.pingcap.tikv.TiSession;
 import com.pingcap.tikv.exception.KeyException;
 import com.pingcap.tikv.meta.TiTimestamp;
 import com.pingcap.tikv.region.RegionStoreClient;
@@ -27,33 +25,18 @@ import com.pingcap.tikv.region.TiRegion;
 import com.pingcap.tikv.util.BackOffer;
 import com.pingcap.tikv.util.ConcreteBackOffer;
 import java.util.Collections;
-import org.junit.Before;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.tikv.kvproto.Kvrpcpb.IsolationLevel;
 
 public class LockResolverRCTest extends LockResolverTest {
-  private final Logger logger = LoggerFactory.getLogger(this.getClass());
-
-  @Before
-  public void setUp() {
-    TiConfiguration conf = TiConfiguration.createDefault(pdAddr);
-    conf.setIsolationLevel(IsolationLevel.RC);
-    try {
-      session = TiSession.getInstance(conf);
-      this.builder = session.getRegionStoreClientBuilder();
-      init = true;
-    } catch (Exception e) {
-      fail("TiDB cluster may not be present");
-      init = false;
-    }
+  public LockResolverRCTest() {
+    super(IsolationLevel.RC);
   }
 
   @Test
   public void getRCTest() {
     if (!init) {
-      skipTest();
+      skipTestInit();
       return;
     }
     session.getConf().setIsolationLevel(IsolationLevel.RC);
@@ -66,7 +49,7 @@ public class LockResolverRCTest extends LockResolverTest {
   @Test
   public void RCTest() {
     if (!init) {
-      skipTest();
+      skipTestInit();
       return;
     }
     TiTimestamp startTs = session.getTimestamp();
@@ -94,11 +77,7 @@ public class LockResolverRCTest extends LockResolverTest {
 
     try {
       // After committing <a, aa>, we can read it.
-      assertTrue(
-          commit(
-              Collections.singletonList(ByteString.copyFromUtf8("a")),
-              startTs.getVersion(),
-              endTs.getVersion()));
+      assertTrue(commit(Collections.singletonList("a"), startTs.getVersion(), endTs.getVersion()));
       BackOffer backOffer = ConcreteBackOffer.newGetBackOff();
       ByteString v =
           client.get(backOffer, ByteString.copyFromUtf8("a"), session.getTimestamp().getVersion());

--- a/tikv-client/src/test/java/com/pingcap/tikv/txn/LockResolverRCTest.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/txn/LockResolverRCTest.java
@@ -77,7 +77,8 @@ public class LockResolverRCTest extends LockResolverTest {
 
     try {
       // After committing <a, aa>, we can read it.
-      assertTrue(commit(Collections.singletonList("a"), startTs.getVersion(), endTs.getVersion()));
+      assertTrue(
+          commitString(Collections.singletonList("a"), startTs.getVersion(), endTs.getVersion()));
       BackOffer backOffer = ConcreteBackOffer.newGetBackOff();
       ByteString v =
           client.get(backOffer, ByteString.copyFromUtf8("a"), session.getTimestamp().getVersion());

--- a/tikv-client/src/test/java/com/pingcap/tikv/txn/LockResolverSITest.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/txn/LockResolverSITest.java
@@ -82,10 +82,10 @@ public class LockResolverSITest extends LockResolverTest {
     TiTimestamp endTs = session.getTimestamp();
 
     boolean res =
-        prewrite(
+        prewriteString(
             mutations, startTs.getVersion(), mutations.get(0).getKey().toStringUtf8(), DEFAULT_TTL);
     assertTrue(res);
-    res = commit(keys, startTs.getVersion(), endTs.getVersion());
+    res = commitString(keys, startTs.getVersion(), endTs.getVersion());
     assertTrue(res);
 
     for (int i = 0; i < 26; i++) {
@@ -135,8 +135,8 @@ public class LockResolverSITest extends LockResolverTest {
     }
 
     try {
-      // Trying to continue the commit phase of <a, aa> will fail because TxnLockNotFound
-      commit(Collections.singletonList("a"), startTs.getVersion(), endTs.getVersion());
+      // Trying to continue the commitString phase of <a, aa> will fail because TxnLockNotFound
+      commitString(Collections.singletonList("a"), startTs.getVersion(), endTs.getVersion());
       fail();
     } catch (KeyException e) {
       assertFalse(e.getKeyError().getRetryable().isEmpty());

--- a/tikv-client/src/test/java/com/pingcap/tikv/txn/LockResolverSIV3OneRowTest.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/txn/LockResolverSIV3OneRowTest.java
@@ -119,8 +119,8 @@ public class LockResolverSIV3OneRowTest extends LockResolverTest {
     // TTL not expire, resolved key fail
     checkTTLNotExpired(key);
 
-    // continue the commit phase of <key, value2>
-    commit(Collections.singletonList(key), startTs, endTs);
+    // continue the commitString phase of <key, value2>
+    commitString(Collections.singletonList(key), startTs, endTs);
 
     // get
     assertEquals(pointGet(key), value2);

--- a/tikv-client/src/test/java/com/pingcap/tikv/txn/LockResolverSIV3OneRowTest.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/txn/LockResolverSIV3OneRowTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2020 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pingcap.tikv.txn;
+
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertTrue;
+
+import java.util.Collections;
+import org.junit.Test;
+import org.tikv.kvproto.Kvrpcpb.IsolationLevel;
+
+public class LockResolverSIV3OneRowTest extends LockResolverTest {
+  private String value1 = "v1";
+  private String value2 = "v2";
+
+  public LockResolverSIV3OneRowTest() {
+    super(IsolationLevel.SI);
+  }
+
+  @Test
+  public void TTLExpire() {
+    if (!init) {
+      skipTestInit();
+      return;
+    }
+
+    if (!isV3()) {
+      skipTestV3();
+      return;
+    }
+
+    String key = genRandomKey(64);
+    long ttl = GET_BACKOFF - GET_BACKOFF / 2;
+
+    // Put <key, value1> into kv
+    putKVandTestGet(key, value1);
+
+    // Prewrite <key, value2> as primary without committing it
+    long startTs = session.getTimestamp().getVersion();
+    long endTs = session.getTimestamp().getVersion();
+    assertTrue(lockKey(key, value2, key, value2, false, startTs, endTs, ttl));
+
+    // TTL expires, we should be able to read <key, value1> instead.
+    assertEquals(pointGet(key), value1);
+
+    commitFail(key, startTs, endTs);
+  }
+
+  @Test
+  public void TTLNotExpireCommitFail() throws InterruptedException {
+    if (!init) {
+      skipTestInit();
+      return;
+    }
+
+    if (!isV3()) {
+      skipTestV3();
+      return;
+    }
+
+    String key = genRandomKey(64);
+    long ttl = GET_BACKOFF + GET_BACKOFF / 2;
+
+    // Put <key, value1> into kv
+    putKVandTestGet(key, value1);
+
+    // Prewrite <key, value2> as primary without committing it
+    long startTs = session.getTimestamp().getVersion();
+    long endTs = session.getTimestamp().getVersion();
+    assertTrue(lockKey(key, value2, key, value2, false, startTs, endTs, ttl));
+
+    // TTL not expire, resolved key fail
+    checkTTLNotExpired(key);
+
+    // TTL expires
+    // We should be able to read <key, value1> instead.
+    Thread.sleep(ttl);
+    assertEquals(pointGet(key), value1);
+
+    commitFail(key, startTs, endTs);
+  }
+
+  @Test
+  public void TTLNotExpireCommitSuccess() {
+    if (!init) {
+      skipTestInit();
+      return;
+    }
+
+    if (!isV3()) {
+      skipTestV3();
+      return;
+    }
+
+    String key = genRandomKey(64);
+    long ttl = GET_BACKOFF + GET_BACKOFF;
+
+    // Put <key, value1> into kv
+    putKVandTestGet(key, value1);
+
+    // Prewrite <key, value2> as primary without committing it
+    long startTs = session.getTimestamp().getVersion();
+    long endTs = session.getTimestamp().getVersion();
+    assertTrue(lockKey(key, value2, key, value2, false, startTs, endTs, ttl));
+
+    // TTL not expire, resolved key fail
+    checkTTLNotExpired(key);
+
+    // continue the commit phase of <key, value2>
+    commit(Collections.singletonList(key), startTs, endTs);
+
+    // get
+    assertEquals(pointGet(key), value2);
+  }
+}

--- a/tikv-client/src/test/java/com/pingcap/tikv/txn/LockResolverSIV3TwoRowTest.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/txn/LockResolverSIV3TwoRowTest.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright 2020 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pingcap.tikv.txn;
+
+import static junit.framework.Assert.assertTrue;
+import static junit.framework.TestCase.assertEquals;
+
+import java.util.Collections;
+import org.junit.Test;
+import org.tikv.kvproto.Kvrpcpb.IsolationLevel;
+
+public class LockResolverSIV3TwoRowTest extends LockResolverTest {
+  private String value1 = "v1";
+  private String value2 = "v2";
+  private String value3 = "v3";
+  private String value4 = "v4";
+
+  public LockResolverSIV3TwoRowTest() {
+    super(IsolationLevel.SI);
+  }
+
+  @Test
+  public void prewriteCommitSuccessTest() {
+    if (!init) {
+      skipTestInit();
+      return;
+    }
+
+    if (!isV3()) {
+      skipTestV3();
+      return;
+    }
+
+    String primaryKey = genRandomKey(64);
+    String secondaryKey = genRandomKey(64);
+
+    long startTs = session.getTimestamp().getVersion();
+    long endTs = session.getTimestamp().getVersion();
+
+    // prewrite <primary key, value1>
+    assertTrue(prewrite(primaryKey, value1, startTs, primaryKey, DEFAULT_TTL));
+
+    // prewrite <secondary key, value2>
+    assertTrue(prewrite(secondaryKey, value2, startTs, primaryKey, DEFAULT_TTL));
+
+    // commit primary key
+    assertTrue(commit(Collections.singletonList(primaryKey), startTs, endTs));
+
+    // commit secondary key
+    assertTrue(commit(Collections.singletonList(secondaryKey), startTs, endTs));
+
+    // get check primary key & secondary key
+    assertEquals(pointGet(primaryKey), value1);
+    assertEquals(pointGet(secondaryKey), value2);
+  }
+
+  @Test
+  public void TTLExpireCommitFail() throws InterruptedException {
+    if (!init) {
+      skipTestInit();
+      return;
+    }
+
+    if (!isV3()) {
+      skipTestV3();
+      return;
+    }
+
+    String primaryKey = genRandomKey(64);
+    String secondaryKey = genRandomKey(64);
+
+    // Put <primaryKey, value1> into kv
+    putKVandTestGet(primaryKey, value1);
+
+    // Put <secondaryKey, value2> into kv
+    putKVandTestGet(secondaryKey, value2);
+
+    long ttl = GET_BACKOFF + GET_BACKOFF / 2;
+
+    long startTs = session.getTimestamp().getVersion();
+    long endTs = session.getTimestamp().getVersion();
+
+    // prewrite <primary key, value1>
+    assertTrue(prewrite(primaryKey, value3, startTs, primaryKey, ttl));
+
+    // prewrite <secondary key, value2>
+    assertTrue(prewrite(secondaryKey, value4, startTs, primaryKey, ttl));
+
+    // check ttl not expired
+    checkTTLNotExpired(primaryKey);
+    checkTTLNotExpired(secondaryKey);
+
+    // TTL expires
+    Thread.sleep(ttl);
+
+    // read old data
+    assertEquals(pointGet(primaryKey), value1);
+    assertEquals(pointGet(secondaryKey), value2);
+
+    // commit fail
+    commitFail(primaryKey, startTs, endTs);
+  }
+
+  @Test
+  public void TTLExpireCommitSuccess() throws InterruptedException {
+    if (!init) {
+      skipTestInit();
+      return;
+    }
+
+    if (!isV3()) {
+      skipTestV3();
+      return;
+    }
+
+    String primaryKey = genRandomKey(64);
+    String secondaryKey = genRandomKey(64);
+
+    // Put <primaryKey, value1> into kv
+    putKVandTestGet(primaryKey, value1);
+
+    // Put <secondaryKey, value2> into kv
+    putKVandTestGet(secondaryKey, value2);
+
+    long ttl = GET_BACKOFF + GET_BACKOFF / 2;
+
+    long startTs = session.getTimestamp().getVersion();
+    long endTs = session.getTimestamp().getVersion();
+
+    // prewrite <primary key, value1>
+    assertTrue(prewrite(primaryKey, value3, startTs, primaryKey, ttl));
+
+    // prewrite <secondary key, value2>
+    assertTrue(prewrite(secondaryKey, value4, startTs, primaryKey, ttl));
+
+    // check ttl not expired
+    checkTTLNotExpired(primaryKey);
+    checkTTLNotExpired(secondaryKey);
+
+    // TTL expires
+    Thread.sleep(ttl);
+
+    // commit primary key
+    assertTrue(commit(Collections.singletonList(primaryKey), startTs, endTs));
+
+    // get check primary key & secondary key
+    assertEquals(pointGet(primaryKey), value3);
+    assertEquals(pointGet(secondaryKey), value4);
+  }
+
+  @Test
+  public void TTLNotExpireCommitSuccess() throws InterruptedException {
+    if (!init) {
+      skipTestInit();
+      return;
+    }
+
+    if (!isV3()) {
+      skipTestV3();
+      return;
+    }
+
+    String primaryKey = genRandomKey(64);
+    String secondaryKey = genRandomKey(64);
+
+    long ttl = GET_BACKOFF + GET_BACKOFF / 2;
+
+    long startTs = session.getTimestamp().getVersion();
+    long endTs = session.getTimestamp().getVersion();
+
+    // prewrite <primary key, value1>
+    assertTrue(prewrite(primaryKey, value1, startTs, primaryKey, ttl));
+
+    // prewrite <secondary key, value2>
+    assertTrue(prewrite(secondaryKey, value2, startTs, primaryKey, ttl));
+
+    // check ttl not expired
+    checkTTLNotExpired(primaryKey);
+    checkTTLNotExpired(secondaryKey);
+
+    // commit primary key
+    assertTrue(commit(Collections.singletonList(primaryKey), startTs, endTs));
+
+    // get check primary key & secondary key
+    assertEquals(pointGet(primaryKey), value1);
+
+    // secondary key ttl not expired
+    checkTTLNotExpired(secondaryKey);
+
+    // get secondary key
+    Thread.sleep(ttl);
+    assertEquals(pointGet(secondaryKey), value2);
+  }
+
+  @Test
+  public void checkPrimaryTTL() throws InterruptedException {
+    if (!init) {
+      skipTestInit();
+      return;
+    }
+
+    if (!isV3()) {
+      skipTestV3();
+      return;
+    }
+
+    String primaryKey = genRandomKey(64);
+    String secondaryKey = genRandomKey(64);
+
+    // Put <primaryKey, value1> into kv
+    putKVandTestGet(primaryKey, value1);
+
+    // Put <secondaryKey, value2> into kv
+    putKVandTestGet(secondaryKey, value2);
+
+    long primaryTTL = GET_BACKOFF + GET_BACKOFF / 2;
+    long secondaryTTL = DEFAULT_TTL;
+
+    long startTs = session.getTimestamp().getVersion();
+    long endTs = session.getTimestamp().getVersion();
+
+    // prewrite <primary key, value1>
+    assertTrue(prewrite(primaryKey, value3, startTs, primaryKey, primaryTTL));
+
+    // prewrite <secondary key, value2>
+    assertTrue(prewrite(secondaryKey, value4, startTs, primaryKey, secondaryTTL));
+
+    // secondary ttl expired, but primary not
+    Thread.sleep(secondaryTTL);
+
+    // check ttl not expired
+    checkTTLNotExpired(primaryKey);
+    checkTTLNotExpired(secondaryKey);
+
+    // secondary ttl expired & primary expired
+    Thread.sleep(primaryTTL);
+
+    // get check primary key & secondary key
+    assertEquals(pointGet(primaryKey), value1);
+    assertEquals(pointGet(secondaryKey), value2);
+  }
+}

--- a/tikv-client/src/test/java/com/pingcap/tikv/txn/LockResolverSIV3TwoRowTest.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/txn/LockResolverSIV3TwoRowTest.java
@@ -50,17 +50,17 @@ public class LockResolverSIV3TwoRowTest extends LockResolverTest {
     long startTs = session.getTimestamp().getVersion();
     long endTs = session.getTimestamp().getVersion();
 
-    // prewrite <primary key, value1>
-    assertTrue(prewrite(primaryKey, value1, startTs, primaryKey, DEFAULT_TTL));
+    // prewriteString <primary key, value1>
+    assertTrue(prewriteString(primaryKey, value1, startTs, primaryKey, DEFAULT_TTL));
 
-    // prewrite <secondary key, value2>
-    assertTrue(prewrite(secondaryKey, value2, startTs, primaryKey, DEFAULT_TTL));
+    // prewriteString <secondary key, value2>
+    assertTrue(prewriteString(secondaryKey, value2, startTs, primaryKey, DEFAULT_TTL));
 
-    // commit primary key
-    assertTrue(commit(Collections.singletonList(primaryKey), startTs, endTs));
+    // commitString primary key
+    assertTrue(commitString(Collections.singletonList(primaryKey), startTs, endTs));
 
-    // commit secondary key
-    assertTrue(commit(Collections.singletonList(secondaryKey), startTs, endTs));
+    // commitString secondary key
+    assertTrue(commitString(Collections.singletonList(secondaryKey), startTs, endTs));
 
     // get check primary key & secondary key
     assertEquals(pointGet(primaryKey), value1);
@@ -93,11 +93,11 @@ public class LockResolverSIV3TwoRowTest extends LockResolverTest {
     long startTs = session.getTimestamp().getVersion();
     long endTs = session.getTimestamp().getVersion();
 
-    // prewrite <primary key, value1>
-    assertTrue(prewrite(primaryKey, value3, startTs, primaryKey, ttl));
+    // prewriteString <primary key, value1>
+    assertTrue(prewriteString(primaryKey, value3, startTs, primaryKey, ttl));
 
-    // prewrite <secondary key, value2>
-    assertTrue(prewrite(secondaryKey, value4, startTs, primaryKey, ttl));
+    // prewriteString <secondary key, value2>
+    assertTrue(prewriteString(secondaryKey, value4, startTs, primaryKey, ttl));
 
     // check ttl not expired
     checkTTLNotExpired(primaryKey);
@@ -110,7 +110,7 @@ public class LockResolverSIV3TwoRowTest extends LockResolverTest {
     assertEquals(pointGet(primaryKey), value1);
     assertEquals(pointGet(secondaryKey), value2);
 
-    // commit fail
+    // commitString fail
     commitFail(primaryKey, startTs, endTs);
   }
 
@@ -140,11 +140,11 @@ public class LockResolverSIV3TwoRowTest extends LockResolverTest {
     long startTs = session.getTimestamp().getVersion();
     long endTs = session.getTimestamp().getVersion();
 
-    // prewrite <primary key, value1>
-    assertTrue(prewrite(primaryKey, value3, startTs, primaryKey, ttl));
+    // prewriteString <primary key, value1>
+    assertTrue(prewriteString(primaryKey, value3, startTs, primaryKey, ttl));
 
-    // prewrite <secondary key, value2>
-    assertTrue(prewrite(secondaryKey, value4, startTs, primaryKey, ttl));
+    // prewriteString <secondary key, value2>
+    assertTrue(prewriteString(secondaryKey, value4, startTs, primaryKey, ttl));
 
     // check ttl not expired
     checkTTLNotExpired(primaryKey);
@@ -153,8 +153,8 @@ public class LockResolverSIV3TwoRowTest extends LockResolverTest {
     // TTL expires
     Thread.sleep(ttl);
 
-    // commit primary key
-    assertTrue(commit(Collections.singletonList(primaryKey), startTs, endTs));
+    // commitString primary key
+    assertTrue(commitString(Collections.singletonList(primaryKey), startTs, endTs));
 
     // get check primary key & secondary key
     assertEquals(pointGet(primaryKey), value3);
@@ -181,18 +181,18 @@ public class LockResolverSIV3TwoRowTest extends LockResolverTest {
     long startTs = session.getTimestamp().getVersion();
     long endTs = session.getTimestamp().getVersion();
 
-    // prewrite <primary key, value1>
-    assertTrue(prewrite(primaryKey, value1, startTs, primaryKey, ttl));
+    // prewriteString <primary key, value1>
+    assertTrue(prewriteString(primaryKey, value1, startTs, primaryKey, ttl));
 
-    // prewrite <secondary key, value2>
-    assertTrue(prewrite(secondaryKey, value2, startTs, primaryKey, ttl));
+    // prewriteString <secondary key, value2>
+    assertTrue(prewriteString(secondaryKey, value2, startTs, primaryKey, ttl));
 
     // check ttl not expired
     checkTTLNotExpired(primaryKey);
     checkTTLNotExpired(secondaryKey);
 
-    // commit primary key
-    assertTrue(commit(Collections.singletonList(primaryKey), startTs, endTs));
+    // commitString primary key
+    assertTrue(commitString(Collections.singletonList(primaryKey), startTs, endTs));
 
     // get check primary key & secondary key
     assertEquals(pointGet(primaryKey), value1);
@@ -232,11 +232,11 @@ public class LockResolverSIV3TwoRowTest extends LockResolverTest {
     long startTs = session.getTimestamp().getVersion();
     long endTs = session.getTimestamp().getVersion();
 
-    // prewrite <primary key, value1>
-    assertTrue(prewrite(primaryKey, value3, startTs, primaryKey, primaryTTL));
+    // prewriteString <primary key, value1>
+    assertTrue(prewriteString(primaryKey, value3, startTs, primaryKey, primaryTTL));
 
-    // prewrite <secondary key, value2>
-    assertTrue(prewrite(secondaryKey, value4, startTs, primaryKey, secondaryTTL));
+    // prewriteString <secondary key, value2>
+    assertTrue(prewriteString(secondaryKey, value4, startTs, primaryKey, secondaryTTL));
 
     // secondary ttl expired, but primary not
     Thread.sleep(secondaryTTL);

--- a/tikv-client/src/test/java/com/pingcap/tikv/txn/LockResolverTest.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/txn/LockResolverTest.java
@@ -18,7 +18,9 @@ package com.pingcap.tikv.txn;
 import static junit.framework.TestCase.*;
 
 import com.google.protobuf.ByteString;
+import com.pingcap.tikv.TiConfiguration;
 import com.pingcap.tikv.TiSession;
+import com.pingcap.tikv.exception.GrpcException;
 import com.pingcap.tikv.exception.KeyException;
 import com.pingcap.tikv.exception.RegionException;
 import com.pingcap.tikv.meta.TiTimestamp;
@@ -31,23 +33,60 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 import org.junit.Before;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.tikv.kvproto.Kvrpcpb.LockInfo;
+import org.tikv.kvproto.Kvrpcpb;
 import org.tikv.kvproto.Kvrpcpb.Mutation;
 import org.tikv.kvproto.Kvrpcpb.Op;
 
-public abstract class LockResolverTest {
+abstract class LockResolverTest {
+  private Kvrpcpb.IsolationLevel isolationLevel;
+
   private final Logger logger = LoggerFactory.getLogger(this.getClass());
   TiSession session;
-  private static final int DefaultTTL = 10;
+  static final int DEFAULT_TTL = 10;
   RegionStoreClient.RegionStoreClientBuilder builder;
   boolean init;
-  protected final String pdAddr = "127.0.0.1:2379";
+  private static final String DEFAULT_PD_ADDR = "127.0.0.1:2379";
+  private static final long LARGE_LOCK_TTL = BackOffer.GET_MAX_BACKOFF + 2 * 1000;
+
+  static final int GET_BACKOFF = 5 * 1000;
+  static final int CHECK_TTL_BACKOFF = 1000;
+
+  private String getPdAddr() {
+    String tmp = System.getenv("pdAddr");
+    if (tmp != null && !tmp.equals("")) {
+      return tmp;
+    }
+
+    tmp = System.getProperty("pdAddr");
+    if (tmp != null && !tmp.equals("")) {
+      return tmp;
+    }
+
+    return DEFAULT_PD_ADDR;
+  }
+
+  LockResolverTest(Kvrpcpb.IsolationLevel isolationLevel) {
+    this.isolationLevel = isolationLevel;
+  }
 
   @Before
-  public abstract void setUp();
+  public void setUp() {
+    TiConfiguration conf = TiConfiguration.createDefault(getPdAddr());
+    conf.setIsolationLevel(isolationLevel);
+    try {
+      session = TiSession.getInstance(conf);
+      this.builder = session.getRegionStoreClientBuilder();
+      init = true;
+    } catch (Exception e) {
+      init = false;
+      fail("TiDB cluster may not be present");
+    }
+  }
 
   void putKV(String key, String value, long startTS, long commitTS) {
     Mutation m =
@@ -57,13 +96,24 @@ public abstract class LockResolverTest {
             .setValue(ByteString.copyFromUtf8(value))
             .build();
 
-    boolean res = prewrite(Collections.singletonList(m), startTS, m);
+    boolean res = prewrite(Collections.singletonList(m), startTS, key, DEFAULT_TTL);
     assertTrue(res);
-    res = commit(Collections.singletonList(ByteString.copyFromUtf8(key)), startTS, commitTS);
+    res = commit(Collections.singletonList(key), startTS, commitTS);
     assertTrue(res);
   }
 
-  boolean prewrite(List<Mutation> mutations, long startTS, Mutation primary) {
+  boolean prewrite(String key, String value, long startTS, String primaryKey, long ttl) {
+    Mutation m =
+        Mutation.newBuilder()
+            .setKey(ByteString.copyFromUtf8(key))
+            .setOp(Op.Put)
+            .setValue(ByteString.copyFromUtf8(value))
+            .build();
+
+    return prewrite(Collections.singletonList(m), startTS, primaryKey, ttl);
+  }
+
+  boolean prewrite(List<Mutation> mutations, long startTS, String primary, long ttl) {
     if (mutations.size() == 0) return true;
     BackOffer backOffer = ConcreteBackOffer.newCustomBackOff(1000);
 
@@ -73,7 +123,11 @@ public abstract class LockResolverTest {
           TiRegion region = session.getRegionManager().getRegionByKey(m.getKey());
           RegionStoreClient client = builder.build(region);
           client.prewrite(
-              backOffer, primary.getKey(), Collections.singletonList(m), startTS, DefaultTTL);
+              backOffer,
+              ByteString.copyFromUtf8(primary),
+              Collections.singletonList(m),
+              startTS,
+              ttl);
           break;
         } catch (RegionException e) {
           backOffer.doBackOff(BackOffFunction.BackOffFuncType.BoRegionMiss, e);
@@ -83,16 +137,17 @@ public abstract class LockResolverTest {
     return true;
   }
 
-  boolean commit(List<ByteString> keys, long startTS, long commitTS) {
+  boolean commit(List<String> keys, long startTS, long commitTS) {
     if (keys.size() == 0) return true;
     BackOffer backOffer = ConcreteBackOffer.newCustomBackOff(1000);
 
-    for (ByteString k : keys) {
+    for (String k : keys) {
       while (true) {
         try {
-          TiRegion tiRegion = session.getRegionManager().getRegionByKey(k);
+          ByteString byteStringK = ByteString.copyFromUtf8(k);
+          TiRegion tiRegion = session.getRegionManager().getRegionByKey(byteStringK);
           RegionStoreClient client = builder.build(tiRegion);
-          client.commit(backOffer, Collections.singletonList(k), startTS, commitTS);
+          client.commit(backOffer, Collections.singletonList(byteStringK), startTS, commitTS);
           break;
         } catch (RegionException e) {
           backOffer.doBackOff(BackOffFunction.BackOffFuncType.BoRegionMiss, e);
@@ -110,6 +165,19 @@ public abstract class LockResolverTest {
       boolean commitPrimary,
       long startTs,
       long commitTS) {
+    return lockKey(
+        key, value, primaryKey, primaryValue, commitPrimary, startTs, commitTS, DEFAULT_TTL);
+  }
+
+  boolean lockKey(
+      String key,
+      String value,
+      String primaryKey,
+      String primaryValue,
+      boolean commitPrimary,
+      long startTs,
+      long commitTS,
+      long ttl) {
     List<Mutation> mutations = new ArrayList<>();
     mutations.add(
         Mutation.newBuilder()
@@ -125,17 +193,13 @@ public abstract class LockResolverTest {
               .setOp(Op.Put)
               .build());
     }
-    if (!prewrite(mutations, startTs, mutations.get(0))) return false;
+    if (!prewrite(mutations, startTs, primaryKey, ttl)) return false;
 
     if (commitPrimary) {
       if (!key.equals(primaryKey)) {
-        return commit(
-            Arrays.asList(ByteString.copyFromUtf8(primaryKey), ByteString.copyFromUtf8(key)),
-            startTs,
-            commitTS);
+        return commit(Arrays.asList(primaryKey, key), startTs, commitTS);
       } else {
-        return commit(
-            Collections.singletonList(ByteString.copyFromUtf8(primaryKey)), startTs, commitTS);
+        return commit(Collections.singletonList(primaryKey), startTs, commitTS);
       }
     }
 
@@ -173,11 +237,24 @@ public abstract class LockResolverTest {
     while (startTs == endTs) {
       endTs = session.getTimestamp();
     }
-    assertTrue(lockKey("d", "dd", "z2", "z2", false, startTs.getVersion(), endTs.getVersion()));
+    assertTrue(
+        lockKey(
+            "d",
+            "dd",
+            "z2",
+            "z2",
+            false,
+            startTs.getVersion(),
+            endTs.getVersion(),
+            LARGE_LOCK_TTL));
   }
 
-  void skipTest() {
+  void skipTestInit() {
     logger.warn("Test skipped due to failure in initializing pd client.");
+  }
+
+  void skipTestV3() {
+    logger.warn("Test skipped due to version of TiKV is to low.");
   }
 
   void versionTest() {
@@ -198,12 +275,77 @@ public abstract class LockResolverTest {
         } else {
           assertEquals(String.valueOf((char) ('a' + i)), v.toStringUtf8());
         }
-      } catch (KeyException e) {
-        assertEquals(ByteString.copyFromUtf8("d"), key);
-        LockInfo lock = e.getKeyError().getLocked();
-        assertEquals(key, lock.getKey());
-        assertEquals(ByteString.copyFromUtf8("z2"), lock.getPrimaryLock());
+      } catch (GrpcException e) {
+        assertEquals(e.getMessage(), "retry is exhausted.");
       }
     }
+  }
+
+  String genRandomKey(int strLength) {
+    Random rnd = ThreadLocalRandom.current();
+    StringBuilder ret = new StringBuilder();
+    for (int i = 0; i < strLength; i++) {
+      boolean isChar = (rnd.nextInt(2) % 2 == 0);
+      if (isChar) {
+        int choice = rnd.nextInt(2) % 2 == 0 ? 65 : 97;
+        ret.append((char) (choice + rnd.nextInt(26)));
+      } else {
+        ret.append(Integer.toString(rnd.nextInt(10)));
+      }
+    }
+    return ret.toString();
+  }
+
+  RegionStoreClient getRegionStoreClient(String key) {
+    TiRegion tiRegion = session.getRegionManager().getRegionByKey(ByteString.copyFromUtf8(key));
+    return builder.build(tiRegion);
+  }
+
+  void checkTTLNotExpired(String key) {
+    try {
+      RegionStoreClient client = getRegionStoreClient(key);
+      BackOffer backOffer = ConcreteBackOffer.newCustomBackOff(CHECK_TTL_BACKOFF);
+      // In SI mode, a lock <key, value2> is read. Try resolve it, but failed, cause TTL not
+      // expires.
+      client.get(backOffer, ByteString.copyFromUtf8(key), session.getTimestamp().getVersion());
+      fail();
+    } catch (GrpcException e) {
+      assertEquals(e.getMessage(), "retry is exhausted.");
+    }
+  }
+
+  String pointGet(String key) {
+    BackOffer backOffer2 = ConcreteBackOffer.newCustomBackOff(GET_BACKOFF);
+    RegionStoreClient client = getRegionStoreClient(key);
+    return client
+        .get(backOffer2, ByteString.copyFromUtf8(key), session.getTimestamp().getVersion())
+        .toStringUtf8();
+  }
+
+  void commitFail(String key, long startTs, long endTs) {
+    try {
+      // Trying to continue the commit phase of <key, value2> will fail because TxnLockNotFound
+      commit(Collections.singletonList(key), startTs, endTs);
+      fail();
+    } catch (KeyException e) {
+      assertFalse(e.getKeyError().getRetryable().isEmpty());
+    }
+  }
+
+  void putKVandTestGet(String key, String value) {
+    RegionStoreClient client = getRegionStoreClient(key);
+
+    TiTimestamp startTs = session.getTimestamp();
+    TiTimestamp endTs = session.getTimestamp();
+    putKV(key, value, startTs.getVersion(), endTs.getVersion());
+
+    BackOffer backOffer = ConcreteBackOffer.newGetBackOff();
+    ByteString v =
+        client.get(backOffer, ByteString.copyFromUtf8(key), session.getTimestamp().getVersion());
+    assertEquals(v.toStringUtf8(), value);
+  }
+
+  boolean isV3() {
+    return getRegionStoreClient("").lockResolverClient.getVersion().equals("V3");
   }
 }


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
TiDB-3.0 changes the logic of `ResolveLock` since `v3.0.5`.

Check the `TTL` on the primary lock to decide the real status of a transaction.
After we [update the `TTL` of a transaction](https://github.com/pingcap/tidb/pull/12177), the TTL information on the secondary lock is not accurate.

see: https://github.com/pingcap/tidb/pull/12212

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test


### /run-all-tests tikv=v3.0.12 tidb=v3.0.12 pd=v3.0.12 success
https://internal.pingcap.net/idc-jenkins/blue/organizations/jenkins/tispark_ghpr_integration_test/detail/tispark_ghpr_integration_test/1559/pipeline