### PR TITLE
BatchWrite: fix row decoder bug

### DIFF
--- a/core/src/main/scala/com/pingcap/tispark/write/TiBatchWrite.scala
+++ b/core/src/main/scala/com/pingcap/tispark/write/TiBatchWrite.scala
@@ -230,7 +230,7 @@ class TiBatchWrite(@transient val dataToWrite: Map[DBTable, DataFrame],
         new TwoPhaseCommitter(tiConf, startTs, lockTTLSeconds * 1000)
 
       val pairs = iterator.map { keyValue =>
-        new TwoPhaseCommitter.BytePairWrapper(
+        new BytePairWrapper(
           keyValue._1.bytes,
           keyValue._2
         )
@@ -296,7 +296,7 @@ class TiBatchWrite(@transient val dataToWrite: Map[DBTable, DataFrame],
         val ti2PCClientOnExecutor = new TwoPhaseCommitter(tiConf, startTs)
 
         val keys = iterator.map { keyValue =>
-          new TwoPhaseCommitter.ByteWrapper(keyValue._1.bytes)
+          new ByteWrapper(keyValue._1.bytes)
         }.asJava
 
         try {

--- a/core/src/main/scala/com/pingcap/tispark/write/TiDBOptions.scala
+++ b/core/src/main/scala/com/pingcap/tispark/write/TiDBOptions.scala
@@ -97,6 +97,9 @@ class TiDBOptions(@transient val parameters: CaseInsensitiveMap[String]) extends
   // ttlMode = { "FIXED", "UPDATE", "DEFAULT" }
   val ttlMode: String = parameters.getOrElse(TIDB_TTL_MODE, "DEFAULT").toUpperCase()
 
+  val useSnapshotBatchGet: Boolean =
+    parameters.getOrElse(TIDB_USE_SNAPSHOT_BATCH_GET, "true").toBoolean
+
   val snapshotBatchGetSize: Int = parameters.getOrElse(TIDB_SNAPSHOT_BATCH_GET_SIZE, "2048").toInt
 
   val useTableLock: Boolean = parameters.getOrElse(TIDB_USE_TABLE_LOCK, "true").toBoolean
@@ -192,6 +195,7 @@ object TiDBOptions {
   val TIDB_REGION_SPLIT_NUM: String = newOption("regionSplitNum")
   val TIDB_WRITE_CONCURRENCY: String = newOption("writeConcurrency")
   val TIDB_TTL_MODE: String = newOption("ttlMode")
+  val TIDB_USE_SNAPSHOT_BATCH_GET: String = newOption("useSnapshotBatchGet")
   val TIDB_SNAPSHOT_BATCH_GET_SIZE: String = newOption("snapshotBatchGetSize")
   val TIDB_USE_TABLE_LOCK: String = newOption("useTableLock")
   val TIDB_MULTI_TABLES: String = newOption("multiTables")

--- a/core/src/test/scala/com/pingcap/tispark/BatchWriteIssueSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/BatchWriteIssueSuite.scala
@@ -1,0 +1,99 @@
+package com.pingcap.tispark
+
+import com.pingcap.tispark.datasource.BaseDataSourceTest
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
+
+class BatchWriteIssueSuite extends BaseDataSourceTest("test_batchwrite_issue") {
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+  }
+
+  test("Combine unique index with null value test") {
+    doTestNullValues(
+      s"create table $dbtable(a int, b varchar(64), CONSTRAINT ab UNIQUE (a, b))"
+    )
+  }
+
+  test("Combine primary key with null value test") {
+    doTestNullValues(
+      s"create table $dbtable(a int, b varchar(64), PRIMARY KEY (a, b))"
+    )
+  }
+
+  test("PK is handler with null value test") {
+    doTestNullValues(
+      s"create table $dbtable(a int, b varchar(64), PRIMARY KEY (a))"
+    )
+  }
+
+  private def doTestNullValues(createTableSQL: String): Unit = {
+    if (!supportBatchWrite) {
+      cancel
+    }
+    val schema = StructType(
+      List(
+        StructField("a", IntegerType),
+        StructField("b", StringType),
+        StructField("c", StringType)
+      )
+    )
+
+    val options = Some(Map("replace" -> "true"))
+
+    dropTable()
+    jdbcUpdate(createTableSQL)
+    jdbcUpdate(s"alter table $dbtable add column to_delete int")
+    jdbcUpdate(s"alter table $dbtable add column c varchar(64) default 'c33'")
+    jdbcUpdate(s"alter table $dbtable drop column to_delete")
+    jdbcUpdate(s"""
+                  |insert into $dbtable values(11, 'c12', null);
+                  |insert into $dbtable values(21, 'c22', null);
+                  |insert into $dbtable (a, b) values(31, 'c32');
+                  |insert into $dbtable values(41, 'c42', 'c43');
+                  |
+      """.stripMargin)
+
+    assert(queryTiDBViaJDBC(s"select c from $dbtable where a=11").head.head == null)
+    assert(queryTiDBViaJDBC(s"select c from $dbtable where a=21").head.head == null)
+    assert(queryTiDBViaJDBC(s"select c from $dbtable where a=31").head.head.toString.equals("c33"))
+    assert(queryTiDBViaJDBC(s"select c from $dbtable where a=41").head.head.toString.equals("c43"))
+
+    {
+      val row1 = Row(11, "c12", "c13")
+      val row3 = Row(31, "c32", null)
+
+      tidbWrite(List(row1, row3), schema, options)
+
+      assert(
+        queryTiDBViaJDBC(s"select c from $dbtable where a=11").head.head.toString.equals("c13")
+      )
+      assert(queryTiDBViaJDBC(s"select c from $dbtable where a=21").head.head == null)
+      assert(queryTiDBViaJDBC(s"select c from $dbtable where a=31").head.head == null)
+      assert(
+        queryTiDBViaJDBC(s"select c from $dbtable where a=41").head.head.toString.equals("c43")
+      )
+    }
+
+    {
+      val row1 = Row(11, "c12", "c213")
+      val row3 = Row(31, "c32", "tt")
+      tidbWrite(List(row1, row3), schema, options)
+      assert(
+        queryTiDBViaJDBC(s"select c from $dbtable where a=11").head.head.toString.equals("c213")
+      )
+      assert(queryTiDBViaJDBC(s"select c from $dbtable where a=21").head.head == null)
+      assert(queryTiDBViaJDBC(s"select c from $dbtable where a=31").head.head.toString.equals("tt"))
+      assert(
+        queryTiDBViaJDBC(s"select c from $dbtable where a=41").head.head.toString.equals("c43")
+      )
+    }
+  }
+
+  override def afterAll(): Unit =
+    try {
+      dropTable()
+    } finally {
+      super.afterAll()
+    }
+}

--- a/tikv-client/src/main/java/com/pingcap/tikv/BytePairWrapper.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/BytePairWrapper.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pingcap.tikv;
+
+public class BytePairWrapper {
+  private byte[] key;
+  private byte[] value;
+
+  public BytePairWrapper(byte[] key, byte[] value) {
+    this.key = key;
+    this.value = value;
+  }
+
+  public byte[] getKey() {
+    return key;
+  }
+
+  public byte[] getValue() {
+    return value;
+  }
+}

--- a/tikv-client/src/main/java/com/pingcap/tikv/ByteWrapper.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/ByteWrapper.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pingcap.tikv;
+
+import java.util.Arrays;
+
+public class ByteWrapper {
+  private byte[] bytes;
+
+  public ByteWrapper(byte[] bytes) {
+    this.bytes = bytes;
+  }
+
+  public byte[] getBytes() {
+    return this.bytes;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    ByteWrapper that = (ByteWrapper) o;
+
+    return Arrays.equals(bytes, that.bytes);
+  }
+
+  @Override
+  public int hashCode() {
+    return Arrays.hashCode(bytes);
+  }
+}

--- a/tikv-client/src/main/java/com/pingcap/tikv/TwoPhaseCommitter.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/TwoPhaseCommitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2019 PingCAP, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,55 +37,6 @@ import org.tikv.kvproto.Kvrpcpb.Op;
 import org.tikv.kvproto.Metapb;
 
 public class TwoPhaseCommitter {
-
-  public static class ByteWrapper {
-    private byte[] bytes;
-
-    public ByteWrapper(byte[] bytes) {
-      this.bytes = bytes;
-    }
-
-    public byte[] getBytes() {
-      return this.bytes;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (o == null || getClass() != o.getClass()) {
-        return false;
-      }
-
-      ByteWrapper that = (ByteWrapper) o;
-
-      return Arrays.equals(bytes, that.bytes);
-    }
-
-    @Override
-    public int hashCode() {
-      return Arrays.hashCode(bytes);
-    }
-  }
-
-  public static class BytePairWrapper {
-    private byte[] key;
-    private byte[] value;
-
-    public BytePairWrapper(byte[] key, byte[] value) {
-      this.key = key;
-      this.value = value;
-    }
-
-    public byte[] getKey() {
-      return key;
-    }
-
-    public byte[] getValue() {
-      return value;
-    }
-  }
 
   /** buffer spark rdd iterator data into memory */
   private static final int WRITE_BUFFER_SIZE = 32 * 1024;
@@ -467,7 +418,7 @@ public class TwoPhaseCommitter {
 
           @Override
           public ByteString next() {
-            return ByteString.copyFrom(keys.next().bytes);
+            return ByteString.copyFrom(keys.next().getBytes());
           }
         };
 

--- a/tikv-client/src/main/java/com/pingcap/tikv/codec/CodecDataInput.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/codec/CodecDataInput.java
@@ -41,10 +41,12 @@ public class CodecDataInput implements DataInput {
       this.count = buf.length;
     }
 
+    @Override
     public int read() {
       return (pos < count) ? (buf[pos++] & 0xff) : -1;
     }
 
+    @Override
     public int read(byte[] b, int off, int len) {
       if (b == null) {
         throw new NullPointerException();
@@ -68,6 +70,7 @@ public class CodecDataInput implements DataInput {
       return len;
     }
 
+    @Override
     public long skip(long n) {
       long k = count - pos;
       if (n < k) {
@@ -78,22 +81,27 @@ public class CodecDataInput implements DataInput {
       return k;
     }
 
+    @Override
     public int available() {
       return count - pos;
     }
 
+    @Override
     public boolean markSupported() {
       return true;
     }
 
+    @Override
     public void mark(int readAheadLimit) {
       mark = pos;
     }
 
+    @Override
     public void reset() {
       pos = mark;
     }
 
+    @Override
     public void close() throws IOException {}
   }
 


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

fail to update rows with unique index and null value

```
Driver stacktrace:,org.apache.spark.SparkException: Job aborted due to stage failure: Task 1 in stage 8.0 failed 1 times, most recent failure: Lost task 1.0 in stage 8.0 (TID 6, localhost, executor driver): java.lang.RuntimeException: java.io.EOFException
at com.pingcap.tikv.codec.CodecDataInput.readByte(CodecDataInput.java:164)
at com.pingcap.tikv.codec.CodecDataInput.peekByte(CodecDataInput.java:288)
at com.pingcap.tikv.types.DataType.isNextNull(DataType.java:312)
at com.pingcap.tikv.row.DefaultRowReader.readRow(DefaultRowReader.java:39)
at com.pingcap.tikv.codec.TableCodec.decodeRow(TableCodec.java:69)
at com.pingcap.tispark.TiBatchWrite$$anonfun$generateDataToBeRemovedRdd$1$$anon$2$$anonfun$processNextBatch$3.apply(TiBatchWrite.scala:647)
at com.pingcap.tispark.TiBatchWrite$$anonfun$generateDataToBeRemovedRdd$1$$anon$2$$anonfun$processNextBatch$3.apply(TiBatchWrite.scala:642)
```

### What is changed and how it works?
fix the row decoder bug

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 
