### PR TITLE
fix resolve current lock npe bug

### DIFF
--- a/tikv-client/src/main/java/com/pingcap/tikv/operation/iterator/ConcreteScanIterator.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/operation/iterator/ConcreteScanIterator.java
@@ -85,7 +85,7 @@ public class ConcreteScanIterator extends ScanIterator {
   private ByteString resolveCurrentLock(Kvrpcpb.KvPair current) {
     logger.warn(String.format("resolve current key error %s", current.getError().toString()));
     Pair<TiRegion, Metapb.Store> pair =
-        builder.getRegionManager().getRegionStorePairByKey(startKey);
+        builder.getRegionManager().getRegionStorePairByKey(current.getKey());
     TiRegion region = pair.first;
     Metapb.Store store = pair.second;
     BackOffer backOffer = ConcreteBackOffer.newGetBackOff();


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
close https://github.com/pingcap/tispark/issues/1005

![image](https://user-images.githubusercontent.com/5574887/85108554-865c4100-b242-11ea-9907-cd7f6b19e23b.png)


### What is changed and how it works?
use `current.getKey()` instead of `startKey`

`startKey` maybe null, cause it means the start key of next region

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

