### PR TITLE
BatchWrite: add schema version check before commit

### DIFF
--- a/core/src/main/scala/com/pingcap/tispark/TiDBOptions.scala
+++ b/core/src/main/scala/com/pingcap/tispark/TiDBOptions.scala
@@ -70,7 +70,7 @@ class TiDBOptions(@transient val parameters: CaseInsensitiveMap[String]) extends
   val regionSplitNum: Int = parameters.getOrElse(TIDB_REGION_SPLIT_NUM, "0").toInt
 
   val enableRegionSplit: Boolean =
-    parameters.getOrElse(TIDB_ENABLE_REGION_SPLIT, "true").toBoolean
+    parameters.getOrElse(TIDB_ENABLE_REGION_SPLIT, "false").toBoolean
 
   val writeConcurrency: Int = parameters.getOrElse(TIDB_WRITE_CONCURRENCY, "0").toInt
 
@@ -79,11 +79,15 @@ class TiDBOptions(@transient val parameters: CaseInsensitiveMap[String]) extends
 
   val snapshotBatchGetSize: Int = parameters.getOrElse(TIDB_SNAPSHOT_BATCH_GET_SIZE, "2048").toInt
 
+  val useTableLock: Boolean = parameters.getOrElse(TIDB_USE_TABLE_LOCK, "true").toBoolean
+
   val sleepAfterPrewritePrimaryKey: Long =
     parameters.getOrElse(TIDB_SLEEP_AFTER_PREWRITE_PRIMARY_KEY, "0").toLong
 
   val sleepAfterPrewriteSecondaryKey: Long =
     parameters.getOrElse(TIDB_SLEEP_AFTER_PREWRITE_SECONDARY_KEY, "0").toLong
+
+  val sleepAfterGetCommitTS: Long = parameters.getOrElse(TIDB_SLEEP_AFTER_GET_COMMIT_TS, "0").toLong
 
   val isTest: Boolean = parameters.getOrElse(TIDB_IS_TEST, "false").toBoolean
 
@@ -159,6 +163,7 @@ object TiDBOptions {
   val TIDB_WRITE_CONCURRENCY: String = newOption("writeConcurrency")
   val TIDB_TTL_MODE: String = newOption("ttlMode")
   val TIDB_SNAPSHOT_BATCH_GET_SIZE: String = newOption("snapshotBatchGetSize")
+  val TIDB_USE_TABLE_LOCK: String = newOption("useTableLock")
 
   // ------------------------------------------------------------
   // parameters only for test
@@ -167,4 +172,5 @@ object TiDBOptions {
   val TIDB_LOCK_TTL_SECONDS: String = newOption("lockTTLSeconds")
   val TIDB_SLEEP_AFTER_PREWRITE_PRIMARY_KEY: String = newOption("sleepAfterPrewritePrimaryKey")
   val TIDB_SLEEP_AFTER_PREWRITE_SECONDARY_KEY: String = newOption("sleepAfterPrewriteSecondaryKey")
+  val TIDB_SLEEP_AFTER_GET_COMMIT_TS: String = newOption("sleepAfterGetCommitTS")
 }

--- a/core/src/test/scala/com/pingcap/tispark/concurrency/WriteDDLConflictSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/concurrency/WriteDDLConflictSuite.scala
@@ -15,8 +15,12 @@
 
 package com.pingcap.tispark.concurrency
 
+import com.pingcap.tikv.exception.TiBatchWriteException
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.Row
+
 class WriteDDLConflictSuite extends ConcurrentcyTest {
-  test("write ddl conflict using jdbc") {
+  test("write ddl conflict using TableLock") {
     if (!supportBatchWrite) {
       cancel
     }
@@ -36,5 +40,38 @@ class WriteDDLConflictSuite extends ConcurrentcyTest {
       caught.getMessage
         .startsWith("Table 'test_concurrency_write_read' was locked in WRITE LOCAL by server")
     )
+  }
+
+  test("write ddl conflict using SchemaVersionCheck") {
+    if (!supportBatchWrite) {
+      cancel
+    }
+
+    dropTable()
+    jdbcUpdate(s"create table $dbtable(i int, s varchar(128))")
+    jdbcUpdate(s"insert into $dbtable values(4, 'null')")
+
+    new Thread(new Runnable {
+      override def run(): Unit = {
+        Thread.sleep(sleepBeforeQuery)
+        jdbcUpdate(s"alter table $dbtable ADD Email varchar(255)")
+      }
+    }).start()
+
+    val caught = intercept[TiBatchWriteException] {
+      val data: RDD[Row] = sc.makeRDD(List(row1, row2, row3))
+      val df = sqlContext.createDataFrame(data, schema)
+      df.write
+        .format("tidb")
+        .options(tidbOptions)
+        .option("database", database)
+        .option("table", table)
+        .option("sleepAfterPrewriteSecondaryKey", sleepBeforeQuery * 2)
+        .option("useTableLock", "false")
+        .mode("append")
+        .save()
+    }
+
+    assert(caught.getMessage.equals("schema has changed during prewrite!"))
   }
 }

--- a/core/src/test/scala/com/pingcap/tispark/concurrency/WriteDDLNotConflictSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/concurrency/WriteDDLNotConflictSuite.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pingcap.tispark.concurrency
+
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.Row
+
+class WriteDDLNotConflictSuite extends ConcurrentcyTest {
+  test("ddl after GetCommitTS: add column") {
+    doTest(s"alter table $dbtable ADD Email varchar(255)")
+  }
+
+  test("ddl after GetCommitTS: delete column") {
+    doTest(s"alter table $dbtable drop column s")
+  }
+
+  test("ddl after GetCommitTS: rename column") {
+    doTest(s"alter table $dbtable CHANGE s s2 varchar(128)")
+  }
+
+  test("ddl after GetCommitTS: change column type") {
+    doTest(s"alter table $dbtable CHANGE i i BIGINT")
+  }
+
+  private def doTest(ddl: String): Unit = {
+    if (!supportBatchWrite) {
+      cancel
+    }
+
+    dropTable()
+    jdbcUpdate(s"create table $dbtable(i int, s varchar(128))")
+    jdbcUpdate(s"insert into $dbtable values(4, 'null')")
+
+    new Thread(new Runnable {
+      override def run(): Unit = {
+        Thread.sleep(sleepBeforeQuery)
+        jdbcUpdate(ddl)
+      }
+    }).start()
+
+    val data: RDD[Row] = sc.makeRDD(List(row1, row2, row3))
+    val df = sqlContext.createDataFrame(data, schema)
+    df.write
+      .format("tidb")
+      .options(tidbOptions)
+      .option("database", database)
+      .option("table", table)
+      .option("sleepAfterGetCommitTS", sleepBeforeQuery * 2)
+      .option("useTableLock", "false")
+      .mode("append")
+      .save()
+
+    compareSelect()
+  }
+}

--- a/docs/datasource_api_userguide.md
+++ b/docs/datasource_api_userguide.md
@@ -222,11 +222,12 @@ The following table shows the TiDB-specific options, which can be passed in thro
 | database                   | -             | true     | -       | TiDB Database                                                                                                                                  |
 | table                      | -             | true     | -       | TiDB Table                                                                                                                                     |
 | replace                    | -             | false    | false   | To define the behavior of append                                                                                                               |
+| useTableLock               | -             | false    | true    | Whether to lock the table during writing                                                                                                       |
 | skipCommitSecondaryKey     | -             | false    | false   | Whether to skip the commit phase of secondary keys                                                                                             |
 | enableRegionSplit          | -             | false    | true    | To split Region to avoid hot Region during insertion                                                                                           |
 | regionSplitNum             | -             | false    | 0       | The Region split number defined by user during insertion                                                                                       |
 | writeConcurrency           | -             | false    | 0       | The maximum number of threads that write data to TiKV. It is recommended that `writeConcurrency` is smaller than 8 * `number of TiKV instance` |
-| snapshotBatchGetSize       | -             | false    | 2048    | The max size of keys for calling `Snapshot.batchGet`                                                                                               |
+| snapshotBatchGetSize       | -             | false    | 2048    | The max size of keys for calling `Snapshot.batchGet`                                                                                           |
 
 ## TiDB Version and Configuration for Write
 

--- a/tikv-client/src/main/java/com/pingcap/tikv/meta/TiTableInfo.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/meta/TiTableInfo.java
@@ -52,6 +52,8 @@ public class TiTableInfo implements Serializable {
   private final TiColumnInfo primaryKeyColumn;
   private final TiViewInfo viewInfo;
   private final TiFlashReplicaInfo tiflashReplicaInfo;
+  private final long version;
+  private final long updateTimestamp;
 
   @JsonCreator
   @JsonIgnoreProperties(ignoreUnknown = true)
@@ -70,7 +72,9 @@ public class TiTableInfo implements Serializable {
       @JsonProperty("old_schema_id") long oldSchemaId,
       @JsonProperty("partition") TiPartitionInfo partitionInfo,
       @JsonProperty("view") TiViewInfo viewInfo,
-      @JsonProperty("tiflash_replica") TiFlashReplicaInfo tiFlashReplicaInfo) {
+      @JsonProperty("tiflash_replica") TiFlashReplicaInfo tiFlashReplicaInfo,
+      @JsonProperty("version") long version,
+      @JsonProperty("update_timestamp") long updateTimestamp) {
     this.id = id;
     this.name = name.getL();
     this.charset = charset;
@@ -93,6 +97,8 @@ public class TiTableInfo implements Serializable {
     this.partitionInfo = partitionInfo;
     this.viewInfo = viewInfo;
     this.tiflashReplicaInfo = tiFlashReplicaInfo;
+    this.version = version;
+    this.updateTimestamp = updateTimestamp;
 
     TiColumnInfo primaryKey = null;
     for (TiColumnInfo col : this.columns) {
@@ -268,7 +274,9 @@ public class TiTableInfo implements Serializable {
           getOldSchemaId(),
           partitionInfo,
           null,
-          getTiflashReplicaInfo());
+          getTiflashReplicaInfo(),
+          version,
+          updateTimestamp);
     } else {
       return this;
     }
@@ -291,5 +299,13 @@ public class TiTableInfo implements Serializable {
       }
     }
     return false;
+  }
+
+  public long getVersion() {
+    return version;
+  }
+
+  public long getUpdateTimestamp() {
+    return updateTimestamp;
   }
 }

--- a/tikv-client/src/test/java/com/pingcap/tikv/meta/MetaUtils.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/meta/MetaUtils.java
@@ -50,6 +50,8 @@ public class MetaUtils {
     private List<TiIndexInfo> indices = new ArrayList<>();
     private TiPartitionInfo partInfo;
     private Long tid = null;
+    private long version = 0L;
+    private long updateTimestamp = 0L;
 
     public TableBuilder() {}
 
@@ -122,6 +124,11 @@ public class MetaUtils {
       return this;
     }
 
+    public TableBuilder version(long version) {
+      this.version = version;
+      return this;
+    }
+
     public TiTableInfo build() {
       if (tid == null) {
         tid = newId();
@@ -144,7 +151,9 @@ public class MetaUtils {
           0,
           partInfo,
           null,
-          null);
+          null,
+          version,
+          updateTimestamp);
     }
   }
 


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
write should fail if table's schema changed during the process of writing

### What is changed and how it works?
add schema version check before commit

```
schemaVersion1 = getSchemaVersion(startTS)
prewrite
schemaVersion2 = getSchemaVersion(commitTS)
if(schemaVersion1 != schemaVersion2) {
    rollback
} else {
    commit
}
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

