### PR TITLE
BatchWrite: update multi-table api

### DIFF
--- a/core/src/test/scala/com/pingcap/tispark/multitable/MultiTableWriteSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/multitable/MultiTableWriteSuite.scala
@@ -53,8 +53,7 @@ class MultiTableWriteSuite extends BaseTiSparkTest {
     }.toMap
 
     // multi table batch write
-    TiBatchWrite
-      .write(data, ti, tidbOptions ++ Map("multiTables" -> "true", "isTest" -> "true"))
+    TiBatchWrite.write(data, spark, tidbOptions ++ Map("multiTables" -> "true", "isTest" -> "true"))
 
     for (table <- tables) {
       val tableToWrite = s"${batchWriteTablePrefix}_$table"

--- a/docs/datasource_api_userguide.md
+++ b/docs/datasource_api_userguide.md
@@ -228,10 +228,10 @@ val data = Map(DBTable(outputDatabase, outputTable1) -> df1, DBTable(outputDatab
 // writing data to multi-tables
 TiBatchWrite.write(
   data,
-  tiContext,
+  spark,
   Map(
-    "tidb.addr" -> "172.16.5.59",
-    "tidb.port" -> "9194",
+    "tidb.addr" -> "127.0.0.1",
+    "tidb.port" -> "4000",
     "tidb.user"-> "root",
     "tidb.password" -> "")
 )


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
update multi-table api: `TiContext` -> `SparkSession`

### What is changed and how it works?
```
val df1 = spark.sql(s"select * from $inputTable1")
val df2 = spark.sql(s"select * from $inputTable2")

val data = Map(DBTable(outputDatabase, outputTable1) -> df1, DBTable(outputDatabase, outputTable2) -> df2)

// writing data to multi-tables
TiBatchWrite.write(
  data,
  spark,
  Map(
    "tidb.addr" -> "127.0.0.1",
    "tidb.port" -> "4000",
    "tidb.user"-> "root",
    "tidb.password" -> "")
```
