### PR TITLE
BatchWrite: fix column name case bug

### DIFF
--- a/core/src/main/scala/com/pingcap/tispark/write/TiBatchWriteTable.scala
+++ b/core/src/main/scala/com/pingcap/tispark/write/TiBatchWriteTable.scala
@@ -129,7 +129,7 @@ class TiBatchWriteTable(
         val start = getAutoTableIdStart(df.count)
 
         // update colsInDF since we just add one column in df
-        colsInDf = newDf.columns.toList
+        colsInDf = newDf.columns.toList.map(_.toLowerCase())
         // last one is auto increment column
         newDf.rdd.zipWithIndex.map { row =>
           val rowSep = row._1.toSeq.zipWithIndex.map { data =>


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

```
java.util.NoSuchElementException: key not found: TMP_ID
	at scala.collection.MapLike$class.default(MapLike.scala:228)
	at scala.collection.AbstractMap.default(Map.scala:59)
	at scala.collection.MapLike$class.apply(MapLike.scala:141)
	at scala.collection.AbstractMap.apply(Map.scala:59)
	at com.pingcap.tispark.write.TiBatchWriteTable$$anonfun$com$pingcap$tispark$write$TiBatchWriteTable$$sparkRow2TiKVRow$1.apply$mcVI$sp(TiBatchWriteTable.scala:531)
	at scala.collection.immutable.Range.foreach$mVc$sp(Range.scala:160)
	at com.pingcap.tispark.write.TiBatchWriteTable.com$pingcap$tispark$write$TiBatchWriteTable$$sparkRow2TiKVRow(TiBatchWriteTable.scala:528)
	at com.pingcap.tispark.write.TiBatchWriteTable$$anonfun$8.apply(TiBatchWriteTable.scala:153)
	at com.pingcap.tispark.write.TiBatchWriteTable$$anonfun$8.apply(TiBatchWriteTable.scala:153)
	at scala.collection.Iterator$$anon$11.next(Iterator.scala:410)
	at scala.collection.Iterator$$anon$13.hasNext(Iterator.scala:463)
	at org.apache.spark.util.Utils$.getIteratorSize(Utils.scala:1817)
	at org.apache.spark.rdd.RDD$$anonfun$count$1.apply(RDD.scala:1168)
	at org.apache.spark.rdd.RDD$$anonfun$count$1.apply(RDD.scala:1168)
	at org.apache.spark.SparkContext$$anonfun$runJob$5.apply(SparkContext.scala:2101)
	at org.apache.spark.SparkContext$$anonfun$runJob$5.apply(SparkContext.scala:2101)
	at org.apache.spark.scheduler.ResultTask.runTask(ResultTask.scala:90)
	at org.apache.spark.scheduler.Task.run(Task.scala:121)
	at org.apache.spark.executor.Executor$TaskRunner$$anonfun$10.apply(Executor.scala:408)
	at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:1360)
	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:414)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```

### What is changed and how it works?
fix column name case bug

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code
