### PR TITLE
fix ut: Write large amount of data

### DIFF
--- a/core/src/test/scala/com/pingcap/tispark/datasource/EdgeConditionSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/EdgeConditionSuite.scala
@@ -5,7 +5,7 @@ import org.apache.spark.sql.types._
 
 class EdgeConditionSuite extends BaseDataSourceTest("test_datasource_edge_condition") {
 
-  private val TEST_LARGE_DATA_SIZE = 102400
+  private val TEST_LARGE_DATA_SIZE = 25600
 
   private val TEST_LARGE_COLUMN_SIZE = 512
 


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
regression test may fail

```
[2020-04-28T19:49:49.604Z] - Write large amount of data *** FAILED ***
[2020-04-28T19:49:49.604Z]   org.apache.spark.SparkException: Job aborted due to stage failure: Task 0 in stage 230.0 failed 1 times, most recent failure: Lost task 0.0 in stage 230.0 (TID 1219, localhost, executor driver): com.pingcap.tikv.exception.TiClientInternalException: Error reading region:
[2020-04-28T19:49:49.604Z] 	at com.pingcap.tikv.operation.iterator.DAGIterator.doReadNextRegionChunks(DAGIterator.java:173)
[2020-04-28T19:49:49.604Z] 	at com.pingcap.tikv.operation.iterator.DAGIterator.readNextRegionChunks(DAGIterator.java:150)
[2020-04-28T19:49:49.605Z] 	at com.pingcap.tikv.operation.iterator.DAGIterator.hasNext(DAGIterator.java:96)
[2020-04-28T19:49:49.605Z] 	at com.pingcap.tikv.operation.iterator.CoprocessorIterator$2.next(CoprocessorIterator.java:129)
[2020-04-28T19:49:49.605Z] 	at com.pingcap.tikv.operation.iterator.CoprocessorIterator$2.next(CoprocessorIterator.java:121)
[2020-04-28T19:49:49.605Z] 	at org.apache.spark.sql.tispark.TiRowRDD$$anon$1.next(TiRowRDD.scala:74)
[2020-04-28T19:49:49.605Z] 	at org.apache.spark.sql.tispark.TiRowRDD$$anon$1.next(TiRowRDD.scala:51)
[2020-04-28T19:49:49.605Z] 	at org.apache.spark.sql.catalyst.expressions.GeneratedClass$GeneratedIteratorForCodegenStage1.coprocessorrdd_nextBatch_0$(Unknown Source)
[2020-04-28T19:49:49.605Z] 	at org.apache.spark.sql.catalyst.expressions.GeneratedClass$GeneratedIteratorForCodegenStage1.processNext(Unknown Source)
[2020-04-28T19:49:49.605Z] 	at org.apache.spark.sql.execution.BufferedRowIterator.hasNext(BufferedRowIterator.java:43)
[2020-04-28T19:49:49.605Z] 	at org.apache.spark.sql.execution.WholeStageCodegenExec$$anonfun$13$$anon$1.hasNext(WholeStageCodegenExec.scala:636)
[2020-04-28T19:49:49.605Z] 	at scala.collection.Iterator$$anon$11.hasNext(Iterator.scala:409)
[2020-04-28T19:49:49.605Z] 	at scala.collection.Iterator$$anon$11.hasNext(Iterator.scala:409)
[2020-04-28T19:49:49.605Z] 	at org.apache.spark.util.random.SamplingUtils$.reservoirSampleAndCount(SamplingUtils.scala:57)
[2020-04-28T19:49:49.605Z] 	at org.apache.spark.RangePartitioner$$anonfun$13.apply(Partitioner.scala:306)
[2020-04-28T19:49:49.605Z] 	at org.apache.spark.RangePartitioner$$anonfun$13.apply(Partitioner.scala:304)
[2020-04-28T19:49:49.605Z] 	at org.apache.spark.rdd.RDD$$anonfun$mapPartitionsWithIndex$1$$anonfun$apply$25.apply(RDD.scala:853)
[2020-04-28T19:49:49.605Z] 	at org.apache.spark.rdd.RDD$$anonfun$mapPartitionsWithIndex$1$$anonfun$apply$25.apply(RDD.scala:853)
[2020-04-28T19:49:49.605Z] 	at org.apache.spark.rdd.MapPartitionsRDD.compute(MapPartitionsRDD.scala:52)
[2020-04-28T19:49:49.605Z] 	at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:324)
[2020-04-28T19:49:49.605Z] 	at org.apache.spark.rdd.RDD.iterator(RDD.scala:288)
[2020-04-28T19:49:49.605Z] 	at org.apache.spark.scheduler.ResultTask.runTask(ResultTask.scala:90)
[2020-04-28T19:49:49.605Z] 	at org.apache.spark.scheduler.Task.run(Task.scala:123)
[2020-04-28T19:49:49.605Z] 	at org.apache.spark.executor.Executor$TaskRunner$$anonfun$10.apply(Executor.scala:408)
[2020-04-28T19:49:49.605Z] 	at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:1360)
[2020-04-28T19:49:49.605Z] 	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:414)
[2020-04-28T19:49:49.605Z] 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
[2020-04-28T19:49:49.605Z] 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
[2020-04-28T19:49:49.605Z] 	at java.lang.Thread.run(Thread.java:748)
[2020-04-28T19:49:49.605Z] Caused by: java.util.concurrent.ExecutionException: com.pingcap.tikv.exception.RegionTaskException: Handle region task failed:
[2020-04-28T19:49:49.605Z] 	at java.util.concurrent.FutureTask.report(FutureTask.java:122)
[2020-04-28T19:49:49.605Z] 	at java.util.concurrent.FutureTask.get(FutureTask.java:192)
[2020-04-28T19:49:49.605Z] 	at com.pingcap.tikv.operation.iterator.DAGIterator.doReadNextRegionChunks(DAGIterator.java:168)
[2020-04-28T19:49:49.605Z] 	... 28 more
```

### What is changed and how it works?
decrease test data size

