### PR TITLE
fix ci error when running in tispark + tiflash mode

### DIFF
--- a/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
@@ -175,6 +175,7 @@ abstract class QueryTest extends SparkFunSuite {
       row.map {
         case null           => "null"
         case a: Array[Byte] => a.mkString("[", ",", "]")
+        case b: Boolean     => if (b) "1" else "0"
         case s              => s.toString
       }.mkString
     }

--- a/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
@@ -187,20 +187,32 @@ abstract class QueryTest extends SparkFunSuite {
       try {
         if (lhs.length != rhs.length) {
           false
-        } else if (!isOrdered) {
-          comp(
-            lhs.sortWith((_1, _2) => sortComp(_1, _2)),
-            rhs.sortWith((_1, _2) => sortComp(_1, _2))
-          )
         } else {
-          implicit object NullableListOrdering extends Ordering[List[Any]] {
-            override def compare(p1: List[Any], p2: List[Any]): Int =
-              p1.contains(null).compareTo(p2.contains(null))
-          }
-          comp(
-            lhs.sortBy[List[Any]](x => x),
-            rhs.sortBy[List[Any]](x => x)
+          // the result order may be different in TiDB and TiSpark, so compare result as follows
+          // 1. compare directly
+          // 2. if 1 fails, use `NullableListOrdering` to sort the result, then compare
+          // 3. if 2 fails and the sql does not contains `order by`, use string compare the sort the result, then compare
+          var result = comp(
+            lhs,
+            rhs
           )
+          if (!result) {
+            implicit object NullableListOrdering extends Ordering[List[Any]] {
+              override def compare(p1: List[Any], p2: List[Any]): Int =
+                p1.contains(null).compareTo(p2.contains(null))
+            }
+            result = comp(
+              lhs.sortBy[List[Any]](x => x),
+              rhs.sortBy[List[Any]](x => x)
+            )
+          }
+          if (!result && !isOrdered) {
+            result = comp(
+              lhs.sortWith((_1, _2) => sortComp(_1, _2)),
+              rhs.sortWith((_1, _2) => sortComp(_1, _2))
+            )
+          }
+          result
         }
       } catch {
         // TODO:Remove this temporary exception handling

--- a/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
@@ -191,7 +191,7 @@ abstract class QueryTest extends SparkFunSuite {
           // the result order may be different in TiDB and TiSpark, so compare result as follows
           // 1. compare directly
           // 2. if 1 fails, use `NullableListOrdering` to sort the result, then compare
-          // 3. if 2 fails and the sql does not contains `order by`, use string compare the sort the result, then compare
+          // 3. if 2 fails and the sql does not contains `order by`, use string based `sortComp` to sort the result, then compare
           var result = comp(
             lhs,
             rhs

--- a/core/src/test/scala/org/apache/spark/sql/test/generator/ColumnValueGenerator.scala
+++ b/core/src/test/scala/org/apache/spark/sql/test/generator/ColumnValueGenerator.scala
@@ -123,10 +123,13 @@ case class ColumnValueGenerator(dataType: ReflectedDataType,
     val list: List[Any] = dataType match {
       case BIT                                                                     => List.empty[Array[Byte]]
       case TINYINT | SMALLINT | MEDIUMINT | INT | BIGINT if !tiDataType.isUnsigned => List(-1L)
-      case TIMESTAMP                                                               => List(new java.sql.Timestamp(1000))
-      case _ if isCharCharset(dataType)                                            => List("")
-      case _ if isBinaryCharset(dataType)                                          => List(Array[Byte]())
-      case _                                                                       => List.empty[String]
+      // todo set the special bound of timestamp to 1970-01-01 08:00:00 to avoid
+      //  TiFlash bug https://internal.pingcap.net/jira/browse/FLASH-1197
+      //  should change it back to 1970-01-01 00:00:01 once Flash-1197 is fixed
+      case TIMESTAMP                      => List(new java.sql.Timestamp(28800000))
+      case _ if isCharCharset(dataType)   => List("")
+      case _ if isBinaryCharset(dataType) => List(Array[Byte]())
+      case _                              => List.empty[String]
     }
     if (lowerBound != null && upperBound != null) {
       list ::: List(lowerBound, upperBound)
@@ -218,7 +221,10 @@ case class ColumnValueGenerator(dataType: ReflectedDataType,
         new java.sql.Date(milliseconds)
       case TIMESTAMP =>
         // start from 1970-01-01 00:00:01 to 2038-01-19 03:14:07
-        val milliseconds = Math.abs(r.nextInt * 1000L + 1000L) + Math.abs(r.nextInt(1000))
+        // todo set the start of timestamp to 1970-01-01 08:00:00 to avoid
+        //  TiFlash bug https://internal.pingcap.net/jira/browse/FLASH-1197
+        //  should change it back to 1970-01-01 00:00:01 once Flash-1197 is fixed
+        val milliseconds = Math.abs(r.nextInt * 1000L + 28800000L) + Math.abs(r.nextInt(1000))
         new java.sql.Timestamp(milliseconds)
       case ENUM => generateRandomEnumValue(r)
       case SET  => generateRandomSetValue(r)

--- a/core/src/test/scala/org/apache/spark/sql/types/MultiColumnDataTypeTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/types/MultiColumnDataTypeTest.scala
@@ -59,9 +59,13 @@ trait MultiColumnDataTypeTest extends BaseTiSparkTest {
                    dataType: ReflectedDataType): Unit = {
     for ((op, value) <- getOperations(dataType)) {
       val query = s"select $col1 from $tableName where $col2 $op $value"
-      test(query) {
-        setCurrentDatabase(dbName)
-        runTest(query, canTestTiFlash = true)
+      if (col1.contains("timestamp0")) {
+        // ignore
+      } else {
+        test(query) {
+          setCurrentDatabase(dbName)
+          runTest(query, canTestTiFlash = true)
+        }
       }
     }
   }

--- a/core/src/test/scala/org/apache/spark/sql/types/MultiColumnDataTypeTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/types/MultiColumnDataTypeTest.scala
@@ -59,7 +59,7 @@ trait MultiColumnDataTypeTest extends BaseTiSparkTest {
                    dataType: ReflectedDataType): Unit = {
     for ((op, value) <- getOperations(dataType)) {
       val query = s"select $col1 from $tableName where $col2 $op $value"
-      if (col1.contains("timestamp0")) {
+      if (col1.contains("timestamp0") || col1.contains("timestamp0")) {
         // ignore
       } else {
         test(query) {

--- a/core/src/test/scala/org/apache/spark/sql/types/MultiColumnDataTypeTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/types/MultiColumnDataTypeTest.scala
@@ -59,13 +59,9 @@ trait MultiColumnDataTypeTest extends BaseTiSparkTest {
                    dataType: ReflectedDataType): Unit = {
     for ((op, value) <- getOperations(dataType)) {
       val query = s"select $col1 from $tableName where $col2 $op $value"
-      if (col1.contains("timestamp0") || col1.contains("timestamp0")) {
-        // ignore
-      } else {
-        test(query) {
-          setCurrentDatabase(dbName)
-          runTest(query, canTestTiFlash = true)
-        }
+      test(query) {
+        setCurrentDatabase(dbName)
+        runTest(query, canTestTiFlash = true)
       }
     }
   }

--- a/core/src/test/scala/org/apache/spark/sql/types/MultiColumnDataTypeTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/types/MultiColumnDataTypeTest.scala
@@ -59,18 +59,9 @@ trait MultiColumnDataTypeTest extends BaseTiSparkTest {
                    dataType: ReflectedDataType): Unit = {
     for ((op, value) <- getOperations(dataType)) {
       val query = s"select $col1 from $tableName where $col2 $op $value"
-      // TODO: revert these ignored tests after they are fixed.
-      if (col1.contains("boolean") || col1.contains("blob0") || col1.contains("date") || col1
-            .contains("bit")) {
-        // ignore
-      } else if (col2.contains("boolean") || col2.contains("blob") || col2.contains("bit") || col2
-                   .contains("binary")) {
-        // ignore
-      } else {
-        test(query) {
-          setCurrentDatabase(dbName)
-          runTest(query, canTestTiFlash = true)
-        }
+      test(query) {
+        setCurrentDatabase(dbName)
+        runTest(query, canTestTiFlash = true)
       }
     }
   }

--- a/tikv-client/src/main/java/com/pingcap/tikv/StoreVersion.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/StoreVersion.java
@@ -34,8 +34,6 @@ public class StoreVersion {
 
   private StoreVersion(String version) {
     try {
-      if (version.startsWith("v"))
-        version = version.substring(1);
       String[] parts = version.split("[.-]");
       if (parts.length > 0) {
         v0 = Integer.parseInt(parts[0]);

--- a/tikv-client/src/main/java/com/pingcap/tikv/StoreVersion.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/StoreVersion.java
@@ -34,6 +34,8 @@ public class StoreVersion {
 
   private StoreVersion(String version) {
     try {
+      if (version.startsWith("v"))
+        version = version.substring(1);
       String[] parts = version.split("[.-]");
       if (parts.length > 0) {
         v0 = Integer.parseInt(parts[0]);

--- a/tikv-client/src/main/java/com/pingcap/tikv/columnar/TiBlockColumnVector.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/columnar/TiBlockColumnVector.java
@@ -12,8 +12,6 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.sql.Timestamp;
 import org.joda.time.LocalDate;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class TiBlockColumnVector extends TiColumnVector {
   private int fixedLength;
@@ -26,7 +24,6 @@ public class TiBlockColumnVector extends TiColumnVector {
 
   long dataAddr;
   ByteBuffer data;
-  protected final Logger logger = LoggerFactory.getLogger(this.getClass());
 
   public TiBlockColumnVector(CHType type, ByteBuffer data, int numOfRows, int fixedLength) {
     super(type.toDataType(), numOfRows);

--- a/tikv-client/src/main/java/com/pingcap/tikv/columnar/TiBlockColumnVector.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/columnar/TiBlockColumnVector.java
@@ -185,7 +185,7 @@ public class TiBlockColumnVector extends TiColumnVector {
     int month = (int) (ym % 13);
     int day = (int) (ymd & ((1 << 5) - 1));
     LocalDate date = new LocalDate(year, month, day);
-    return DateType.getEpochDayForSpark(date.toDate().getTime());
+    return Math.floorDiv(date.toDate().getTime(), (3600 * 24 * 1000));
   }
   /**
    * Returns the long type value for rowId. The return value is undefined and can be anything, if

--- a/tikv-client/src/main/java/com/pingcap/tikv/columnar/TiBlockColumnVector.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/columnar/TiBlockColumnVector.java
@@ -4,6 +4,7 @@ import static com.pingcap.tikv.util.MemoryUtil.EMPTY_BYTE_BUFFER_DIRECT;
 
 import com.pingcap.tikv.columnar.datatypes.CHType;
 import com.pingcap.tikv.types.AbstractDateTimeType;
+import com.pingcap.tikv.types.BytesType;
 import com.pingcap.tikv.types.DateType;
 import com.pingcap.tikv.util.MemoryUtil;
 import java.math.BigDecimal;
@@ -280,7 +281,15 @@ public class TiBlockColumnVector extends TiColumnVector {
    */
   @Override
   public byte[] getBinary(int rowId) {
-    throw new UnsupportedOperationException("get Binary for TiBlockColumnVector is not supported");
+      if (type.equals(BytesType.BLOB) || type.equals(BytesType.TINY_BLOB)) {
+        long offset = (dataAddr + offsetAt(rowId));
+        int numBytes = sizeAt(rowId) - 1;
+        byte[] ret = new byte[numBytes];
+        MemoryUtil.getBytes(offset, ret, 0, numBytes);
+        return ret;
+      } else {
+        throw new UnsupportedOperationException("get Binary for TiBlockColumnVector is not supported");
+      }
   }
 
   /** @return child [[TiColumnVector]] at the given ordinal. */

--- a/tikv-client/src/main/java/com/pingcap/tikv/columnar/TiBlockColumnVector.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/columnar/TiBlockColumnVector.java
@@ -163,33 +163,18 @@ public class TiBlockColumnVector extends TiColumnVector {
 
   private long getDateTime(int rowId) {
     long v = MemoryUtil.getLong(dataAddr + (rowId << 3));
-    long ymdhms = v >> 24;
-    long ymd = ymdhms >> 17;
+    long ymdhms = v >>> 24;
+    long ymd = ymdhms >>> 17;
     int day = (int) (ymd & ((1 << 5) - 1));
-    long ym = ymd >> 5;
+    long ym = ymd >>> 5;
     int month = (int) (ym % 13);
     int year = (int) (ym / 13);
 
     int hms = (int) (ymdhms & ((1 << 17) - 1));
     int second = hms & ((1 << 6) - 1);
-    int minute = (hms >> 6) & ((1 << 6) - 1);
-    int hour = hms >> 12;
+    int minute = (hms >>> 6) & ((1 << 6) - 1);
+    int hour = hms >>> 12;
     int microsec = (int) (v % (1 << 24));
-    logger.warn(
-        "Read date/timestamp column: "
-            + year
-            + "-"
-            + month
-            + "-"
-            + day
-            + " "
-            + hour
-            + ":"
-            + minute
-            + ":"
-            + second
-            + "."
-            + microsec);
     Timestamp ts =
         new Timestamp(year - 1900, month - 1, day, hour, minute, second, microsec * 1000);
     return ts.getTime() / 1000 * 1000000 + ts.getNanos() / 1000;
@@ -197,26 +182,11 @@ public class TiBlockColumnVector extends TiColumnVector {
 
   private long getTime(int rowId) {
     long v = MemoryUtil.getLong(dataAddr + (rowId << 3));
-    long ymd = v >> 41;
-    long ym = ymd >> 5;
+    long ymd = v >>> 41;
+    long ym = ymd >>> 5;
     int year = (int) (ym / 13);
     int month = (int) (ym % 13);
     int day = (int) (ymd & ((1 << 5) - 1));
-    logger.warn(
-        "Read date/timestamp column: "
-            + year
-            + "-"
-            + month
-            + "-"
-            + day
-            + " "
-            + 0
-            + ":"
-            + 0
-            + ":"
-            + 0
-            + "."
-            + 0);
     LocalDate date = new LocalDate(year, month, day);
     return Math.floorDiv(date.toDate().getTime(), (3600 * 24 * 1000));
   }

--- a/tikv-client/src/main/java/com/pingcap/tikv/columnar/TiBlockColumnVector.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/columnar/TiBlockColumnVector.java
@@ -282,15 +282,16 @@ public class TiBlockColumnVector extends TiColumnVector {
    */
   @Override
   public byte[] getBinary(int rowId) {
-      if (type.equals(BytesType.BLOB) || type.equals(BytesType.TINY_BLOB)) {
-        long offset = (dataAddr + offsetAt(rowId));
-        int numBytes = sizeAt(rowId) - 1;
-        byte[] ret = new byte[numBytes];
-        MemoryUtil.getBytes(offset, ret, 0, numBytes);
-        return ret;
-      } else {
-        throw new UnsupportedOperationException("get Binary for TiBlockColumnVector is not supported");
-      }
+    if (type.equals(BytesType.BLOB) || type.equals(BytesType.TINY_BLOB)) {
+      long offset = (dataAddr + offsetAt(rowId));
+      int numBytes = sizeAt(rowId) - 1;
+      byte[] ret = new byte[numBytes];
+      MemoryUtil.getBytes(offset, ret, 0, numBytes);
+      return ret;
+    } else {
+      throw new UnsupportedOperationException(
+          "get Binary for TiBlockColumnVector is not supported");
+    }
   }
 
   /** @return child [[TiColumnVector]] at the given ordinal. */

--- a/tikv-client/src/main/java/com/pingcap/tikv/columnar/TiBlockColumnVector.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/columnar/TiBlockColumnVector.java
@@ -12,6 +12,8 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.sql.Timestamp;
 import org.joda.time.LocalDate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class TiBlockColumnVector extends TiColumnVector {
   private int fixedLength;
@@ -24,6 +26,7 @@ public class TiBlockColumnVector extends TiColumnVector {
 
   long dataAddr;
   ByteBuffer data;
+  protected final Logger logger = LoggerFactory.getLogger(this.getClass());
 
   public TiBlockColumnVector(CHType type, ByteBuffer data, int numOfRows, int fixedLength) {
     super(type.toDataType(), numOfRows);
@@ -172,6 +175,21 @@ public class TiBlockColumnVector extends TiColumnVector {
     int minute = (hms >> 6) & ((1 << 6) - 1);
     int hour = hms >> 12;
     int microsec = (int) (v % (1 << 24));
+    logger.warn(
+        "Read date/timestamp column: "
+            + year
+            + "-"
+            + month
+            + "-"
+            + day
+            + " "
+            + hour
+            + ":"
+            + minute
+            + ":"
+            + second
+            + "."
+            + microsec);
     Timestamp ts =
         new Timestamp(year - 1900, month - 1, day, hour, minute, second, microsec * 1000);
     return ts.getTime() / 1000 * 1000000 + ts.getNanos() / 1000;
@@ -184,6 +202,21 @@ public class TiBlockColumnVector extends TiColumnVector {
     int year = (int) (ym / 13);
     int month = (int) (ym % 13);
     int day = (int) (ymd & ((1 << 5) - 1));
+    logger.warn(
+        "Read date/timestamp column: "
+            + year
+            + "-"
+            + month
+            + "-"
+            + day
+            + " "
+            + 0
+            + ":"
+            + 0
+            + ":"
+            + 0
+            + "."
+            + 0);
     LocalDate date = new LocalDate(year, month, day);
     return Math.floorDiv(date.toDate().getTime(), (3600 * 24 * 1000));
   }

--- a/tikv-client/src/main/java/com/pingcap/tikv/columnar/TiBlockColumnVector.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/columnar/TiBlockColumnVector.java
@@ -185,7 +185,7 @@ public class TiBlockColumnVector extends TiColumnVector {
     int month = (int) (ym % 13);
     int day = (int) (ymd & ((1 << 5) - 1));
     LocalDate date = new LocalDate(year, month, day);
-    return Math.floorDiv(date.toDate().getTime(), (3600 * 24 * 1000));
+    return Math.floorDiv(date.toDate().getTime(), AbstractDateTimeType.MILLS_PER_DAY);
   }
   /**
    * Returns the long type value for rowId. The return value is undefined and can be anything, if

--- a/tikv-client/src/main/java/com/pingcap/tikv/columnar/TiBlockColumnVector.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/columnar/TiBlockColumnVector.java
@@ -184,8 +184,8 @@ public class TiBlockColumnVector extends TiColumnVector {
     int year = (int) (ym / 13);
     int month = (int) (ym % 13);
     int day = (int) (ymd & ((1 << 5) - 1));
-    LocalDate date = new LocalDate(year, month, day, null);
-    return date.toDate().getTime() / 24 / 3600 / 1000;
+    LocalDate date = new LocalDate(year, month, day);
+    return DateType.getEpochDayForSpark(date.toDate().getTime());
   }
   /**
    * Returns the long type value for rowId. The return value is undefined and can be anything, if

--- a/tikv-client/src/main/java/com/pingcap/tikv/columnar/TiChunkColumnVector.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/columnar/TiChunkColumnVector.java
@@ -23,8 +23,6 @@ import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.sql.Timestamp;
 import org.joda.time.LocalDate;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /** An implementation of {@link TiColumnVector}. All data is stored in TiDB chunk format. */
 public class TiChunkColumnVector extends TiColumnVector {
@@ -38,8 +36,6 @@ public class TiChunkColumnVector extends TiColumnVector {
   private long[] offsets;
 
   private ByteBuffer data;
-
-  protected final Logger logger = LoggerFactory.getLogger(this.getClass());
 
   public TiChunkColumnVector(
       DataType dataType,

--- a/tikv-client/src/main/java/com/pingcap/tikv/columnar/TiChunkColumnVector.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/columnar/TiChunkColumnVector.java
@@ -136,21 +136,6 @@ public class TiChunkColumnVector extends TiColumnVector {
       month = 1;
       day = 1;
     }
-    logger.warn(
-        "Read date/timestamp column: "
-            + year
-            + "-"
-            + month
-            + "-"
-            + day
-            + " "
-            + hour
-            + ":"
-            + minute
-            + ":"
-            + second
-            + "."
-            + microsecond);
     if (this.type instanceof DateType) {
       LocalDate date = new LocalDate(year, month, day);
       return Math.floorDiv(date.toDate().getTime(), (3600 * 24 * 1000));

--- a/tikv-client/src/main/java/com/pingcap/tikv/columnar/TiChunkColumnVector.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/columnar/TiChunkColumnVector.java
@@ -23,6 +23,8 @@ import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.sql.Timestamp;
 import org.joda.time.LocalDate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** An implementation of {@link TiColumnVector}. All data is stored in TiDB chunk format. */
 public class TiChunkColumnVector extends TiColumnVector {
@@ -36,6 +38,8 @@ public class TiChunkColumnVector extends TiColumnVector {
   private long[] offsets;
 
   private ByteBuffer data;
+
+  protected final Logger logger = LoggerFactory.getLogger(this.getClass());
 
   public TiChunkColumnVector(
       DataType dataType,
@@ -132,6 +136,21 @@ public class TiChunkColumnVector extends TiColumnVector {
       month = 1;
       day = 1;
     }
+    logger.warn(
+        "Read date/timestamp column: "
+            + year
+            + "-"
+            + month
+            + "-"
+            + day
+            + " "
+            + hour
+            + ":"
+            + minute
+            + ":"
+            + second
+            + "."
+            + microsecond);
     if (this.type instanceof DateType) {
       LocalDate date = new LocalDate(year, month, day);
       return Math.floorDiv(date.toDate().getTime(), (3600 * 24 * 1000));

--- a/tikv-client/src/main/java/com/pingcap/tikv/columnar/TiChunkColumnVector.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/columnar/TiChunkColumnVector.java
@@ -134,7 +134,7 @@ public class TiChunkColumnVector extends TiColumnVector {
     }
     if (this.type instanceof DateType) {
       LocalDate date = new LocalDate(year, month, day);
-      return Math.floorDiv(date.toDate().getTime(), (3600 * 24 * 1000));
+      return Math.floorDiv(date.toDate().getTime(), AbstractDateTimeType.MILLS_PER_DAY);
     } else if (type instanceof DateTimeType || type instanceof TimestampType) {
       // only return microsecond from epoch.
       Timestamp ts =

--- a/tikv-client/src/main/java/com/pingcap/tikv/columnar/TiChunkColumnVector.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/columnar/TiChunkColumnVector.java
@@ -134,7 +134,7 @@ public class TiChunkColumnVector extends TiColumnVector {
     }
     if (this.type instanceof DateType) {
       LocalDate date = new LocalDate(year, month, day);
-      return DateType.getEpochDayForSpark(date.toDate().getTime());
+      return Math.floorDiv(date.toDate().getTime(), (3600 * 24 * 1000));
     } else if (type instanceof DateTimeType || type instanceof TimestampType) {
       // only return microsecond from epoch.
       Timestamp ts =

--- a/tikv-client/src/main/java/com/pingcap/tikv/columnar/TiChunkColumnVector.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/columnar/TiChunkColumnVector.java
@@ -133,8 +133,8 @@ public class TiChunkColumnVector extends TiColumnVector {
       day = 1;
     }
     if (this.type instanceof DateType) {
-      LocalDate date = new LocalDate(year, month, day, null);
-      return date.toDate().getTime() / 24 / 3600 / 1000;
+      LocalDate date = new LocalDate(year, month, day);
+      return DateType.getEpochDayForSpark(date.toDate().getTime());
     } else if (type instanceof DateTimeType || type instanceof TimestampType) {
       // only return microsecond from epoch.
       Timestamp ts =

--- a/tikv-client/src/main/java/com/pingcap/tikv/columnar/TiCoreTime.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/columnar/TiCoreTime.java
@@ -50,30 +50,30 @@ public class TiCoreTime {
   }
 
   public int getYear() {
-    return (int) ((coreTime & YEAR_BIT_FIELD_MASK) >> YEAR_BIT_FIELD_OFFSET);
+    return (int) ((coreTime & YEAR_BIT_FIELD_MASK) >>> YEAR_BIT_FIELD_OFFSET);
   }
 
   public int getMonth() {
-    return (int) ((coreTime & MONTH_BIT_FIELD_MASK) >> MONTH_BIT_FIELD_OFFSET);
+    return (int) ((coreTime & MONTH_BIT_FIELD_MASK) >>> MONTH_BIT_FIELD_OFFSET);
   }
 
   public int getDay() {
-    return (int) ((coreTime & DAY_BIT_FIELD_MASK) >> DAY_BIT_FIELD_OFFSET);
+    return (int) ((coreTime & DAY_BIT_FIELD_MASK) >>> DAY_BIT_FIELD_OFFSET);
   }
 
   public int getHour() {
-    return (int) ((coreTime & HOUR_BIT_FIELD_MASK) >> HOUR_BIT_FIELD_OFFSET);
+    return (int) ((coreTime & HOUR_BIT_FIELD_MASK) >>> HOUR_BIT_FIELD_OFFSET);
   }
 
   public int getMinute() {
-    return (int) ((coreTime & MINUTE_BIT_FIELD_MASK) >> MINUTE_BIT_FIELD_OFFSET);
+    return (int) ((coreTime & MINUTE_BIT_FIELD_MASK) >>> MINUTE_BIT_FIELD_OFFSET);
   }
 
   public int getSecond() {
-    return (int) ((coreTime & SECOND_BIT_FIELD_MASK) >> SECOND_BIT_FIELD_OFFSET);
+    return (int) ((coreTime & SECOND_BIT_FIELD_MASK) >>> SECOND_BIT_FIELD_OFFSET);
   }
 
   public long getMicroSecond() {
-    return (coreTime & MICROSECOND_BIT_FIELD_MASK) >> MICROSECOND_BIT_FIELD_OFFSET;
+    return (coreTime & MICROSECOND_BIT_FIELD_MASK) >>> MICROSECOND_BIT_FIELD_OFFSET;
   }
 }

--- a/tikv-client/src/main/java/com/pingcap/tikv/expression/visitor/MetaResolver.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/expression/visitor/MetaResolver.java
@@ -56,7 +56,11 @@ public class MetaResolver extends DefaultVisitor<Void, Expression> {
     // We may need add a expressionRewriter to address this.
     if (predicate != null) {
       visit(predicate.getColumnRef(), node);
-      if (predicate.getValue().getDataType() == null || !predicate.getValue().getDataType().isSameCatalog(predicate.getColumnRef().getDataType()))
+      if (predicate.getValue().getDataType() == null
+          || !predicate
+              .getValue()
+              .getDataType()
+              .isSameCatalog(predicate.getColumnRef().getDataType()))
         predicate.getValue().setDataType(predicate.getColumnRef().getDataType());
     }
     return null;

--- a/tikv-client/src/main/java/com/pingcap/tikv/expression/visitor/MetaResolver.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/expression/visitor/MetaResolver.java
@@ -56,7 +56,8 @@ public class MetaResolver extends DefaultVisitor<Void, Expression> {
     // We may need add a expressionRewriter to address this.
     if (predicate != null) {
       visit(predicate.getColumnRef(), node);
-      predicate.getValue().setDataType(predicate.getColumnRef().getDataType());
+      if (predicate.getValue().getDataType() == null)
+        predicate.getValue().setDataType(predicate.getColumnRef().getDataType());
     }
     return null;
   }

--- a/tikv-client/src/main/java/com/pingcap/tikv/expression/visitor/MetaResolver.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/expression/visitor/MetaResolver.java
@@ -56,11 +56,10 @@ public class MetaResolver extends DefaultVisitor<Void, Expression> {
     // We may need add a expressionRewriter to address this.
     if (predicate != null) {
       visit(predicate.getColumnRef(), node);
-      // do not set the constant data type to the column ref data type because it may narrow the
-      // constant type, and cause wrong result.
-      // for example when the filter is `bit_col op long_constant`, set long_constant to bit type
-      // will
-      // truncated the long_constant, and may cause wrong result
+      // do not set the constant data type to the column ref data type if they are the
+      // same catalog because it may narrow the constant type, and cause wrong result.
+      // for example when the filter is `bit_col op long_constant`, set long_constant
+      // to bit type will truncated the long_constant, and may cause wrong result
       if (predicate.getValue().getDataType() == null
           || !predicate
               .getValue()

--- a/tikv-client/src/main/java/com/pingcap/tikv/expression/visitor/MetaResolver.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/expression/visitor/MetaResolver.java
@@ -56,6 +56,11 @@ public class MetaResolver extends DefaultVisitor<Void, Expression> {
     // We may need add a expressionRewriter to address this.
     if (predicate != null) {
       visit(predicate.getColumnRef(), node);
+      // do not set the constant data type to the column ref data type because it may narrow the
+      // constant type, and cause wrong result.
+      // for example when the filter is `bit_col op long_constant`, set long_constant to bit type
+      // will
+      // truncated the long_constant, and may cause wrong result
       if (predicate.getValue().getDataType() == null
           || !predicate
               .getValue()

--- a/tikv-client/src/main/java/com/pingcap/tikv/expression/visitor/MetaResolver.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/expression/visitor/MetaResolver.java
@@ -56,7 +56,7 @@ public class MetaResolver extends DefaultVisitor<Void, Expression> {
     // We may need add a expressionRewriter to address this.
     if (predicate != null) {
       visit(predicate.getColumnRef(), node);
-      if (predicate.getValue().getDataType() == null)
+      if (predicate.getValue().getDataType() == null || !predicate.getValue().getDataType().isSameCatalog(predicate.getColumnRef().getDataType()))
         predicate.getValue().setDataType(predicate.getColumnRef().getDataType());
     }
     return null;

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/AbstractDateTimeType.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/AbstractDateTimeType.java
@@ -23,6 +23,8 @@ public abstract class AbstractDateTimeType extends DataType {
     super(tp);
   }
 
+  public static long MILLS_PER_DAY = 3600L * 24 * 1000;
+
   public abstract DateTimeZone getTimezone();
   /**
    * Decode DateTime from packed long value In TiDB / MySQL, timestamp type is converted to UTC and

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/DataType.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/DataType.java
@@ -257,6 +257,10 @@ public abstract class DataType implements Serializable {
         + ((long) (readBuffer[7] & 255) << 56));
   }
 
+  public boolean isSameCatalog(DataType other) {
+    return false;
+  }
+
   // all data should be read in little endian.
   public TiChunkColumnVector decodeChunkColumn(CodecDataInput cdi) {
     int numRows = readIntLittleEndian(cdi);

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/DateType.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/DateType.java
@@ -99,6 +99,6 @@ public class DateType extends AbstractDateTimeType {
       return null;
     }
     // return how many days from EPOCH
-    return date.toDate().getTime() / (24 * 60 * 60 * 1000);
+    return Math.floorDiv(date.toDate().getTime(), (3600 * 24 * 1000));
   }
 }

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/DateType.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/DateType.java
@@ -24,7 +24,6 @@ import com.pingcap.tikv.exception.ConvertNotSupportException;
 import com.pingcap.tikv.exception.ConvertOverflowException;
 import com.pingcap.tikv.meta.TiColumnInfo;
 import java.sql.Date;
-import java.util.TimeZone;
 import org.joda.time.DateTimeZone;
 import org.joda.time.LocalDate;
 
@@ -101,13 +100,5 @@ public class DateType extends AbstractDateTimeType {
     }
     // return how many days from EPOCH
     return date.toDate().getTime() / (24 * 60 * 60 * 1000);
-  }
-
-  // Spark will add timezone offset when convert epoch day to date, so need to consider timezone
-  // offset here
-  public static int getEpochDayForSpark(long millisUtc) {
-    TimeZone tz = TimeZone.getDefault();
-    long millisLocal = millisUtc + tz.getOffset(millisUtc);
-    return (int) Math.floor((double) millisLocal / (3600 * 24 * 1000));
   }
 }

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/DateType.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/DateType.java
@@ -24,6 +24,7 @@ import com.pingcap.tikv.exception.ConvertNotSupportException;
 import com.pingcap.tikv.exception.ConvertOverflowException;
 import com.pingcap.tikv.meta.TiColumnInfo;
 import java.sql.Date;
+import java.util.TimeZone;
 import org.joda.time.DateTimeZone;
 import org.joda.time.LocalDate;
 
@@ -105,9 +106,8 @@ public class DateType extends AbstractDateTimeType {
   // Spark will add timezone offset when convert epoch day to date, so need to consider timezone
   // offset here
   public static int getEpochDayForSpark(long millisUtc) {
-    DateTimeZone tz = Converter.getLocalTimezone();
-    tz.getOffset(millisUtc);
+    TimeZone tz = TimeZone.getDefault();
     long millisLocal = millisUtc + tz.getOffset(millisUtc);
-    return (int) Math.floor((double) millisLocal / 3600 / 24 / 1000);
+    return (int) Math.floor((double) millisLocal / (3600 * 24 * 1000));
   }
 }

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/DateType.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/DateType.java
@@ -101,4 +101,12 @@ public class DateType extends AbstractDateTimeType {
     // return how many days from EPOCH
     return date.toDate().getTime() / (24 * 60 * 60 * 1000);
   }
+
+  //Spark will add timezone offset when convert epoch day to date, so need to consider timezone offset here
+  static public int getEpochDayForSpark(long millisUtc) {
+    DateTimeZone tz = Converter.getLocalTimezone();
+    tz.getOffset(millisUtc);
+    long millisLocal = millisUtc + tz.getOffset(millisUtc);
+    return (int)Math.floor((double)millisLocal/ 3600 / 24 / 1000);
+  }
 }

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/DateType.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/DateType.java
@@ -102,11 +102,12 @@ public class DateType extends AbstractDateTimeType {
     return date.toDate().getTime() / (24 * 60 * 60 * 1000);
   }
 
-  //Spark will add timezone offset when convert epoch day to date, so need to consider timezone offset here
-  static public int getEpochDayForSpark(long millisUtc) {
+  // Spark will add timezone offset when convert epoch day to date, so need to consider timezone
+  // offset here
+  public static int getEpochDayForSpark(long millisUtc) {
     DateTimeZone tz = Converter.getLocalTimezone();
     tz.getOffset(millisUtc);
     long millisLocal = millisUtc + tz.getOffset(millisUtc);
-    return (int)Math.floor((double)millisLocal/ 3600 / 24 / 1000);
+    return (int) Math.floor((double) millisLocal / 3600 / 24 / 1000);
   }
 }

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/DateType.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/DateType.java
@@ -99,6 +99,6 @@ public class DateType extends AbstractDateTimeType {
       return null;
     }
     // return how many days from EPOCH
-    return Math.floorDiv(date.toDate().getTime(), (3600 * 24 * 1000));
+    return Math.floorDiv(date.toDate().getTime(), AbstractDateTimeType.MILLS_PER_DAY);
   }
 }

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/IntegerType.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/IntegerType.java
@@ -83,6 +83,10 @@ public class IntegerType extends DataType {
     return result;
   }
 
+  public boolean isSameCatalog(DataType other) {
+    return other instanceof IntegerType;
+  }
+
   /** {@inheritDoc} */
   @Override
   protected Object decodeNotNull(int flag, CodecDataInput cdi) {


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
fix ci error when running in tispark + tiflash mode

### What is changed and how it works?
1. fix result verification logical to avoid false error
2. support `getBinary` in `TiBlockColumnVector`
3. return correct epoch day for date type
4. fix some data type error in dag request

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test
 - Manual test (add detailed scripts or steps below)