### PR TITLE
fix oom: set partitionPerSplit default value = 1

### DIFF
--- a/tikv-client/src/main/java/com/pingcap/tikv/TiConfiguration.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/TiConfiguration.java
@@ -53,7 +53,7 @@ public class TiConfiguration implements Serializable {
   private static final boolean DEF_WRITE_ALLOW_SPARK_SQL = false;
   private static final boolean DEF_WRITE_WITHOUT_LOCK_TABLE = false;
   private static final int DEF_TIKV_REGION_SPLIT_SIZE_IN_MB = 96;
-  private static final int DEF_PARTITION_PER_SPLIT = 10;
+  private static final int DEF_PARTITION_PER_SPLIT = 1;
   private static final List<TiStoreType> DEF_ISOLATION_READ_ENGINES =
       ImmutableList.of(TiStoreType.TiKV, TiStoreType.TiFlash);
 

--- a/tikv-client/src/main/java/com/pingcap/tikv/TiSession.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/TiSession.java
@@ -163,15 +163,8 @@ public class TiSession implements AutoCloseable {
       synchronized (this) {
         if (tableScanThreadPool == null) {
           tableScanThreadPool =
-              // partitionPerSplit is added to batch region task in single CoprocessorIterator.
-              // When partitionPerSplit is larger than 1, original table scan concurrency setting
-              // may lead to high context switch in thread pool which causes performance regression.
-
-              // To address this problem, we take a division of original table scan concurrency and
-              // partitionPerSplit to create thread pool. In this way, we can decrease
-              // the thread competition.
               Executors.newFixedThreadPool(
-                  conf.getTableScanConcurrency() / conf.getPartitionPerSplit(),
+                  conf.getTableScanConcurrency(),
                   new ThreadFactoryBuilder().setDaemon(true).build());
         }
         res = tableScanThreadPool;


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
closing https://github.com/pingcap/tispark/issues/1518

### What is changed and how it works?
set partitionPerSplit default value = 1

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

