### PR TITLE
BatchWrite: fix split index

### DIFF
--- a/core/src/main/scala/com/pingcap/tispark/TiBatchWrite.scala
+++ b/core/src/main/scala/com/pingcap/tispark/TiBatchWrite.scala
@@ -15,6 +15,7 @@
 
 package com.pingcap.tispark
 
+import java.sql.SQLException
 import java.util
 
 import com.pingcap.tikv.allocator.RowIDAllocator
@@ -847,8 +848,20 @@ class TiBatchWrite(@transient val df: DataFrame,
       val indices = tiTableInfo.getIndices.asScala
 
       indices.foreach { index =>
-        val rdd = wrappedEncodedRdd.filter(_.indexId == index.getId)
+        val colName = index.getIndexColumns.get(0).getName
+        val tiColumn = tiTableInfo.getColumn(colName)
+        val colOffset = tiColumn.getOffset
+        val dataType = tiColumn.getType
 
+        val ordering = new Ordering[WrappedEncodedRow] {
+          override def compare(x: WrappedEncodedRow, y: WrappedEncodedRow): Int = {
+            val xIndex = x.row.get(colOffset, dataType)
+            val yIndex = y.row.get(colOffset, dataType)
+            xIndex.toString.compare(yIndex.toString)
+          }
+        }
+
+        val rdd = wrappedEncodedRdd.filter(_.indexId == index.getId)
         val regionSplitNum = if (options.regionSplitNum != 0) {
           options.regionSplitNum
         } else {
@@ -857,22 +870,31 @@ class TiBatchWrite(@transient val df: DataFrame,
 
         // region split
         if (regionSplitNum > 1) {
-          val minHandle = rdd.min().handle
-          val maxHandle = rdd.max().handle
-          if (checkTidbRegionSplitContidion(minHandle, maxHandle, regionSplitNum) || options.regionSplitNum != 0) {
-            logger.info("region split num=" + regionSplitNum + " index name=" + index.getName)
+          val minIndexValue = rdd.min()(ordering).row.get(colOffset, dataType).toString
+          val maxIndexValue = rdd.max()(ordering).row.get(colOffset, dataType).toString
+          logger.info(
+            s"index region split, regionSplitNum=$regionSplitNum, indexName=${index.getName}"
+          )
+          try {
             tiDBJDBCClient
               .splitIndexRegion(
                 options.database,
                 options.table,
                 index.getName,
-                minHandle,
-                maxHandle,
+                minIndexValue,
+                maxIndexValue,
                 regionSplitNum
               )
-          } else {
-            logger.warn("region split is skipped")
+          } catch {
+            case e: SQLException =>
+              if (options.isTest) {
+                throw e
+              }
           }
+        } else {
+          logger.warn(
+            s"skip index split index, regionSplitNum=$regionSplitNum, indexName=${index.getName}"
+          )
         }
       }
     }
@@ -884,14 +906,21 @@ class TiBatchWrite(@transient val df: DataFrame,
   private def splitTableRegion(wrappedRowRdd: RDD[WrappedEncodedRow]): Unit = {
     if (options.enableRegionSplit && isEnableSplitRegion) {
       if (options.regionSplitNum != 0) {
-        tiDBJDBCClient
-          .splitTableRegion(
-            options.database,
-            options.table,
-            0,
-            Int.MaxValue,
-            options.regionSplitNum
-          )
+        try {
+          tiDBJDBCClient
+            .splitTableRegion(
+              options.database,
+              options.table,
+              0,
+              Int.MaxValue,
+              options.regionSplitNum
+            )
+        } catch {
+          case e: SQLException =>
+            if (options.isTest) {
+              throw e
+            }
+        }
       } else {
         val regionSplitNum = if (options.regionSplitNum != 0) {
           options.regionSplitNum
@@ -903,18 +932,24 @@ class TiBatchWrite(@transient val df: DataFrame,
           val minHandle = wrappedRowRdd.min().handle
           val maxHandle = wrappedRowRdd.max().handle
           if (checkTidbRegionSplitContidion(minHandle, maxHandle, regionSplitNum)) {
-            logger.info("region split is enabled.")
-            logger.info("region split num is " + regionSplitNum)
-            tiDBJDBCClient
-              .splitTableRegion(
-                options.database,
-                options.table,
-                minHandle,
-                maxHandle,
-                regionSplitNum
-              )
+            logger.info(s"table region split is enabled, regionSplitNum=$regionSplitNum")
+            try {
+              tiDBJDBCClient
+                .splitTableRegion(
+                  options.database,
+                  options.table,
+                  minHandle,
+                  maxHandle,
+                  regionSplitNum
+                )
+            } catch {
+              case e: SQLException =>
+                if (options.isTest) {
+                  throw e
+                }
+            }
           } else {
-            logger.warn("region split is skipped")
+            logger.warn("table region split is skipped")
           }
         }
       }

--- a/core/src/main/scala/com/pingcap/tispark/TiDBOptions.scala
+++ b/core/src/main/scala/com/pingcap/tispark/TiDBOptions.scala
@@ -80,6 +80,8 @@ class TiDBOptions(@transient val parameters: CaseInsensitiveMap[String]) extends
   val sleepAfterPrewritePrimaryKey: Long =
     parameters.getOrElse(TIDB_SLEEP_AFTER_PREWRITE_PRIMARY_KEY, "0").toLong
 
+  val isTest: Boolean = parameters.getOrElse(TIDB_IS_TEST, "false").toBoolean
+
   // ------------------------------------------------------------
   // Calculated parameters
   // ------------------------------------------------------------
@@ -157,4 +159,5 @@ object TiDBOptions {
   // parameters only for test
   // ------------------------------------------------------------
   val TIDB_SLEEP_AFTER_PREWRITE_PRIMARY_KEY: String = newOption("sleepAfterPrewritePrimaryKey")
+  val TIDB_IS_TEST: String = newOption("isTest")
 }

--- a/core/src/test/scala/com/pingcap/tispark/TiBatchWriteSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/TiBatchWriteSuite.scala
@@ -61,7 +61,7 @@ class TiBatchWriteSuite extends BaseTiSparkTest {
         df,
         ti,
         new TiDBOptions(
-          tidbOptions + ("database" -> s"$database", "table" -> tableToWrite)
+          tidbOptions + ("database" -> s"$database", "table" -> tableToWrite, "isTest" -> "true")
         )
       )
 
@@ -91,7 +91,7 @@ class TiBatchWriteSuite extends BaseTiSparkTest {
         df,
         ti,
         new TiDBOptions(
-          tidbOptions + ("database" -> s"$dbPrefix$database", "table" -> s"${batchWriteTablePrefix}_TABLE_NOT_EXISTS")
+          tidbOptions + ("database" -> s"$dbPrefix$database", "table" -> s"${batchWriteTablePrefix}_TABLE_NOT_EXISTS", "isTest" -> "true")
         )
       )
     }

--- a/core/src/test/scala/com/pingcap/tispark/index/LineItemSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/index/LineItemSuite.scala
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2019 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pingcap.tispark.index
+
+import com.pingcap.tispark.{TiBatchWrite, TiDBOptions}
+import org.apache.spark.sql.BaseTiSparkTest
+
+class LineItemSuite extends BaseTiSparkTest {
+
+  private var database: String = _
+
+  private val table = "LINEITEM"
+
+  private val limit = 30000
+
+  private val batchWriteTablePrefix = "BATCH.WRITE"
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    database = tpchDBName
+    setCurrentDatabase(database)
+    val tableToWrite = s"${batchWriteTablePrefix}_$table"
+    tidbStmt.execute(s"drop table if exists `$tableToWrite`")
+    tidbStmt.execute(s"create table if not exists `$tableToWrite` like $table ")
+  }
+
+  test("ti batch write: lineitem") {
+    logDebug(s"start test table [$table]")
+
+    val tableToWrite = s"${batchWriteTablePrefix}_$table"
+
+    // select
+    refreshConnections(TestTables(database, tableToWrite))
+    val df = sql(s"select * from $table limit $limit")
+
+    // batch write
+    TiBatchWrite.writeToTiDB(
+      df,
+      ti,
+      new TiDBOptions(
+        tidbOptions + ("database" -> s"$database", "table" -> tableToWrite, "isTest" -> "true")
+      )
+    )
+
+    // refresh
+    refreshConnections(TestTables(database, tableToWrite))
+    setCurrentDatabase(database)
+
+    // select
+    queryTiDBViaJDBC(s"select * from `$tableToWrite`")
+
+    // assert
+    // cannot use count since batch write is not support index writing yet.
+    val count = queryViaTiSpark(s"select * from `$tableToWrite`").length
+      .asInstanceOf[Long]
+    assert(count == limit)
+  }
+
+  override def afterAll(): Unit =
+    try {
+      setCurrentDatabase(database)
+      val tableToWrite = s"${batchWriteTablePrefix}_$table"
+      tidbStmt.execute(s"drop table if exists `$tableToWrite`")
+
+    } finally {
+      super.afterAll()
+    }
+}

--- a/core/src/test/scala/org/apache/spark/sql/test/SharedSQLContext.scala
+++ b/core/src/test/scala/org/apache/spark/sql/test/SharedSQLContext.scala
@@ -482,7 +482,8 @@ object SharedSQLContext extends Logging {
       TiDB_PASSWORD -> tidbPassword,
       TiDB_PORT -> s"$tidbPort",
       TiDB_USER -> tidbUser,
-      PD_ADDRESSES -> pdAddresses
+      PD_ADDRESSES -> pdAddresses,
+      "isTest" -> "true"
     )
   }
 }

--- a/tikv-client/src/main/java/com/pingcap/tikv/TiDBJDBCClient.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/TiDBJDBCClient.java
@@ -100,10 +100,18 @@ public class TiDBJDBCClient implements AutoCloseable {
     return (Boolean) splitTable;
   }
 
-  // SPLIT TABLE table_name [INDEX index_name] BETWEEN (lower_value) AND (upper_value) REGIONS
-  // region_num
+  /**
+   * split table region by calling tidb jdbc command `SPLIT TABLE`, e.g. SPLIT TABLE table_name
+   * BETWEEN (lower_value) AND (upper_value) REGIONS 9
+   *
+   * @param dbName database name in tidb
+   * @param tblName table name in tidb
+   * @param minVal min value
+   * @param maxVal max value
+   * @param regionNum number of regions to split
+   */
   public void splitTableRegion(
-      String dbName, String tblName, long minVal, long maxVal, long regionNum) {
+      String dbName, String tblName, long minVal, long maxVal, long regionNum) throws SQLException {
     try (Statement tidbStmt = connection.createStatement()) {
       String sql =
           String.format(
@@ -111,87 +119,41 @@ public class TiDBJDBCClient implements AutoCloseable {
               dbName, tblName, minVal, maxVal, regionNum);
       logger.info("split table region: " + sql);
       tidbStmt.execute(sql);
-    } catch (Exception ignored) {
-      logger.warn("failed to split table region");
+    } catch (SQLException e) {
+      logger.warn("failed to split table region", e);
+      throw e;
     }
   }
 
   /**
    * split index region by calling tidb jdbc command `SPLIT TABLE`, e.g. SPLIT TABLE t INDEX idx
-   * BETWEEN (-9223372036854775808) AND (9223372036854775807) REGIONS 16;
+   * BETWEEN ("2010-01-01 00:00:00") AND ("2020-01-01 00:00:00") REGIONS 16;
    *
    * @param dbName database name in tidb
    * @param tblName table name in tidb
    * @param idxName index name in table
-   * @param minVal min value
-   * @param maxVal max value
+   * @param minIndexVal min index value
+   * @param maxIndexVal max index value
    * @param regionNum number of regions to split
    */
   public void splitIndexRegion(
-      String dbName, String tblName, String idxName, long minVal, long maxVal, long regionNum) {
+      String dbName,
+      String tblName,
+      String idxName,
+      String minIndexVal,
+      String maxIndexVal,
+      long regionNum)
+      throws SQLException {
     try (Statement tidbStmt = connection.createStatement()) {
       String sql =
           String.format(
-              "split table `%s`.`%s` index %s between (%d) and (%d) regions %d",
-              dbName, tblName, idxName, minVal, maxVal, regionNum);
+              "split table `%s`.`%s` index %s between (\"%s\") and (\"%s\") regions %d",
+              dbName, tblName, idxName, minIndexVal, maxIndexVal, regionNum);
       logger.info("split index region: " + sql);
       tidbStmt.execute(sql);
-    } catch (Exception ignored) {
-      logger.warn("failed to split index region", ignored);
-    }
-  }
-
-  /**
-   * split index region by calling tidb jdbc command `SPLIT TABLE`, e.g. SPLIT TABLE t1 INDEX idx4
-   * by ("a", "2000-01-01 00:00:01"), ("b", "2019-04-17 14:26:19"), ("c", ""); if you have a table
-   * t1 and index idx4.
-   *
-   * @param dbName database name in tidb
-   * @param tblName table name in tidb
-   * @param idxName index name in table
-   * @param splitPoints represents the index column's value.
-   * @return
-   */
-  public void splitIndexRegion(
-      String dbName, String tblName, String idxName, List<List<String>> splitPoints) {
-
-    if (splitPoints.isEmpty()) {
-      return;
-    }
-    StringBuilder sb = new StringBuilder();
-    sb.append("split table ")
-        .append("`")
-        .append(dbName)
-        .append("`.`")
-        .append(tblName)
-        .append("`")
-        .append(" index ")
-        .append(idxName)
-        .append(" by");
-
-    for (int i = 0; i < splitPoints.size(); i++) {
-      List<String> splitPoint = splitPoints.get(i);
-      StringBuilder splitPointStr = new StringBuilder("(");
-      for (int j = 0; j < splitPoint.size(); j++) {
-        splitPointStr.append("\"");
-        splitPointStr.append(splitPoint.get(j));
-        if (j < splitPoint.size() - 1) {
-          splitPointStr.append(",");
-        }
-        splitPointStr.append("\"");
-      }
-      splitPointStr.append(")");
-      sb.append(splitPointStr);
-
-      if (i < splitPoints.size() - 1) {
-        sb.append(",");
-      }
-    }
-
-    try (Statement tidbStmt = connection.createStatement()) {
-      tidbStmt.execute(sb.toString());
-    } catch (Exception ignored) {
-      logger.warn("failed to split index region", ignored);
+    } catch (SQLException e) {
+      logger.warn("failed to split index region", e);
+      throw e;
     }
   }
 


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

```
20/04/21 15:33:57 INFO TiDBJDBCClient: split index region: split table `tpch_test`.`BATCH.WRITE_LINEITEM` index idx_ship_date between (0) and (233906) regions 9
20/04/21 15:33:58 WARN TiDBJDBCClient: failed to split index region
com.mysql.jdbc.MysqlDataTruncation: Data truncation: Incorrect datetime value: '2023-39-6'
```

### What is changed and how it works?
use values on `index column` instead of `handler`

https://pingcap.com/docs-cn/stable/reference/sql/statements/split-region/#split-index-region

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - UnitTest

