### PR TITLE
Fix covering index generates incorrect plan when first column is not included in index

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/catalyst/expressions/ExprUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/catalyst/expressions/ExprUtils.scala
@@ -80,8 +80,12 @@ object ExprUtils {
             val col = meta.getColumns.asScala.filter(col => col.isPrimaryKey).head
             ColumnRef.create(col.getName, meta)
           } else {
-            val firstCol = meta.getColumns.get(0)
-            ColumnRef.create(firstCol.getName, meta)
+            if (dagRequest.getFields.isEmpty) {
+              val firstCol = meta.getColumns.get(0)
+              ColumnRef.create(firstCol.getName, meta)
+            } else {
+              dagRequest.getFields.head
+            }
           }
 
           dagRequest.addRequiredColumn(firstColRef)

--- a/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
@@ -19,6 +19,7 @@ import com.pingcap.tispark.TiConfigConst
 import org.apache.spark.sql.functions.{col, sum}
 
 class IssueTestSuite extends BaseTiSparkTest {
+  // https://github.com/pingcap/tispark/issues/1570
   test("Fix covering index generates incorrect plan when first column is not included in index") {
     tidbStmt.execute("DROP TABLE IF EXISTS tt")
     tidbStmt.execute("create table tt(c varchar(12), dt datetime, key dt_index(dt))")
@@ -29,10 +30,8 @@ class IssueTestSuite extends BaseTiSparkTest {
                        | ('cc', '2007-09-03 00:00:00'),
                        | ('dd', '2007-09-04 00:00:00')""".stripMargin)
 
-    spark
-      .sql(
-        "select count(*) from tt where dt >= timestamp '2007-09-01 00:00:01' and dt <=  timestamp '2007-09-04 00:00:00'")
-      .show(false)
+    runTest(
+      "select count(*) from tt where dt >= timestamp '2007-09-01 00:00:01' and dt <=  timestamp '2007-09-04 00:00:00'")
   }
 
   test("fix partition table pruning when partdef contains bigint") {


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
Close #1570 

### What is changed and how it works?
Check if DAGRequest contains other columns when building plan for `count(1)`, use them in prior.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Related changes

 - Need to cherry-pick to the release branch
 - Need to be included in the release note

Release Note

`Fix covering index generates incorrect plan when first column is not included in index`