### PR TITLE
BatchWrite: support multi tables

### DIFF
--- a/core/src/main/scala/com/pingcap/tispark/TiDBDataSource.scala
+++ b/core/src/main/scala/com/pingcap/tispark/TiDBDataSource.scala
@@ -16,6 +16,7 @@
 package com.pingcap.tispark
 
 import com.pingcap.tikv.exception.TiBatchWriteException
+import com.pingcap.tispark.write.{TiDBOptions, TiDBWriter}
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql._

--- a/core/src/main/scala/com/pingcap/tispark/TiDBRelation.scala
+++ b/core/src/main/scala/com/pingcap/tispark/TiDBRelation.scala
@@ -20,6 +20,7 @@ import com.pingcap.tikv.exception.{TiBatchWriteException, TiClientInternalExcept
 import com.pingcap.tikv.meta.{TiDAGRequest, TiTableInfo, TiTimestamp}
 import com.pingcap.tispark.utils.ReflectionUtil.newAttributeReference
 import com.pingcap.tispark.utils.TiUtil
+import com.pingcap.tispark.write.{TiDBOptions, TiDBWriter}
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.sources.{BaseRelation, InsertableRelation}

--- a/core/src/main/scala/com/pingcap/tispark/TiDBUtils.scala
+++ b/core/src/main/scala/com/pingcap/tispark/TiDBUtils.scala
@@ -3,6 +3,7 @@ package com.pingcap.tispark
 import java.sql.{Connection, Driver, DriverManager}
 import java.util.Properties
 
+import com.pingcap.tispark.write.TiDBOptions
 import org.apache.spark.sql.execution.datasources.jdbc.{DriverRegistry, DriverWrapper}
 
 import scala.util.Try

--- a/core/src/main/scala/com/pingcap/tispark/write/DBTable.scala
+++ b/core/src/main/scala/com/pingcap/tispark/write/DBTable.scala
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2020 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pingcap.tispark.write
+
+case class DBTable(database: String, table: String) {}

--- a/core/src/main/scala/com/pingcap/tispark/write/EncodedKVPair.scala
+++ b/core/src/main/scala/com/pingcap/tispark/write/EncodedKVPair.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2020 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pingcap.tispark.write
+
+/**
+ * EncodedKVPair is used at last stage if write process.
+ * At this stage, sorting should not be happened anymore.
+ */
+case class EncodedKVPair(encodedKey: SerializableKey, encodedValue: Array[Byte]) {
+  override def hashCode(): Int = encodedKey.hashCode()
+}

--- a/core/src/main/scala/com/pingcap/tispark/write/SerializableKey.scala
+++ b/core/src/main/scala/com/pingcap/tispark/write/SerializableKey.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pingcap.tispark.write
+
+import java.util
+
+import com.pingcap.tikv.codec.KeyUtils
+
+class SerializableKey(val bytes: Array[Byte]) extends Serializable {
+  override def toString: String = KeyUtils.formatBytes(bytes)
+
+  override def equals(that: Any): Boolean =
+    that match {
+      case that: SerializableKey => this.bytes.sameElements(that.bytes)
+      case _                     => false
+    }
+
+  override def hashCode(): Int =
+    util.Arrays.hashCode(bytes)
+}

--- a/core/src/main/scala/com/pingcap/tispark/write/TiBatchWrite.scala
+++ b/core/src/main/scala/com/pingcap/tispark/write/TiBatchWrite.scala
@@ -1,0 +1,350 @@
+/*
+ * Copyright 2019 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pingcap.tispark.write
+
+import com.pingcap.tikv.exception.TiBatchWriteException
+import com.pingcap.tikv.util.{BackOffer, ConcreteBackOffer}
+import com.pingcap.tikv.{TTLManager, TiDBJDBCClient, _}
+import com.pingcap.tispark.utils.TiUtil
+import com.pingcap.tispark.TiDBUtils
+import org.apache.spark.SparkConf
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.analysis.NoSuchTableException
+import org.apache.spark.sql.{DataFrame, TiContext}
+import org.slf4j.LoggerFactory
+
+import scala.collection.JavaConverters._
+
+object TiBatchWrite {
+  // Milliseconds
+  private val MIN_DELAY_CLEAN_TABLE_LOCK = 60000
+  private val DELAY_CLEAN_TABLE_LOCK_AND_COMMIT_BACKOFF_DELTA = 30000
+  private val PRIMARY_KEY_COMMIT_BACKOFF = MIN_DELAY_CLEAN_TABLE_LOCK - DELAY_CLEAN_TABLE_LOCK_AND_COMMIT_BACKOFF_DELTA
+
+  type SparkRow = org.apache.spark.sql.Row
+  type TiRow = com.pingcap.tikv.row.Row
+  type TiDataType = com.pingcap.tikv.types.DataType
+
+  @throws(classOf[NoSuchTableException])
+  @throws(classOf[TiBatchWriteException])
+  def write(df: DataFrame, tiContext: TiContext, options: TiDBOptions): Unit = {
+    val dataToWrite = Map(DBTable(options.database, options.table) -> df)
+    new TiBatchWrite(dataToWrite, tiContext, options).write()
+  }
+
+  @throws(classOf[NoSuchTableException])
+  @throws(classOf[TiBatchWriteException])
+  def write(dataToWrite: Map[DBTable, DataFrame],
+            tiContext: TiContext,
+            parameters: Map[String, String]): Unit = {
+    new TiBatchWrite(
+      dataToWrite,
+      tiContext,
+      new TiDBOptions(parameters ++ Map(TiDBOptions.TIDB_MULTI_TABLES -> "true"))
+    ).write()
+  }
+}
+
+class TiBatchWrite(@transient val dataToWrite: Map[DBTable, DataFrame],
+                   @transient val tiContext: TiContext,
+                   options: TiDBOptions)
+    extends Serializable {
+  private final val logger = LoggerFactory.getLogger(getClass.getName)
+
+  import TiBatchWrite._
+
+  private var tiConf: TiConfiguration = _
+  @transient private var tiSession: TiSession = _
+  private var useTableLock: Boolean = _
+  @transient private var ttlManager: TTLManager = _
+  private var isTTLUpdate: Boolean = _
+  private var lockTTLSeconds: Long = _
+  @transient private var tiDBJDBCClient: TiDBJDBCClient = _
+  @transient private var tiBatchWriteTables: List[TiBatchWriteTable] = _
+
+  private def write(): Unit = {
+    try {
+      doWrite()
+    } finally {
+      close()
+    }
+  }
+
+  private def close(): Unit = {
+    try {
+      if (tiBatchWriteTables != null) {
+        tiBatchWriteTables.foreach(_.unlockTable())
+      }
+    } catch {
+      case _: Throwable =>
+    }
+
+    try {
+      if (ttlManager != null) {
+        ttlManager.close()
+      }
+    } catch {
+      case _: Throwable =>
+    }
+
+    try {
+      if (tiDBJDBCClient != null) {
+        tiDBJDBCClient.close()
+      }
+    } catch {
+      case _: Throwable =>
+    }
+  }
+
+  private def doWrite(): Unit = {
+    // check if write enable
+    if (!tiContext.tiConf.isWriteEnable) {
+      throw new TiBatchWriteException(
+        "tispark batch write is disabled! set spark.tispark.write.enable to enable."
+      )
+    }
+
+    // initialize
+    tiConf = mergeSparkConfWithDataSourceConf(tiContext.conf, options)
+    tiSession = tiContext.tiSession
+    val tikvSupportUpdateTTL = StoreVersion.minTiKVVersion("3.0.5", tiSession.getPDClient)
+    isTTLUpdate = options.isTTLUpdate(tikvSupportUpdateTTL)
+    lockTTLSeconds = options.getLockTTLSeconds(tikvSupportUpdateTTL)
+    tiDBJDBCClient = new TiDBJDBCClient(TiDBUtils.createConnectionFactory(options.url)())
+
+    // init tiBatchWriteTables
+    tiBatchWriteTables = {
+      val isEnableSplitRegion = tiDBJDBCClient.isEnableSplitRegion
+      dataToWrite.map {
+        case (dbTable, df) =>
+          new TiBatchWriteTable(
+            df,
+            tiContext,
+            options.setDBTable(dbTable),
+            tiConf,
+            tiDBJDBCClient,
+            isEnableSplitRegion
+          )
+      }.toList
+    }
+
+    // check unsupported
+    tiBatchWriteTables.foreach(_.checkUnsupported())
+
+    // cache data
+    tiBatchWriteTables.foreach(_.persist())
+
+    // check empty
+    var allEmpty = true
+    tiBatchWriteTables.foreach { table =>
+      if (!table.isDFEmpty()) {
+        allEmpty = false
+      }
+    }
+    if (allEmpty) {
+      logger.warn("data is empty!")
+      return
+    }
+
+    // lock table
+    useTableLock = getUseTableLock()
+    if (useTableLock) {
+      tiBatchWriteTables.foreach(_.lockTable())
+    } else {
+      if (tiContext.tiConf.isWriteWithoutLockTable) {
+        logger.warn("write without lock table enabled! only for test!")
+      } else {
+        throw new TiBatchWriteException("current tidb does not support LockTable or is disabled!")
+      }
+    }
+
+    // check schema
+    tiBatchWriteTables.foreach(_.checkColumnNumbers())
+
+    // get timestamp as start_ts
+    val startTimeStamp = tiSession.getTimestamp
+    val startTs = startTimeStamp.getVersion
+    logger.info(s"startTS: $startTs")
+
+    // pre calculate
+    val shuffledRDD: RDD[(SerializableKey, Array[Byte])] = {
+      val rddList = tiBatchWriteTables.map(_.preCalculate(startTimeStamp))
+      tiContext.sparkSession.sparkContext.union(rddList)
+    }
+
+    // take one row as primary key
+    val (primaryKey: SerializableKey, primaryRow: Array[Byte]) = {
+      val takeOne = shuffledRDD.take(1)
+      if (takeOne.length == 0) {
+        logger.warn("there is no data in source rdd")
+        return
+      } else {
+        takeOne(0)
+      }
+    }
+
+    logger.info(s"primary key: $primaryKey")
+
+    // filter primary key
+    val secondaryKeysRDD = shuffledRDD.filter { keyValue =>
+      !keyValue._1.equals(primaryKey)
+    }
+
+    // driver primary pre-write
+    val ti2PCClient = new TwoPhaseCommitter(tiConf, startTs, lockTTLSeconds * 1000)
+    val prewritePrimaryBackoff =
+      ConcreteBackOffer.newCustomBackOff(BackOffer.BATCH_PREWRITE_BACKOFF)
+    logger.info("start to prewritePrimaryKey")
+    ti2PCClient.prewritePrimaryKey(prewritePrimaryBackoff, primaryKey.bytes, primaryRow)
+    logger.info("prewritePrimaryKey success")
+
+    // for test
+    if (options.sleepAfterPrewritePrimaryKey > 0) {
+      logger.info(s"sleep ${options.sleepAfterPrewritePrimaryKey} ms for test")
+      Thread.sleep(options.sleepAfterPrewritePrimaryKey)
+    }
+
+    // start primary key ttl update
+    if (isTTLUpdate) {
+      ttlManager = new TTLManager(tiConf, startTs, primaryKey.bytes)
+      ttlManager.keepAlive()
+    }
+
+    // executors secondary pre-write
+    logger.info("start to prewriteSecondaryKeys")
+    secondaryKeysRDD.foreachPartition { iterator =>
+      val ti2PCClientOnExecutor =
+        new TwoPhaseCommitter(tiConf, startTs, lockTTLSeconds * 1000)
+
+      val pairs = iterator.map { keyValue =>
+        new TwoPhaseCommitter.BytePairWrapper(
+          keyValue._1.bytes,
+          keyValue._2
+        )
+      }.asJava
+
+      ti2PCClientOnExecutor.prewriteSecondaryKeys(primaryKey.bytes, pairs)
+
+      try {
+        ti2PCClientOnExecutor.close()
+      } catch {
+        case _: Throwable =>
+      }
+    }
+    logger.info("prewriteSecondaryKeys success")
+
+    // for test
+    if (options.sleepAfterPrewriteSecondaryKey > 0) {
+      logger.info(s"sleep ${options.sleepAfterPrewriteSecondaryKey} ms for test")
+      Thread.sleep(options.sleepAfterPrewriteSecondaryKey)
+    }
+
+    // driver primary commit
+    val commitTs = tiSession.getTimestamp.getVersion
+    // check commitTS
+    if (commitTs <= startTs) {
+      throw new TiBatchWriteException(
+        s"invalid transaction tso with startTs=$startTs, commitTs=$commitTs"
+      )
+    }
+
+    // check schema change
+    if (!useTableLock) {
+      tiBatchWriteTables.foreach(_.checkSchemaChange())
+    }
+
+    // for test
+    if (options.sleepAfterGetCommitTS > 0) {
+      logger.info(s"sleep ${options.sleepAfterGetCommitTS} ms for test")
+      Thread.sleep(options.sleepAfterGetCommitTS)
+    }
+
+    val commitPrimaryBackoff = ConcreteBackOffer.newCustomBackOff(PRIMARY_KEY_COMMIT_BACKOFF)
+
+    // check connection lost if using lock table
+    checkConnectionLost()
+
+    logger.info("start to commitPrimaryKey")
+    ti2PCClient.commitPrimaryKey(commitPrimaryBackoff, primaryKey.bytes, commitTs)
+    logger.info("commitPrimaryKey success")
+
+    // stop primary key ttl update
+    if (isTTLUpdate) {
+      ttlManager.close()
+    }
+
+    // unlock table
+    tiBatchWriteTables.foreach(_.unlockTable())
+
+    // executors secondary commit
+    if (!options.skipCommitSecondaryKey) {
+      logger.info("start to commitSecondaryKeys")
+      secondaryKeysRDD.foreachPartition { iterator =>
+        val ti2PCClientOnExecutor = new TwoPhaseCommitter(tiConf, startTs)
+
+        val keys = iterator.map { keyValue =>
+          new TwoPhaseCommitter.ByteWrapper(keyValue._1.bytes)
+        }.asJava
+
+        try {
+          ti2PCClientOnExecutor.commitSecondaryKeys(keys, commitTs)
+        } catch {
+          case e: TiBatchWriteException =>
+            // ignored
+            logger.warn(s"commit secondary key error", e)
+        }
+      }
+      logger.info("commitSecondaryKeys finish")
+    } else {
+      logger.info("skipping commit secondary key")
+    }
+  }
+
+  private def getUseTableLock(): Boolean = {
+    if (!options.useTableLock) {
+      false
+    } else {
+      if (tiDBJDBCClient.isEnableTableLock) {
+        if (tiDBJDBCClient.getDelayCleanTableLock >= MIN_DELAY_CLEAN_TABLE_LOCK) {
+          true
+        } else {
+          logger.warn(
+            s"table lock disabled! to enable table lock, please set tidb config: delay-clean-table-lock >= $MIN_DELAY_CLEAN_TABLE_LOCK"
+          )
+          false
+        }
+      } else {
+        false
+      }
+    }
+  }
+
+  private def mergeSparkConfWithDataSourceConf(conf: SparkConf,
+                                               options: TiDBOptions): TiConfiguration = {
+    val clonedConf = conf.clone()
+    // priority: data source config > spark config
+    clonedConf.setAll(options.parameters)
+    TiUtil.sparkConfToTiConf(clonedConf)
+  }
+
+  private def checkConnectionLost(): Unit = {
+    if (useTableLock) {
+      if (tiDBJDBCClient.isClosed) {
+        throw new TiBatchWriteException("tidb's jdbc connection is lost!")
+      }
+    }
+  }
+}

--- a/core/src/main/scala/com/pingcap/tispark/write/TiDBWriter.scala
+++ b/core/src/main/scala/com/pingcap/tispark/write/TiDBWriter.scala
@@ -1,6 +1,22 @@
-package com.pingcap.tispark
+/*
+ * Copyright 2020 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pingcap.tispark.write
 
 import com.pingcap.tikv.exception.TiBatchWriteException
+import com.pingcap.tispark.TiDBUtils
 import org.apache.spark.sql._
 
 object TiDBWriter {
@@ -20,7 +36,7 @@ object TiDBWriter {
           if (tableExists) {
             saveMode match {
               case SaveMode.Append =>
-                TiBatchWrite.writeToTiDB(df, tiContext, options)
+                TiBatchWrite.write(df, tiContext, options)
 
               case _ =>
                 throw new TiBatchWriteException(

--- a/core/src/main/scala/com/pingcap/tispark/write/TiRegionPartitioner.scala
+++ b/core/src/main/scala/com/pingcap/tispark/write/TiRegionPartitioner.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pingcap.tispark.write
+
+import java.util
+
+import com.pingcap.tikv.key.Key
+import com.pingcap.tikv.region.TiRegion
+import org.apache.spark.Partitioner
+
+class TiRegionPartitioner(regions: util.List[TiRegion], writeConcurrency: Int) extends Partitioner {
+  def binarySearch(key: Key): Int = {
+    if (regions.get(0).contains(key)) {
+      return 0
+    }
+    var l = 0
+    var r = regions.size()
+    while (l < r) {
+      val mid = l + (r - l) / 2
+      val region = regions.get(mid)
+      if (Key.toRawKey(region.getEndKey).compareTo(key) <= 0) {
+        l = mid + 1
+      } else {
+        r = mid
+      }
+    }
+    assert(regions.get(l).contains(key))
+    l
+  }
+
+  override def numPartitions: Int = if (writeConcurrency <= 0) regions.size() else writeConcurrency
+
+  override def getPartition(key: Any): Int = {
+    val serializableKey = key.asInstanceOf[SerializableKey]
+    val rawKey = Key.toRawKey(serializableKey.bytes)
+
+    binarySearch(rawKey) % numPartitions
+  }
+}

--- a/core/src/main/scala/com/pingcap/tispark/write/WrappedEncodedRow.scala
+++ b/core/src/main/scala/com/pingcap/tispark/write/WrappedEncodedRow.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pingcap.tispark.write
+
+import TiBatchWrite.TiRow
+
+case class WrappedEncodedRow(row: TiRow,
+                             handle: Long,
+                             encodedKey: SerializableKey,
+                             encodedValue: Array[Byte],
+                             isIndex: Boolean,
+                             indexId: Long,
+                             remove: Boolean)
+    extends Ordered[WrappedEncodedRow] {
+  override def compare(that: WrappedEncodedRow): Int = this.handle.toInt - that.handle.toInt
+
+  override def hashCode(): Int = encodedKey.hashCode()
+}

--- a/core/src/main/scala/com/pingcap/tispark/write/WrappedRow.scala
+++ b/core/src/main/scala/com/pingcap/tispark/write/WrappedRow.scala
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2020 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pingcap.tispark.write
+
+import TiBatchWrite.TiRow
+
+case class WrappedRow(row: TiRow, handle: Long)

--- a/core/src/test/scala/com/pingcap/tispark/TiBatchWriteSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/TiBatchWriteSuite.scala
@@ -15,6 +15,7 @@
 
 package com.pingcap.tispark
 
+import com.pingcap.tispark.write.{TiBatchWrite, TiDBOptions}
 import org.apache.spark.sql.BaseTiSparkTest
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException
 
@@ -64,7 +65,7 @@ class TiBatchWriteSuite extends BaseTiSparkTest {
       val df = sql(s"select * from $table")
 
       // batch write
-      TiBatchWrite.writeToTiDB(
+      TiBatchWrite.write(
         df,
         ti,
         new TiDBOptions(
@@ -188,7 +189,7 @@ class TiBatchWriteSuite extends BaseTiSparkTest {
       } else {
         tidbStmt.execute(createTableSQL)
         val df = sql(s"select * from $table")
-        TiBatchWrite.writeToTiDB(
+        TiBatchWrite.write(
           df,
           ti,
           new TiDBOptions(
@@ -333,7 +334,7 @@ class TiBatchWriteSuite extends BaseTiSparkTest {
         )
 
         // batch write
-        TiBatchWrite.writeToTiDB(
+        TiBatchWrite.write(
           df,
           ti,
           new TiDBOptions(
@@ -499,7 +500,7 @@ class TiBatchWriteSuite extends BaseTiSparkTest {
         )
 
         // batch write
-        TiBatchWrite.writeToTiDB(
+        TiBatchWrite.write(
           df,
           ti,
           new TiDBOptions(
@@ -553,7 +554,7 @@ class TiBatchWriteSuite extends BaseTiSparkTest {
 
     // batch write
     intercept[NoSuchTableException] {
-      TiBatchWrite.writeToTiDB(
+      TiBatchWrite.write(
         df,
         ti,
         new TiDBOptions(

--- a/core/src/test/scala/com/pingcap/tispark/index/LineItemSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/index/LineItemSuite.scala
@@ -15,7 +15,7 @@
 
 package com.pingcap.tispark.index
 
-import com.pingcap.tispark.{TiBatchWrite, TiDBOptions}
+import com.pingcap.tispark.write.{TiBatchWrite, TiDBOptions}
 import org.apache.spark.sql.BaseTiSparkTest
 import org.apache.spark.sql.functions._
 
@@ -53,7 +53,7 @@ class LineItemSuite extends BaseTiSparkTest {
     val df = sql(s"select * from $table $where")
 
     // batch write
-    TiBatchWrite.writeToTiDB(
+    TiBatchWrite.write(
       df,
       ti,
       new TiDBOptions(
@@ -111,7 +111,7 @@ class LineItemSuite extends BaseTiSparkTest {
     val df = sql(s"select * from $table $where")
       .withColumn("FAKEKEY", expr("monotonically_increasing_id()"))
 
-    TiBatchWrite.writeToTiDB(
+    TiBatchWrite.write(
       df,
       ti,
       new TiDBOptions(
@@ -179,7 +179,7 @@ class LineItemSuite extends BaseTiSparkTest {
       .withColumn("FAKEKEY", expr("monotonically_increasing_id()"))
     val dfCount1 = df1.count().toInt
 
-    TiBatchWrite.writeToTiDB(
+    TiBatchWrite.write(
       df1,
       ti,
       new TiDBOptions(
@@ -194,7 +194,7 @@ class LineItemSuite extends BaseTiSparkTest {
       s"select FAKEKEY, L_ORDERKEY, L_PARTKEY, L_SUPPKEY, L_LINENUMBER, L_QUANTITY, L_EXTENDEDPRICE, L_DISCOUNT, L_TAX, L_RETURNFLAG, L_LINESTATUS, L_SHIPDATE, L_COMMITDATE, L_RECEIPTDATE, L_SHIPINSTRUCT, L_SHIPMODE, CONCAT(L_COMMENT, '_t') AS L_COMMENT from global_temp.`$tmpView` limit $dfCount2"
     )
 
-    TiBatchWrite.writeToTiDB(
+    TiBatchWrite.write(
       df2,
       ti,
       new TiDBOptions(
@@ -262,7 +262,7 @@ class LineItemSuite extends BaseTiSparkTest {
       .withColumn("FAKEKEY", expr("monotonically_increasing_id()"))
     val dfCount1 = df1.count().toInt
 
-    TiBatchWrite.writeToTiDB(
+    TiBatchWrite.write(
       df1,
       ti,
       new TiDBOptions(
@@ -277,7 +277,7 @@ class LineItemSuite extends BaseTiSparkTest {
       s"select FAKEKEY, L_ORDERKEY, L_PARTKEY, L_SUPPKEY, L_LINENUMBER, L_QUANTITY, L_EXTENDEDPRICE, L_DISCOUNT, L_TAX, L_RETURNFLAG, L_LINESTATUS, L_SHIPDATE, L_COMMITDATE, L_RECEIPTDATE, L_SHIPINSTRUCT, L_SHIPMODE, CONCAT(L_COMMENT, '_t') AS L_COMMENT from global_temp.`$tmpView` limit $dfCount2"
     )
 
-    TiBatchWrite.writeToTiDB(
+    TiBatchWrite.write(
       df2,
       ti,
       new TiDBOptions(

--- a/core/src/test/scala/com/pingcap/tispark/multitable/MultiTableWriteSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/multitable/MultiTableWriteSuite.scala
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2019 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pingcap.tispark.multitable
+
+import com.pingcap.tispark.write.{DBTable, TiBatchWrite}
+import org.apache.spark.sql._
+
+class MultiTableWriteSuite extends BaseTiSparkTest {
+
+  private var database: String = _
+
+  private val tables =
+    "CUSTOMER" ::
+      "NATION" ::
+      Nil
+
+  private val batchWriteTablePrefix = "BATCH.WRITE"
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    database = tpchDBName
+    setCurrentDatabase(database)
+    for (table <- tables) {
+      val tableToWrite = s"${batchWriteTablePrefix}_$table"
+      tidbStmt.execute(s"drop table if exists `$tableToWrite`")
+      tidbStmt.execute(s"create table if not exists `$tableToWrite` like $table ")
+    }
+  }
+
+  test("multi table batch write") {
+    if (!supportBatchWrite) {
+      cancel
+    }
+
+    val data = tables.map { table =>
+      val tableToWrite = s"${batchWriteTablePrefix}_$table"
+      val dbTable = new DBTable(database, tableToWrite)
+      val df = sql(s"select * from $table")
+      (dbTable, df)
+    }.toMap
+
+    // multi table batch write
+    TiBatchWrite
+      .write(data, ti, tidbOptions ++ Map("multiTables" -> "true", "isTest" -> "true"))
+
+    for (table <- tables) {
+      val tableToWrite = s"${batchWriteTablePrefix}_$table"
+      // select
+      queryTiDBViaJDBC(s"select * from `$tableToWrite`")
+
+      // assert
+      val originCount =
+        queryTiDBViaJDBC(s"select count(*) from $table").head.head.asInstanceOf[Long]
+      val count =
+        queryTiDBViaJDBC(s"select count(*) from `$tableToWrite`").head.head.asInstanceOf[Long]
+      assert(count == originCount)
+    }
+  }
+
+  override def afterAll(): Unit =
+    try {
+      setCurrentDatabase(database)
+      for (table <- tables) {
+        val tableToWrite = s"${batchWriteTablePrefix}_$table"
+        tidbStmt.execute(s"drop table if exists `$tableToWrite`")
+      }
+    } finally {
+      super.afterAll()
+    }
+}

--- a/docs/datasource_api_userguide.md
+++ b/docs/datasource_api_userguide.md
@@ -37,7 +37,7 @@ In addition, if `replace` is true, data to be inserted is duplicated before the 
     - if the primary key or unique index exists in the database, data with conflicts expects an exception.
     - if no same primary key or unique index exists, data is inserted.
 
-## Use Spark connector with extensions enabled
+## Use Spark connector
 
 The Spark connector adheres to the standard Spark API, but with the addition of TiDB-specific options.
 
@@ -206,6 +206,35 @@ CREATE TABLE CUSTOMER_DST USING tidb OPTIONS (database 'tpch_test', table 'TARGE
 INSERT INTO CUSTOMER_DST VALUES(1000, 'Customer#000001000', 'AnJ5lxtLjioClr2khl9pb8NLxG2', 9, '19-407-425-2584', 2209.81, 'AUTOMOBILE', '. even, express theodolites upo')
 
 INSERT INTO CUSTOMER_DST SELECT * FROM CUSTOMER_SRC
+```
+
+## Writing to Multi-tables
+
+TiDB Connector supports writing data into multi-tables in one transaction using scala/java API.
+
+```
+val inputDatabase = args(0)
+val inputTable1 = args(1)
+val inputTable2 = args(2)
+val outputDatabase = args(3)
+val outputTable1 = args(4)
+val outputTable2 = args(5)
+
+val df1 = spark.sql(s"select * from $inputTable1")
+val df2 = spark.sql(s"select * from $inputTable2")
+
+val data = Map(DBTable(outputDatabase, outputTable1) -> df1, DBTable(outputDatabase, outputTable2) -> df2)
+
+// writing data to multi-tables
+TiBatchWrite.write(
+  data,
+  tiContext,
+  Map(
+    "tidb.addr" -> "172.16.5.59",
+    "tidb.port" -> "9194",
+    "tidb.user"-> "root",
+    "tidb.password" -> "")
+)
 ```
 
 ## TiDB Options


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

close https://github.com/pingcap/tispark/issues/1460

### What is changed and how it works?
TiDB Connector supports writing data into multi-tables in one transaction using scala/java API.

```
val inputDatabase = args(0)
val inputTable1 = args(1)
val inputTable2 = args(2)
val outputDatabase = args(3)
val outputTable1 = args(4)
val outputTable2 = args(5)

val df1 = spark.sql(s"select * from $inputTable1")
val df2 = spark.sql(s"select * from $inputTable2")

val data = Map(
    DBTable(outputDatabase, outputTable1) -> df1, 
    DBTable(outputDatabase, outputTable2) -> df2)

// writing data to multi-tables
TiBatchWrite.write(
  data,
  tiContext,
  Map(
    "tidb.addr" -> "172.16.5.59",
    "tidb.port" -> "9194",
    "tidb.user"-> "root",
    "tidb.password" -> "")
)
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

