### PR TITLE
prewrite primary key backoffer use prewriteBackOfferMS

### DIFF
--- a/core/src/main/scala/com/pingcap/tispark/write/TiBatchWrite.scala
+++ b/core/src/main/scala/com/pingcap/tispark/write/TiBatchWrite.scala
@@ -16,7 +16,7 @@
 package com.pingcap.tispark.write
 
 import com.pingcap.tikv.exception.TiBatchWriteException
-import com.pingcap.tikv.util.{BackOffer, ConcreteBackOffer}
+import com.pingcap.tikv.util.ConcreteBackOffer
 import com.pingcap.tikv.{TTLManager, TiDBJDBCClient, _}
 import com.pingcap.tispark.TiDBUtils
 import com.pingcap.tispark.utils.TiUtil
@@ -252,7 +252,7 @@ class TiBatchWrite(
         options.writeThreadPerTask,
         options.retryCommitSecondaryKey)
     val prewritePrimaryBackoff =
-      ConcreteBackOffer.newCustomBackOff(BackOffer.BATCH_PREWRITE_BACKOFF)
+      ConcreteBackOffer.newCustomBackOff(options.prewriteBackOfferMS)
     logger.info("start to prewritePrimaryKey")
     ti2PCClient.prewritePrimaryKey(prewritePrimaryBackoff, primaryKey.bytes, primaryRow)
     logger.info("prewritePrimaryKey success")

--- a/tikv-client/src/main/java/com/pingcap/tikv/util/BackOffer.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/util/BackOffer.java
@@ -17,8 +17,6 @@
 
 package com.pingcap.tikv.util;
 
-import com.pingcap.tikv.TTLManager;
-
 public interface BackOffer {
   // Back off types.
   int seconds = 1000;
@@ -35,7 +33,6 @@ public interface BackOffer {
   int GC_DELETE_RANGE_MAX_BACKOFF = 100 * seconds;
   int RAWKV_MAX_BACKOFF = 40 * seconds;
   int SPLIT_REGION_BACKOFF = 20 * seconds;
-  int BATCH_PREWRITE_BACKOFF = TTLManager.MANAGED_LOCK_TTL;
   int BATCH_COMMIT_BACKOFF = 10 * seconds;
   int PD_INFO_BACKOFF = 5 * seconds;
 


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
currently prewrite key backoffer = 20s

### What is changed and how it works?
prewrite primary key backoffer use parameter `prewriteBackOfferMS`

