### PR TITLE
BatchWrite: add parameter regionSplitUsingSize

### DIFF
--- a/core/src/main/scala/com/pingcap/tispark/write/TiDBOptions.scala
+++ b/core/src/main/scala/com/pingcap/tispark/write/TiDBOptions.scala
@@ -105,6 +105,10 @@ class TiDBOptions(@transient val parameters: CaseInsensitiveMap[String]) extends
   val minRegionSplitNum: Int = getOrDefault(TIDB_MIN_REGION_SPLIT_NUM, "4").toInt
   val regionSplitThreshold: Int = getOrDefault(TIDB_REGION_SPLIT_THRESHOLD, "100000").toInt
   val splitRegionBackoffMS: Int = getOrDefault(TIDB_SPLIT_REGION_BACKOFFER_MS, "120000").toInt
+  val regionSplitUsingSize: Boolean =
+    getOrDefault(TIDB_REGION_SPLIT_USING_SIZE, "false").toBoolean
+  //96M
+  val bytesPerRegion: Int = getOrDefault(TIDB_BYTES_PER_REGION, "100663296").toInt
 
   // ------------------------------------------------------------
   // Calculated parameters
@@ -219,6 +223,8 @@ object TiDBOptions {
   val TIDB_MIN_REGION_SPLIT_NUM: String = newOption("minRegionSplitNum")
   val TIDB_REGION_SPLIT_THRESHOLD: String = newOption("regionSplitThreshold")
   val TIDB_SPLIT_REGION_BACKOFFER_MS: String = newOption("splitRegionBackoffMS")
+  val TIDB_REGION_SPLIT_USING_SIZE: String = newOption("regionSplitUsingSize")
+  val TIDB_BYTES_PER_REGION: String = newOption("bytesPerRegion")
 
   // ------------------------------------------------------------
   // parameters only for test


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
Currently,  regions are split according to 960000 keys.
But if the table has a large number of columns, some huge regions will occur on Grafana.

### What is changed and how it works?
The size of values should be used to split regions.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

