### PR TITLE
BatchWrite: use snapshot.batchGet instead of snapshot.get

### DIFF
--- a/core/src/main/scala/com/pingcap/tispark/TiDBOptions.scala
+++ b/core/src/main/scala/com/pingcap/tispark/TiDBOptions.scala
@@ -77,6 +77,8 @@ class TiDBOptions(@transient val parameters: CaseInsensitiveMap[String]) extends
   // ttlMode = { "FIXED", "UPDATE", "DEFAULT" }
   val ttlMode: String = parameters.getOrElse(TIDB_TTL_MODE, "DEFAULT").toUpperCase()
 
+  val snapshotBatchGetSize: Int = parameters.getOrElse(TIDB_SNAPSHOT_BATCH_GET_SIZE, "2048").toInt
+
   val sleepAfterPrewritePrimaryKey: Long =
     parameters.getOrElse(TIDB_SLEEP_AFTER_PREWRITE_PRIMARY_KEY, "0").toLong
 
@@ -154,6 +156,7 @@ object TiDBOptions {
   val TIDB_LOCK_TTL_SECONDS: String = newOption("lockTTLSeconds")
   val TIDB_WRITE_CONCURRENCY: String = newOption("writeConcurrency")
   val TIDB_TTL_MODE: String = newOption("ttlMode")
+  val TIDB_SNAPSHOT_BATCH_GET_SIZE: String = newOption("snapshotBatchGetSize")
 
   // ------------------------------------------------------------
   // parameters only for test

--- a/core/src/test/scala/com/pingcap/tispark/TiBatchWriteSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/TiBatchWriteSuite.scala
@@ -34,6 +34,9 @@ class TiBatchWriteSuite extends BaseTiSparkTest {
       Nil
 
   private val batchWriteTablePrefix = "BATCH.WRITE"
+  private val isPkHandlePrefix = "isPkHandle"
+  private val replacePKHandlePrefix = "replacePKHandle"
+  private val replaceUniquePrefix = "replaceUnique"
 
   override def beforeAll(): Unit = {
     super.beforeAll()
@@ -65,19 +68,462 @@ class TiBatchWriteSuite extends BaseTiSparkTest {
         )
       )
 
-      // refresh
-      refreshConnections(TestTables(database, tableToWrite))
-      setCurrentDatabase(database)
-
       // select
       queryTiDBViaJDBC(s"select * from `$tableToWrite`")
 
       // assert
-      val originCount = queryViaTiSpark(s"select count(*) from $table").head.head.asInstanceOf[Long]
-      // cannot use count since batch write is not support index writing yet.
-      val count = queryViaTiSpark(s"select * from `$tableToWrite`").length
-        .asInstanceOf[Long]
+      val originCount =
+        queryTiDBViaJDBC(s"select count(*) from $table").head.head.asInstanceOf[Long]
+      val count =
+        queryTiDBViaJDBC(s"select count(*) from `$tableToWrite`").head.head.asInstanceOf[Long]
       assert(count == originCount)
+    }
+  }
+
+  test("ti batch write: isPkHandle") {
+    for (table <- tables) {
+      logDebug(s"start test table [$table]")
+      val tableToWrite = s"${batchWriteTablePrefix}_${isPkHandlePrefix}_$table"
+      tidbStmt.execute(s"drop table if exists `$tableToWrite`")
+      val (createTableSQL, selectColumns) = table match {
+        case "CUSTOMER" =>
+          (
+            s"""
+               |CREATE TABLE `$tableToWrite` (
+               |  `C_CUSTKEY` int(11) NOT NULL,
+               |  `C_NAME` varchar(25) NOT NULL,
+               |  `C_ADDRESS` varchar(40) NOT NULL,
+               |  `C_NATIONKEY` int(11) NOT NULL,
+               |  `C_PHONE` char(15) NOT NULL,
+               |  `C_ACCTBAL` decimal(15,2) NOT NULL,
+               |  `C_MKTSEGMENT` char(10) NOT NULL,
+               |  `C_COMMENT` varchar(117) NOT NULL,
+               |  PRIMARY KEY(`C_CUSTKEY`)
+               |)
+        """.stripMargin,
+            "C_CUSTKEY, C_NAME, C_ADDRESS, C_NATIONKEY, C_PHONE, C_ACCTBAL, C_MKTSEGMENT, C_COMMENT"
+          )
+        case "NATION" => (s"""
+                             |CREATE TABLE `$tableToWrite` (
+                             |  `N_NATIONKEY` int(11) NOT NULL,
+                             |  `N_NAME` char(25) NOT NULL,
+                             |  `N_REGIONKEY` int(11) NOT NULL,
+                             |  `N_COMMENT` varchar(152) DEFAULT NULL,
+                             |  PRIMARY KEY (`N_NATIONKEY`)
+                             |)
+           """.stripMargin, "N_NATIONKEY, N_NAME, N_REGIONKEY, N_COMMENT")
+        case "ORDERS" =>
+          (
+            s"""
+               |CREATE TABLE `$tableToWrite` (
+               |  `O_ORDERKEY` int(11) NOT NULL,
+               |  `O_CUSTKEY` int(11) NOT NULL,
+               |  `O_ORDERSTATUS` char(1) NOT NULL,
+               |  `O_TOTALPRICE` decimal(15,2) NOT NULL,
+               |  `O_ORDERDATE` date NOT NULL,
+               |  `O_ORDERPRIORITY` char(15) NOT NULL,
+               |  `O_CLERK` char(15) NOT NULL,
+               |  `O_SHIPPRIORITY` int(11) NOT NULL,
+               |  `O_COMMENT` varchar(79) NOT NULL,
+               |  PRIMARY KEY (`O_ORDERKEY`)
+               |)
+           """.stripMargin,
+            "O_ORDERKEY, O_CUSTKEY, O_ORDERSTATUS, O_TOTALPRICE, O_ORDERDATE, O_ORDERPRIORITY, O_CLERK, O_SHIPPRIORITY, O_COMMENT"
+          )
+        case "PART" =>
+          (
+            s"""
+               |CREATE TABLE `$tableToWrite` (
+               |  `P_PARTKEY` int(11) NOT NULL,
+               |  `P_NAME` varchar(55) NOT NULL,
+               |  `P_MFGR` char(25) NOT NULL,
+               |  `P_BRAND` char(10) NOT NULL,
+               |  `P_TYPE` varchar(25) NOT NULL,
+               |  `P_SIZE` int(11) NOT NULL,
+               |  `P_CONTAINER` char(10) NOT NULL,
+               |  `P_RETAILPRICE` decimal(15,2) NOT NULL,
+               |  `P_COMMENT` varchar(23) NOT NULL,
+               |  PRIMARY KEY (`P_PARTKEY`)
+               |)
+           """.stripMargin,
+            "P_PARTKEY, P_NAME, P_MFGR, P_BRAND, P_TYPE, P_SIZE, P_CONTAINER, P_RETAILPRICE, P_COMMENT"
+          )
+        case "REGION" => (s"""
+                             |CREATE TABLE `$tableToWrite` (
+                             |  `R_REGIONKEY` int(11) NOT NULL,
+                             |  `R_NAME` char(25) NOT NULL,
+                             |  `R_COMMENT` varchar(152) DEFAULT NULL,
+                             |  PRIMARY KEY (`R_REGIONKEY`)
+                             |)
+           """.stripMargin, "R_REGIONKEY, R_NAME, R_COMMENT")
+        case "SUPPLIER" =>
+          (
+            s"""
+               |CREATE TABLE `$tableToWrite` (
+               |  `S_SUPPKEY` int(11) NOT NULL,
+               |  `S_NAME` char(25) NOT NULL,
+               |  `S_ADDRESS` varchar(40) NOT NULL,
+               |  `S_NATIONKEY` int(11) NOT NULL,
+               |  `S_PHONE` char(15) NOT NULL,
+               |  `S_ACCTBAL` decimal(15,2) NOT NULL,
+               |  `S_COMMENT` varchar(101) NOT NULL,
+               |  PRIMARY KEY (`S_SUPPKEY`)
+               |)
+           """.stripMargin,
+            "S_SUPPKEY, S_NAME, S_ADDRESS, S_NATIONKEY, S_PHONE, S_ACCTBAL, S_COMMENT"
+          )
+        case _ => ("", "")
+      }
+
+      if (createTableSQL.isEmpty) {
+        logDebug(s"skip test table [$table]")
+      } else {
+        tidbStmt.execute(createTableSQL)
+        val df = sql(s"select * from $table")
+        TiBatchWrite.writeToTiDB(
+          df,
+          ti,
+          new TiDBOptions(
+            tidbOptions + ("database" -> s"$database", "table" -> tableToWrite, "isTest" -> "true")
+          )
+        )
+
+        queryTiDBViaJDBC(s"select * from `$tableToWrite`")
+
+        val diff = queryTiDBViaJDBC(s"""
+                                       |SELECT $selectColumns
+                                       |FROM (
+                                       |    SELECT $selectColumns FROM `$table`
+                                       |    UNION ALL
+                                       |    SELECT $selectColumns FROM `$tableToWrite`
+                                       |) tbl
+                                       |GROUP BY $selectColumns
+                                       |HAVING count(*) != 2""".stripMargin)
+        assert(diff.isEmpty)
+      }
+    }
+  }
+
+  test("ti batch write: replace + isPkHandle") {
+    for (table <- tables) {
+      logDebug(s"start test table [$table]")
+
+      val tableToWrite = s"${batchWriteTablePrefix}_${replacePKHandlePrefix}_$table"
+      tidbStmt.execute(s"drop table if exists `$tableToWrite`")
+
+      val (createTableSQL, updateColumn, selectColumns, updateSize) = table match {
+        case "CUSTOMER" =>
+          (
+            s"""
+               |CREATE TABLE `$tableToWrite` (
+               |  `C_CUSTKEY` int(11) NOT NULL,
+               |  `C_NAME` varchar(25) NOT NULL,
+               |  `C_ADDRESS` varchar(40) NOT NULL,
+               |  `C_NATIONKEY` int(11) NOT NULL,
+               |  `C_PHONE` char(15) NOT NULL,
+               |  `C_ACCTBAL` decimal(15,2) NOT NULL,
+               |  `C_MKTSEGMENT` char(10) NOT NULL,
+               |  `C_COMMENT` varchar(117) NOT NULL,
+               |  PRIMARY KEY(`C_CUSTKEY`)
+               |)
+        """.stripMargin,
+            "C_NAME",
+            "C_CUSTKEY, C_ADDRESS, C_NATIONKEY, C_PHONE, C_ACCTBAL, C_MKTSEGMENT, C_COMMENT",
+            100
+          )
+        case "NATION" => (s"""
+                             |CREATE TABLE `$tableToWrite` (
+                             |  `N_NATIONKEY` int(11) NOT NULL,
+                             |  `N_NAME` char(25) NOT NULL,
+                             |  `N_REGIONKEY` int(11) NOT NULL,
+                             |  `N_COMMENT` varchar(152) DEFAULT NULL,
+                             |  PRIMARY KEY (`N_NATIONKEY`)
+                             |)
+           """.stripMargin, "N_NAME", "N_NATIONKEY, N_REGIONKEY, N_COMMENT", 10)
+        case "ORDERS" =>
+          (
+            s"""
+               |CREATE TABLE `$tableToWrite` (
+               |  `O_ORDERKEY` int(11) NOT NULL,
+               |  `O_CUSTKEY` int(11) NOT NULL,
+               |  `O_ORDERSTATUS` char(1) NOT NULL,
+               |  `O_TOTALPRICE` decimal(15,2) NOT NULL,
+               |  `O_ORDERDATE` date NOT NULL,
+               |  `O_ORDERPRIORITY` char(15) NOT NULL,
+               |  `O_CLERK` char(15) NOT NULL,
+               |  `O_SHIPPRIORITY` int(11) NOT NULL,
+               |  `O_COMMENT` varchar(100) NOT NULL,
+               |  PRIMARY KEY (`O_ORDERKEY`)
+               |)
+           """.stripMargin,
+            "O_COMMENT",
+            "O_ORDERKEY, O_CUSTKEY, O_ORDERSTATUS, O_TOTALPRICE, O_ORDERDATE, O_ORDERPRIORITY, O_CLERK, O_SHIPPRIORITY",
+            1000
+          )
+        case "PART" =>
+          (
+            s"""
+               |CREATE TABLE `$tableToWrite` (
+               |  `P_PARTKEY` int(11) NOT NULL,
+               |  `P_NAME` varchar(55) NOT NULL,
+               |  `P_MFGR` char(25) NOT NULL,
+               |  `P_BRAND` char(10) NOT NULL,
+               |  `P_TYPE` varchar(25) NOT NULL,
+               |  `P_SIZE` int(11) NOT NULL,
+               |  `P_CONTAINER` char(10) NOT NULL,
+               |  `P_RETAILPRICE` decimal(15,2) NOT NULL,
+               |  `P_COMMENT` varchar(23) NOT NULL,
+               |  PRIMARY KEY (`P_PARTKEY`)
+               |)
+           """.stripMargin,
+            "P_NAME",
+            "P_PARTKEY, P_MFGR, P_BRAND, P_TYPE, P_SIZE, P_CONTAINER, P_RETAILPRICE, P_COMMENT",
+            100
+          )
+        case "REGION" => (s"""
+                             |CREATE TABLE `$tableToWrite` (
+                             |  `R_REGIONKEY` int(11) NOT NULL,
+                             |  `R_NAME` char(25) NOT NULL,
+                             |  `R_COMMENT` varchar(152) DEFAULT NULL,
+                             |  PRIMARY KEY (`R_REGIONKEY`)
+                             |)
+           """.stripMargin, "R_NAME", "R_REGIONKEY, R_COMMENT", 3)
+        case "SUPPLIER" =>
+          (
+            s"""
+               |CREATE TABLE `$tableToWrite` (
+               |  `S_SUPPKEY` int(11) NOT NULL,
+               |  `S_NAME` char(25) NOT NULL,
+               |  `S_ADDRESS` varchar(40) NOT NULL,
+               |  `S_NATIONKEY` int(11) NOT NULL,
+               |  `S_PHONE` char(15) NOT NULL,
+               |  `S_ACCTBAL` decimal(15,2) NOT NULL,
+               |  `S_COMMENT` varchar(101) NOT NULL,
+               |  PRIMARY KEY (`S_SUPPKEY`)
+               |)
+           """.stripMargin,
+            "S_NAME",
+            "S_SUPPKEY, S_ADDRESS, S_NATIONKEY, S_PHONE, S_ACCTBAL, S_COMMENT",
+            5
+          )
+        case _ => ("", "", "", 0)
+      }
+
+      if (createTableSQL.isEmpty) {
+        logDebug(s"skip test table [$table]")
+      } else {
+        tidbStmt.execute(createTableSQL)
+        tidbStmt.execute(s"""insert into `$tableToWrite` select * from `$table`""")
+
+        // select
+        val df = sql(
+          s"""select $selectColumns, CONCAT($updateColumn, "_t") AS $updateColumn from $table limit $updateSize"""
+        )
+
+        // batch write
+        TiBatchWrite.writeToTiDB(
+          df,
+          ti,
+          new TiDBOptions(
+            tidbOptions + ("database" -> s"$database", "table" -> tableToWrite, "replace" -> "true", "isTest" -> "true")
+          )
+        )
+        // select
+        queryTiDBViaJDBC(s"select * from `$tableToWrite`")
+
+        // assert
+        val diff1 = queryTiDBViaJDBC(s"""
+                                        |SELECT $selectColumns
+                                        |FROM (
+                                        |    SELECT $selectColumns FROM `$table`
+                                        |    UNION ALL
+                                        |    SELECT $selectColumns FROM `$tableToWrite`
+                                        |) tbl
+                                        |GROUP BY $selectColumns
+                                        |HAVING count(*) != 2""".stripMargin)
+        assert(diff1.isEmpty)
+
+        // assert
+        val diff2 = queryTiDBViaJDBC(s"""
+                                        |SELECT $selectColumns, $updateColumn
+                                        |FROM (
+                                        |    SELECT $selectColumns, $updateColumn FROM `$table`
+                                        |    UNION ALL
+                                        |    SELECT $selectColumns, $updateColumn FROM `$tableToWrite`
+                                        |) tbl
+                                        |GROUP BY $selectColumns, $updateColumn
+                                        |HAVING count(*) != 2""".stripMargin)
+        assert(diff2.nonEmpty)
+        assert(diff2.size == updateSize * 2)
+
+        val originCount =
+          queryTiDBViaJDBC(s"select count(*) from $table").head.head.asInstanceOf[Long]
+        val count =
+          queryTiDBViaJDBC(s"select count(*) from `$tableToWrite`").head.head.asInstanceOf[Long]
+        assert(count == originCount)
+      }
+    }
+  }
+
+  test("ti batch write: replace + uniqueKey") {
+    for (table <- tables) {
+      logDebug(s"start test table [$table]")
+
+      val tableToWrite = s"${batchWriteTablePrefix}_${replaceUniquePrefix}_$table"
+      tidbStmt.execute(s"drop table if exists `$tableToWrite`")
+
+      val (createTableSQL, updateColumn, selectColumns, updateSize) = table match {
+        case "CUSTOMER" =>
+          (
+            s"""
+               |CREATE TABLE `$tableToWrite` (
+               |  `C_CUSTKEY` int(11) NOT NULL,
+               |  `C_NAME` varchar(25) NOT NULL,
+               |  `C_ADDRESS` varchar(40) NOT NULL,
+               |  `C_NATIONKEY` int(11) NOT NULL,
+               |  `C_PHONE` char(15) NOT NULL,
+               |  `C_ACCTBAL` decimal(15,2) NOT NULL,
+               |  `C_MKTSEGMENT` char(10) NOT NULL,
+               |  `C_COMMENT` varchar(117) NOT NULL,
+               |  UNIQUE KEY `idx_cust_key` (`C_CUSTKEY`)
+               |)
+        """.stripMargin,
+            "C_NAME",
+            "C_CUSTKEY, C_ADDRESS, C_NATIONKEY, C_PHONE, C_ACCTBAL, C_MKTSEGMENT, C_COMMENT",
+            100
+          )
+        case "NATION" => (s"""
+                             |CREATE TABLE `$tableToWrite` (
+                             |  `N_NATIONKEY` int(11) NOT NULL,
+                             |  `N_NAME` char(25) NOT NULL,
+                             |  `N_REGIONKEY` int(11) NOT NULL,
+                             |  `N_COMMENT` varchar(152) DEFAULT NULL,
+                             |  PRIMARY KEY (`N_NATIONKEY`)
+                             |)
+           """.stripMargin, "N_NAME", "N_NATIONKEY, N_REGIONKEY, N_COMMENT", 10)
+        case "ORDERS" =>
+          (
+            s"""
+               |CREATE TABLE `$tableToWrite` (
+               |  `O_ORDERKEY` int(11) NOT NULL,
+               |  `O_CUSTKEY` int(11) NOT NULL,
+               |  `O_ORDERSTATUS` char(1) NOT NULL,
+               |  `O_TOTALPRICE` decimal(15,2) NOT NULL,
+               |  `O_ORDERDATE` date NOT NULL,
+               |  `O_ORDERPRIORITY` char(15) NOT NULL,
+               |  `O_CLERK` char(15) NOT NULL,
+               |  `O_SHIPPRIORITY` int(11) NOT NULL,
+               |  `O_COMMENT` varchar(100) NOT NULL,
+               |  UNIQUE KEY `idx_order_key` (`O_ORDERKEY`)
+               |)
+           """.stripMargin,
+            "O_COMMENT",
+            "O_ORDERKEY, O_CUSTKEY, O_ORDERSTATUS, O_TOTALPRICE, O_ORDERDATE, O_ORDERPRIORITY, O_CLERK, O_SHIPPRIORITY",
+            1000
+          )
+        case "PART" =>
+          (
+            s"""
+               |CREATE TABLE `$tableToWrite` (
+               |  `P_PARTKEY` int(11) NOT NULL,
+               |  `P_NAME` varchar(55) NOT NULL,
+               |  `P_MFGR` char(25) NOT NULL,
+               |  `P_BRAND` char(10) NOT NULL,
+               |  `P_TYPE` varchar(25) NOT NULL,
+               |  `P_SIZE` int(11) NOT NULL,
+               |  `P_CONTAINER` char(10) NOT NULL,
+               |  `P_RETAILPRICE` decimal(15,2) NOT NULL,
+               |  `P_COMMENT` varchar(23) NOT NULL,
+               |  UNIQUE KEY `idx_part_key` (`P_PARTKEY`)
+               |)
+           """.stripMargin,
+            "P_NAME",
+            "P_PARTKEY, P_MFGR, P_BRAND, P_TYPE, P_SIZE, P_CONTAINER, P_RETAILPRICE, P_COMMENT",
+            100
+          )
+        case "REGION" => (s"""
+                             |CREATE TABLE `$tableToWrite` (
+                             |  `R_REGIONKEY` int(11) NOT NULL,
+                             |  `R_NAME` char(25) NOT NULL,
+                             |  `R_COMMENT` varchar(152) DEFAULT NULL,
+                             |  UNIQUE KEY `idx_region_key` (`R_REGIONKEY`)
+                             |)
+           """.stripMargin, "R_NAME", "R_REGIONKEY, R_COMMENT", 3)
+        case "SUPPLIER" =>
+          (
+            s"""
+               |CREATE TABLE `$tableToWrite` (
+               |  `S_SUPPKEY` int(11) NOT NULL,
+               |  `S_NAME` char(25) NOT NULL,
+               |  `S_ADDRESS` varchar(40) NOT NULL,
+               |  `S_NATIONKEY` int(11) NOT NULL,
+               |  `S_PHONE` char(15) NOT NULL,
+               |  `S_ACCTBAL` decimal(15,2) NOT NULL,
+               |  `S_COMMENT` varchar(101) NOT NULL,
+               |  UNIQUE KEY `idx_supp_key` (`S_SUPPKEY`)
+               |)
+           """.stripMargin,
+            "S_NAME",
+            "S_SUPPKEY, S_ADDRESS, S_NATIONKEY, S_PHONE, S_ACCTBAL, S_COMMENT",
+            5
+          )
+        case _ => ("", "", "", 0)
+      }
+
+      if (createTableSQL.isEmpty) {
+        logDebug(s"skip test table [$table]")
+      } else {
+        tidbStmt.execute(createTableSQL)
+
+        tidbStmt.execute(s"""insert into `$tableToWrite` select * from `$table`""")
+
+        // select
+        val df = sql(
+          s"""select $selectColumns, CONCAT($updateColumn, "_t") AS $updateColumn from $table limit $updateSize"""
+        )
+
+        // batch write
+        TiBatchWrite.writeToTiDB(
+          df,
+          ti,
+          new TiDBOptions(
+            tidbOptions + ("database" -> s"$database", "table" -> tableToWrite, "replace" -> "true", "isTest" -> "true")
+          )
+        )
+        // select
+        queryTiDBViaJDBC(s"select * from `$tableToWrite`")
+
+        // assert
+        val diff1 = queryTiDBViaJDBC(s"""
+                                        |SELECT $selectColumns
+                                        |FROM (
+                                        |    SELECT $selectColumns FROM `$table`
+                                        |    UNION ALL
+                                        |    SELECT $selectColumns FROM `$tableToWrite`
+                                        |) tbl
+                                        |GROUP BY $selectColumns
+                                        |HAVING count(*) != 2""".stripMargin)
+        assert(diff1.isEmpty)
+
+        // assert
+        val diff2 = queryTiDBViaJDBC(s"""
+                                        |SELECT $selectColumns, $updateColumn
+                                        |FROM (
+                                        |    SELECT $selectColumns, $updateColumn FROM `$table`
+                                        |    UNION ALL
+                                        |    SELECT $selectColumns, $updateColumn FROM `$tableToWrite`
+                                        |) tbl
+                                        |GROUP BY $selectColumns, $updateColumn
+                                        |HAVING count(*) != 2""".stripMargin)
+        assert(diff2.nonEmpty)
+        assert(diff2.size == updateSize * 2)
+
+        val originCount =
+          queryTiDBViaJDBC(s"select count(*) from $table").head.head.asInstanceOf[Long]
+        val count =
+          queryTiDBViaJDBC(s"select count(*) from `$tableToWrite`").head.head.asInstanceOf[Long]
+        assert(count == originCount)
+      }
     }
   }
 
@@ -102,6 +548,21 @@ class TiBatchWriteSuite extends BaseTiSparkTest {
       setCurrentDatabase(database)
       for (table <- tables) {
         val tableToWrite = s"${batchWriteTablePrefix}_$table"
+        tidbStmt.execute(s"drop table if exists `$tableToWrite`")
+      }
+
+      for (table <- tables) {
+        val tableToWrite = s"${batchWriteTablePrefix}_${isPkHandlePrefix}_$table"
+        tidbStmt.execute(s"drop table if exists `$tableToWrite`")
+      }
+
+      for (table <- tables) {
+        val tableToWrite = s"${batchWriteTablePrefix}_${replacePKHandlePrefix}_$table"
+        tidbStmt.execute(s"drop table if exists `$tableToWrite`")
+      }
+
+      for (table <- tables) {
+        val tableToWrite = s"${batchWriteTablePrefix}_${replaceUniquePrefix}_$table"
         tidbStmt.execute(s"drop table if exists `$tableToWrite`")
       }
     } finally {

--- a/core/src/test/scala/com/pingcap/tispark/index/LineItemSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/index/LineItemSuite.scala
@@ -17,6 +17,7 @@ package com.pingcap.tispark.index
 
 import com.pingcap.tispark.{TiBatchWrite, TiDBOptions}
 import org.apache.spark.sql.BaseTiSparkTest
+import org.apache.spark.sql.functions._
 
 class LineItemSuite extends BaseTiSparkTest {
 
@@ -24,9 +25,12 @@ class LineItemSuite extends BaseTiSparkTest {
 
   private val table = "LINEITEM"
 
-  private val limit = 30000
+  private val where = "where L_PARTKEY < 2100000"
 
   private val batchWriteTablePrefix = "BATCH.WRITE"
+  private val isPkHandlePrefix = "isPkHandle"
+  private val replacePKHandlePrefix = "replacePKHandle"
+  private val replaceUniquePrefix = "replaceUnique"
 
   override def beforeAll(): Unit = {
     super.beforeAll()
@@ -38,13 +42,11 @@ class LineItemSuite extends BaseTiSparkTest {
   }
 
   test("ti batch write: lineitem") {
-    logDebug(s"start test table [$table]")
-
     val tableToWrite = s"${batchWriteTablePrefix}_$table"
 
     // select
     refreshConnections(TestTables(database, tableToWrite))
-    val df = sql(s"select * from $table limit $limit")
+    val df = sql(s"select * from $table $where")
 
     // batch write
     TiBatchWrite.writeToTiDB(
@@ -63,19 +65,261 @@ class LineItemSuite extends BaseTiSparkTest {
     queryTiDBViaJDBC(s"select * from `$tableToWrite`")
 
     // assert
-    // cannot use count since batch write is not support index writing yet.
-    val count = queryViaTiSpark(s"select * from `$tableToWrite`").length
-      .asInstanceOf[Long]
-    assert(count == limit)
+    val originCount =
+      queryTiDBViaJDBC(s"select count(*) from $table $where").head.head.asInstanceOf[Long]
+    val count =
+      queryTiDBViaJDBC(s"select count(*) from `$tableToWrite`").head.head.asInstanceOf[Long]
+    assert(count == originCount)
   }
 
-  override def afterAll(): Unit =
+  test("ti batch write: isPkHandle: lineitem") {
+    val tableToWrite = s"${batchWriteTablePrefix}_${isPkHandlePrefix}_$table"
+    tidbStmt.execute(s"drop table if exists `$tableToWrite`")
+    val createTableSQL =
+      s"""
+         |CREATE TABLE `$tableToWrite` (
+         |  `FAKEKEY` bigint(20) not NULL,
+         |  `L_ORDERKEY` int(11) NOT NULL,
+         |  `L_PARTKEY` int(11) NOT NULL,
+         |  `L_SUPPKEY` int(11) NOT NULL,
+         |  `L_LINENUMBER` int(11) NOT NULL,
+         |  `L_QUANTITY` decimal(15,2) NOT NULL,
+         |  `L_EXTENDEDPRICE` decimal(15,2) NOT NULL,
+         |  `L_DISCOUNT` decimal(15,2) NOT NULL,
+         |  `L_TAX` decimal(15,2) NOT NULL,
+         |  `L_RETURNFLAG` char(1) NOT NULL,
+         |  `L_LINESTATUS` char(1) NOT NULL,
+         |  `L_SHIPDATE` date NOT NULL,
+         |  `L_COMMITDATE` date NOT NULL,
+         |  `L_RECEIPTDATE` date NOT NULL,
+         |  `L_SHIPINSTRUCT` char(25) NOT NULL,
+         |  `L_SHIPMODE` char(10) NOT NULL,
+         |  `L_COMMENT` varchar(44) NOT NULL,
+         |  PRIMARY KEY `idx_fake_key` (`FAKEKEY`)
+         |)
+       """.stripMargin
+
+    tidbStmt.execute(createTableSQL)
+    val df = sql(s"select * from $table $where")
+      .withColumn("FAKEKEY", expr("monotonically_increasing_id()"))
+
+    TiBatchWrite.writeToTiDB(
+      df,
+      ti,
+      new TiDBOptions(
+        tidbOptions + ("database" -> s"$database", "table" -> tableToWrite, "isTest" -> "true")
+      )
+    )
+
+    // select
+    queryTiDBViaJDBC(s"select * from `$tableToWrite`")
+
+    // assert
+    val originCount =
+      queryTiDBViaJDBC(s"select count(*) from $table $where").head.head.asInstanceOf[Long]
+    val count =
+      queryTiDBViaJDBC(s"select count(*) from `$tableToWrite`").head.head.asInstanceOf[Long]
+    assert(count == originCount)
+
+    // assert
+    val selectColumns = "L_ORDERKEY, L_PARTKEY, L_SUPPKEY, L_QUANTITY, L_SHIPDATE, L_COMMENT"
+    val diff = queryTiDBViaJDBC(s"""
+                                   |SELECT $selectColumns
+                                   |FROM (
+                                   |    SELECT $selectColumns FROM `$table` $where
+                                   |    UNION ALL
+                                   |    SELECT $selectColumns FROM `$tableToWrite`
+                                   |) tbl
+                                   |GROUP BY $selectColumns
+                                   |HAVING count(*) != 2""".stripMargin)
+    assert(diff.isEmpty)
+  }
+
+  test("ti batch write: replace + isPkHandle: lineitem") {
+    val tableToWrite = s"${batchWriteTablePrefix}_${replacePKHandlePrefix}_$table"
+    tidbStmt.execute(s"drop table if exists `$tableToWrite`")
+    val createTableSQL =
+      s"""
+         |CREATE TABLE `$tableToWrite` (
+         |  `FAKEKEY` bigint(20) not NULL,
+         |  `L_ORDERKEY` int(11) NOT NULL,
+         |  `L_PARTKEY` int(11) NOT NULL,
+         |  `L_SUPPKEY` int(11) NOT NULL,
+         |  `L_LINENUMBER` int(11) NOT NULL,
+         |  `L_QUANTITY` decimal(15,2) NOT NULL,
+         |  `L_EXTENDEDPRICE` decimal(15,2) NOT NULL,
+         |  `L_DISCOUNT` decimal(15,2) NOT NULL,
+         |  `L_TAX` decimal(15,2) NOT NULL,
+         |  `L_RETURNFLAG` char(1) NOT NULL,
+         |  `L_LINESTATUS` char(1) NOT NULL,
+         |  `L_SHIPDATE` date NOT NULL,
+         |  `L_COMMITDATE` date NOT NULL,
+         |  `L_RECEIPTDATE` date NOT NULL,
+         |  `L_SHIPINSTRUCT` char(25) NOT NULL,
+         |  `L_SHIPMODE` char(10) NOT NULL,
+         |  `L_COMMENT` varchar(50) NOT NULL,
+         |  PRIMARY KEY (`FAKEKEY`)
+         |)
+       """.stripMargin
+
+    tidbStmt.execute(createTableSQL)
+    val df1 = sql(s"select * from $table $where")
+      .withColumn("FAKEKEY", expr("monotonically_increasing_id()"))
+    val dfCount1 = df1.count().toInt
+
+    TiBatchWrite.writeToTiDB(
+      df1,
+      ti,
+      new TiDBOptions(
+        tidbOptions + ("database" -> s"$database", "table" -> tableToWrite, "isTest" -> "true")
+      )
+    )
+
+    val tmpView = "lineitem_tempview"
+    df1.createOrReplaceGlobalTempView(tmpView)
+    val dfCount2 = dfCount1 / 2
+    val df2 = sql(
+      s"select FAKEKEY, L_ORDERKEY, L_PARTKEY, L_SUPPKEY, L_LINENUMBER, L_QUANTITY, L_EXTENDEDPRICE, L_DISCOUNT, L_TAX, L_RETURNFLAG, L_LINESTATUS, L_SHIPDATE, L_COMMITDATE, L_RECEIPTDATE, L_SHIPINSTRUCT, L_SHIPMODE, CONCAT(L_COMMENT, '_t') AS L_COMMENT from global_temp.`$tmpView` limit $dfCount2"
+    )
+
+    TiBatchWrite.writeToTiDB(
+      df2,
+      ti,
+      new TiDBOptions(
+        tidbOptions + ("database" -> s"$database", "table" -> tableToWrite, "replace" -> "true", "isTest" -> "true")
+      )
+    )
+
+    // select
+    queryTiDBViaJDBC(s"select * from `$tableToWrite`")
+
+    // assert
+    val originCount =
+      queryTiDBViaJDBC(s"select count(*) from $table $where").head.head.asInstanceOf[Long]
+    val count =
+      queryTiDBViaJDBC(s"select count(*) from `$tableToWrite`").head.head.asInstanceOf[Long]
+    assert(count == originCount)
+
+    // assert
+    val selectColumns = "L_ORDERKEY, L_PARTKEY, L_SUPPKEY, L_QUANTITY, L_SHIPDATE, L_COMMENT"
+    val diff = queryTiDBViaJDBC(s"""
+                                   |SELECT $selectColumns
+                                   |FROM (
+                                   |    SELECT $selectColumns FROM `$table` $where
+                                   |    UNION ALL
+                                   |    SELECT $selectColumns FROM `$tableToWrite`
+                                   |) tbl
+                                   |GROUP BY $selectColumns
+                                   |HAVING count(*) != 2""".stripMargin)
+    assert(diff.size == dfCount2 * 2)
+  }
+
+  test("ti batch write: replace + uniqueKey: lineitem") {
+    val tableToWrite = s"${batchWriteTablePrefix}_${replaceUniquePrefix}_$table"
+    tidbStmt.execute(s"drop table if exists `$tableToWrite`")
+    val createTableSQL =
+      s"""
+         |CREATE TABLE `$tableToWrite` (
+         |  `FAKEKEY` bigint(20) not NULL,
+         |  `L_ORDERKEY` int(11) NOT NULL,
+         |  `L_PARTKEY` int(11) NOT NULL,
+         |  `L_SUPPKEY` int(11) NOT NULL,
+         |  `L_LINENUMBER` int(11) NOT NULL,
+         |  `L_QUANTITY` decimal(15,2) NOT NULL,
+         |  `L_EXTENDEDPRICE` decimal(15,2) NOT NULL,
+         |  `L_DISCOUNT` decimal(15,2) NOT NULL,
+         |  `L_TAX` decimal(15,2) NOT NULL,
+         |  `L_RETURNFLAG` char(1) NOT NULL,
+         |  `L_LINESTATUS` char(1) NOT NULL,
+         |  `L_SHIPDATE` date NOT NULL,
+         |  `L_COMMITDATE` date NOT NULL,
+         |  `L_RECEIPTDATE` date NOT NULL,
+         |  `L_SHIPINSTRUCT` char(25) NOT NULL,
+         |  `L_SHIPMODE` char(10) NOT NULL,
+         |  `L_COMMENT` varchar(50) NOT NULL,
+         |  UNIQUE KEY `idx_fake_key` (`FAKEKEY`)
+         |)
+       """.stripMargin
+
+    tidbStmt.execute(createTableSQL)
+    val df1 = sql(s"select * from $table $where")
+      .withColumn("FAKEKEY", expr("monotonically_increasing_id()"))
+    val dfCount1 = df1.count().toInt
+
+    TiBatchWrite.writeToTiDB(
+      df1,
+      ti,
+      new TiDBOptions(
+        tidbOptions + ("database" -> s"$database", "table" -> tableToWrite, "isTest" -> "true")
+      )
+    )
+
+    val tmpView = "lineitem_tempview"
+    df1.createOrReplaceGlobalTempView(tmpView)
+    val dfCount2 = dfCount1 / 2
+    val df2 = sql(
+      s"select FAKEKEY, L_ORDERKEY, L_PARTKEY, L_SUPPKEY, L_LINENUMBER, L_QUANTITY, L_EXTENDEDPRICE, L_DISCOUNT, L_TAX, L_RETURNFLAG, L_LINESTATUS, L_SHIPDATE, L_COMMITDATE, L_RECEIPTDATE, L_SHIPINSTRUCT, L_SHIPMODE, CONCAT(L_COMMENT, '_t') AS L_COMMENT from global_temp.`$tmpView` limit $dfCount2"
+    )
+
+    TiBatchWrite.writeToTiDB(
+      df2,
+      ti,
+      new TiDBOptions(
+        tidbOptions + ("database" -> s"$database", "table" -> tableToWrite, "replace" -> "true", "isTest" -> "true")
+      )
+    )
+
+    // select
+    queryTiDBViaJDBC(s"select * from `$tableToWrite`")
+
+    // assert
+    val originCount =
+      queryTiDBViaJDBC(s"select count(*) from $table $where").head.head.asInstanceOf[Long]
+    val count =
+      queryTiDBViaJDBC(s"select count(*) from `$tableToWrite`").head.head.asInstanceOf[Long]
+    assert(count == originCount)
+
+    // assert
+    val selectColumns = "L_ORDERKEY, L_PARTKEY, L_SUPPKEY, L_QUANTITY, L_SHIPDATE, L_COMMENT"
+    val diff = queryTiDBViaJDBC(s"""
+                                   |SELECT $selectColumns
+                                   |FROM (
+                                   |    SELECT $selectColumns FROM `$table` $where
+                                   |    UNION ALL
+                                   |    SELECT $selectColumns FROM `$tableToWrite`
+                                   |) tbl
+                                   |GROUP BY $selectColumns
+                                   |HAVING count(*) != 2""".stripMargin)
+    assert(diff.size == dfCount2 * 2)
+  }
+
+  override def afterAll(): Unit = {
     try {
       setCurrentDatabase(database)
-      val tableToWrite = s"${batchWriteTablePrefix}_$table"
-      tidbStmt.execute(s"drop table if exists `$tableToWrite`")
+
+      {
+        val tableToWrite = s"${batchWriteTablePrefix}_$table"
+        tidbStmt.execute(s"drop table if exists `$tableToWrite`")
+      }
+
+      {
+        val tableToWrite = s"${batchWriteTablePrefix}_${isPkHandlePrefix}_$table"
+        tidbStmt.execute(s"drop table if exists `$tableToWrite`")
+      }
+
+      {
+        val tableToWrite = s"${batchWriteTablePrefix}_${replacePKHandlePrefix}_$table"
+        tidbStmt.execute(s"drop table if exists `$tableToWrite`")
+      }
+
+      {
+        val tableToWrite = s"${batchWriteTablePrefix}_${replaceUniquePrefix}_$table"
+        tidbStmt.execute(s"drop table if exists `$tableToWrite`")
+      }
 
     } finally {
       super.afterAll()
     }
+  }
+
 }

--- a/tikv-client/src/main/java/com/pingcap/tikv/Snapshot.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/Snapshot.java
@@ -29,6 +29,7 @@ import com.pingcap.tikv.operation.iterator.IndexScanIterator;
 import com.pingcap.tikv.row.Row;
 import com.pingcap.tikv.util.RangeSplitter;
 import com.pingcap.tikv.util.RangeSplitter.RegionTask;
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import javax.annotation.Nonnull;
@@ -66,6 +67,16 @@ public class Snapshot {
   public ByteString get(ByteString key) {
     return new KVClient(session.getConf(), session.getRegionStoreClientBuilder())
         .get(key, timestamp.getVersion());
+  }
+
+  public List<KvPair> batchGet(List<byte[]> keys) {
+    List<ByteString> list = new ArrayList<>();
+    for (byte[] key : keys) {
+      list.add(ByteString.copyFrom(key));
+    }
+
+    return new KVClient(session.getConf(), session.getRegionStoreClientBuilder())
+        .batchGet(list, timestamp.getVersion());
   }
 
   public Iterator<TiChunk> tableReadChunk(


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
`snapshot.get` is too slow

### What is changed and how it works?
use `snapshot.batchGet` instead of `snapshot.get`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

