### PR TITLE
fix table not found bug

### DIFF
--- a/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
@@ -467,8 +467,25 @@ class IssueTestSuite extends BaseTiSparkTest {
     )
   }
 
+  test("test large amount of tables") {
+    tidbStmt.execute("DROP DATABASE IF EXISTS large_amount_tables")
+    tidbStmt.execute("CREATE DATABASE large_amount_tables")
+
+    val size = 2000
+    var sqls = ""
+    (1 to size).foreach { i =>
+      val sql = s"create table large_amount_tables.t$i(c1 bigint); "
+      sqls = sqls + sql
+    }
+    tidbStmt.execute(sqls)
+    sql(s"use ${dbPrefix}large_amount_tables")
+    val df = sql("show tables")
+    assert(df.count() >= size)
+  }
+
   override def afterAll(): Unit =
     try {
+      tidbStmt.execute("DROP DATABASE IF EXISTS large_amount_tables")
       tidbStmt.execute("drop table if exists t")
       tidbStmt.execute("drop table if exists tmp_debug")
       tidbStmt.execute("drop table if exists t1")

--- a/tikv-client/src/main/java/com/pingcap/tikv/operation/iterator/ScanIterator.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/operation/iterator/ScanIterator.java
@@ -91,6 +91,7 @@ public abstract class ScanIterator implements Iterator<Kvrpcpb.KvPair> {
       // of a transaction. Otherwise below code might lose data
       if (currentCache.size() < conf.getScanBatchSize()) {
         startKey = curRegionEndKey;
+        lastKey = Key.toRawKey(curRegionEndKey);
       } else if (currentCache.size() > conf.getScanBatchSize()) {
         throw new IndexOutOfBoundsException(
             "current cache size = "


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
regression test failed (region size=1M)

```
org.apache.spark.sql.AnalysisException: Table or view 'full_data_type_table_idx' not found in database 'tidb_tispark_test';
```

### What is changed and how it works?
the bug occurs when metadata stores in 2 different regions.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

![image](https://user-images.githubusercontent.com/5574887/80351463-f1be0e00-88a4-11ea-8592-12515a72be77.png)

