### PR TITLE
ignore sequence

### DIFF
--- a/core/src/test/scala/org/apache/spark/sql/SequenceTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/SequenceTestSuite.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql
+
+class SequenceTestSuite extends BaseTiSparkTest {
+  private val table = "test_seq"
+
+  test("Test seq") {
+    dropTbl()
+
+    tidbStmt.execute(s"create table $table(qty INT, price INT);")
+    tidbStmt.execute(s"INSERT INTO $table VALUES(3, 50);")
+
+    try {
+      tidbStmt.execute(s"CREATE sequence sq_test;")
+    } catch {
+      case _: Exception => cancel
+    }
+
+    refreshConnections()
+
+    judge(s"select * from $table")
+
+    spark.sql("show tables").show(false)
+  }
+
+  override def afterAll(): Unit = {
+    dropTbl()
+  }
+
+  private def dropTbl() = {
+    tidbStmt.execute(s"drop table if exists $table")
+    try {
+      tidbStmt.execute("drop sequence if exists sq_test")
+    } catch {
+      case _: Exception => cancel
+    }
+  }
+}

--- a/tikv-client/src/main/java/com/pingcap/tikv/catalog/Catalog.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/catalog/Catalog.java
@@ -162,7 +162,10 @@ public class Catalog implements AutoCloseable {
         tableMap = loadTables(db);
       }
       Collection<TiTableInfo> tables = tableMap.values();
-      return tables.stream().filter(tbl -> !tbl.isView()).collect(Collectors.toList());
+      return tables
+          .stream()
+          .filter(tbl -> !tbl.isView() || !tbl.isSequence())
+          .collect(Collectors.toList());
     }
 
     public TiTableInfo getTable(TiDBInfo db, String tableName) {
@@ -173,7 +176,7 @@ public class Catalog implements AutoCloseable {
       TiTableInfo tbl = tableMap.get(tableName.toLowerCase());
       // https://github.com/pingcap/tispark/issues/961
       // TODO: support reading from view table in the future.
-      if (tbl != null && tbl.isView()) return null;
+      if (tbl != null && (tbl.isView() || tbl.isSequence())) return null;
       return tbl;
     }
 

--- a/tikv-client/src/main/java/com/pingcap/tikv/meta/TiSequenceInfo.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/meta/TiSequenceInfo.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pingcap.tikv.meta;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.io.Serializable;
+
+public class TiSequenceInfo implements Serializable {
+  private final long sequenceStart;
+  private final boolean sequenceCache;
+  private final boolean sequenceCycle;
+  private final long sequenceMinValue;
+  private final long sequenceMaxValue;
+  private final long sequenceIncrement;
+  private final long sequenceCacheValue;
+  private final String sequenceComment;
+
+  @JsonCreator
+  public TiSequenceInfo(
+      @JsonProperty("sequence_start") long sequenceStart,
+      @JsonProperty("sequence_cache") boolean sequenceCache,
+      @JsonProperty("sequence_cycle") boolean sequenceCycle,
+      @JsonProperty("sequence_min_value") long sequenceMinValue,
+      @JsonProperty("sequence_max_value") long sequenceMaxValue,
+      @JsonProperty("sequence_increment") long sequenceIncrement,
+      @JsonProperty("sequence_cache_value") long sequenceCacheValue,
+      @JsonProperty("sequence_comment") String sequenceComment) {
+    this.sequenceStart = sequenceStart;
+    this.sequenceCache = sequenceCache;
+    this.sequenceCycle = sequenceCycle;
+    this.sequenceMinValue = sequenceMinValue;
+    this.sequenceMaxValue = sequenceMaxValue;
+    this.sequenceIncrement = sequenceIncrement;
+    this.sequenceCacheValue = sequenceCacheValue;
+    this.sequenceComment = sequenceComment;
+  }
+}

--- a/tikv-client/src/test/java/com/pingcap/tikv/meta/MetaUtils.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/meta/MetaUtils.java
@@ -160,7 +160,8 @@ public class MetaUtils {
           null,
           null,
           version,
-          updateTimestamp);
+          updateTimestamp,
+          null);
     }
   }
 


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

When there is `sequence` in TiDB database, TiSpark failed to get catalog info

### What is changed and how it works?

Ignore the `sequence` object in TiDB database

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test
 - Manual test (add detailed scripts or steps below)

Side effects

 - Increased code complexity
