### PR TITLE
fix store version starts with v

### DIFF
--- a/tikv-client/src/main/java/com/pingcap/tikv/StoreVersion.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/StoreVersion.java
@@ -34,6 +34,10 @@ public class StoreVersion {
 
   private StoreVersion(String version) {
     try {
+      // tiflash version starts with `v`
+      if (version.startsWith("v")) {
+        version = version.substring(1);
+      }
       String[] parts = version.split("[.-]");
       if (parts.length > 0) {
         v0 = Integer.parseInt(parts[0]);


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
tikv version: 4.0.0
tiflash version: v4.0.0

### What is changed and how it works?
fix store version start with v

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code
