### PR TITLE
skip LockResolverTest if tidb's version >= 4.0.0

### DIFF
--- a/tikv-client/src/test/java/com/pingcap/tikv/txn/LockResolverRCTest.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/txn/LockResolverRCTest.java
@@ -39,6 +39,12 @@ public class LockResolverRCTest extends LockResolverTest {
       skipTestInit();
       return;
     }
+
+    if (isTiDBV4()) {
+      skipTestTiDBV4();
+      return;
+    }
+
     session.getConf().setIsolationLevel(IsolationLevel.RC);
     putAlphabet();
     prepareAlphabetLocks();
@@ -52,6 +58,12 @@ public class LockResolverRCTest extends LockResolverTest {
       skipTestInit();
       return;
     }
+
+    if (isTiDBV4()) {
+      skipTestTiDBV4();
+      return;
+    }
+
     TiTimestamp startTs = session.getTimestamp();
     TiTimestamp endTs = session.getTimestamp();
 

--- a/tikv-client/src/test/java/com/pingcap/tikv/txn/LockResolverSITest.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/txn/LockResolverSITest.java
@@ -43,6 +43,12 @@ public class LockResolverSITest extends LockResolverTest {
       skipTestInit();
       return;
     }
+
+    if (isTiDBV4()) {
+      skipTestTiDBV4();
+      return;
+    }
+
     session.getConf().setIsolationLevel(IsolationLevel.SI);
     putAlphabet();
     prepareAlphabetLocks();
@@ -56,6 +62,12 @@ public class LockResolverSITest extends LockResolverTest {
       skipTestInit();
       return;
     }
+
+    if (isTiDBV4()) {
+      skipTestTiDBV4();
+      return;
+    }
+
     for (int i = 0; i < 26; i++) {
       String k = String.valueOf((char) ('a' + i));
       TiTimestamp startTs = session.getTimestamp();
@@ -110,6 +122,12 @@ public class LockResolverSITest extends LockResolverTest {
       skipTestInit();
       return;
     }
+
+    if (isTiDBV4()) {
+      skipTestTiDBV4();
+      return;
+    }
+
     TiTimestamp startTs = session.getTimestamp();
     TiTimestamp endTs = session.getTimestamp();
 

--- a/tikv-client/src/test/java/com/pingcap/tikv/txn/LockResolverSIV3OneRowTest.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/txn/LockResolverSIV3OneRowTest.java
@@ -37,8 +37,13 @@ public class LockResolverSIV3OneRowTest extends LockResolverTest {
       return;
     }
 
-    if (!isV3()) {
-      skipTestV3();
+    if (!isLockResolverClientV3()) {
+      skipTestTiDBV3();
+      return;
+    }
+
+    if (isTiDBV4()) {
+      skipTestTiDBV4();
       return;
     }
 
@@ -66,8 +71,13 @@ public class LockResolverSIV3OneRowTest extends LockResolverTest {
       return;
     }
 
-    if (!isV3()) {
-      skipTestV3();
+    if (!isLockResolverClientV3()) {
+      skipTestTiDBV3();
+      return;
+    }
+
+    if (isTiDBV4()) {
+      skipTestTiDBV4();
       return;
     }
 
@@ -100,8 +110,13 @@ public class LockResolverSIV3OneRowTest extends LockResolverTest {
       return;
     }
 
-    if (!isV3()) {
-      skipTestV3();
+    if (!isLockResolverClientV3()) {
+      skipTestTiDBV3();
+      return;
+    }
+
+    if (isTiDBV4()) {
+      skipTestTiDBV4();
       return;
     }
 

--- a/tikv-client/src/test/java/com/pingcap/tikv/txn/LockResolverSIV3TwoRowTest.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/txn/LockResolverSIV3TwoRowTest.java
@@ -39,8 +39,13 @@ public class LockResolverSIV3TwoRowTest extends LockResolverTest {
       return;
     }
 
-    if (!isV3()) {
-      skipTestV3();
+    if (!isLockResolverClientV3()) {
+      skipTestTiDBV3();
+      return;
+    }
+
+    if (isTiDBV4()) {
+      skipTestTiDBV4();
       return;
     }
 
@@ -74,8 +79,13 @@ public class LockResolverSIV3TwoRowTest extends LockResolverTest {
       return;
     }
 
-    if (!isV3()) {
-      skipTestV3();
+    if (!isLockResolverClientV3()) {
+      skipTestTiDBV3();
+      return;
+    }
+
+    if (isTiDBV4()) {
+      skipTestTiDBV4();
       return;
     }
 
@@ -121,8 +131,13 @@ public class LockResolverSIV3TwoRowTest extends LockResolverTest {
       return;
     }
 
-    if (!isV3()) {
-      skipTestV3();
+    if (!isLockResolverClientV3()) {
+      skipTestTiDBV3();
+      return;
+    }
+
+    if (isTiDBV4()) {
+      skipTestTiDBV4();
       return;
     }
 
@@ -168,8 +183,13 @@ public class LockResolverSIV3TwoRowTest extends LockResolverTest {
       return;
     }
 
-    if (!isV3()) {
-      skipTestV3();
+    if (!isLockResolverClientV3()) {
+      skipTestTiDBV3();
+      return;
+    }
+
+    if (isTiDBV4()) {
+      skipTestTiDBV4();
       return;
     }
 
@@ -212,8 +232,13 @@ public class LockResolverSIV3TwoRowTest extends LockResolverTest {
       return;
     }
 
-    if (!isV3()) {
-      skipTestV3();
+    if (!isLockResolverClientV3()) {
+      skipTestTiDBV3();
+      return;
+    }
+
+    if (isTiDBV4()) {
+      skipTestTiDBV4();
       return;
     }
 

--- a/tikv-client/src/test/java/com/pingcap/tikv/txn/LockResolverTest.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/txn/LockResolverTest.java
@@ -18,6 +18,7 @@ package com.pingcap.tikv.txn;
 import static junit.framework.TestCase.*;
 
 import com.google.protobuf.ByteString;
+import com.pingcap.tikv.StoreVersion;
 import com.pingcap.tikv.TiConfiguration;
 import com.pingcap.tikv.TiSession;
 import com.pingcap.tikv.exception.GrpcException;
@@ -259,8 +260,12 @@ abstract class LockResolverTest {
     logger.warn("Test skipped due to failure in initializing pd client.");
   }
 
-  void skipTestV3() {
-    logger.warn("Test skipped due to version of TiKV is to low.");
+  void skipTestTiDBV3() {
+    logger.warn("Test skipped due to version of TiDB/TiKV is to low.");
+  }
+
+  void skipTestTiDBV4() {
+    logger.warn("Test skipped due to version of TiDB/TiDB is to 4.0.");
   }
 
   void versionTest() {
@@ -352,7 +357,11 @@ abstract class LockResolverTest {
     assertEquals(v.toStringUtf8(), value);
   }
 
-  boolean isV3() {
+  boolean isLockResolverClientV3() {
     return getRegionStoreClient("").lockResolverClient.getVersion().equals("V3");
+  }
+
+  boolean isTiDBV4() {
+    return StoreVersion.minTiKVVersion("4.0.0", session.getPDClient());
   }
 }


### PR DESCRIPTION
cause TiDB-v4.0.0's resolve lock logic is different with TiDB-v3.x, and it's not implemented yet.