### PR TITLE
BatchWrite: use ShardRowIDBits to generate row id

### DIFF
--- a/core/src/test/scala/com/pingcap/tispark/datasource/AutoIncrementSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/AutoIncrementSuite.scala
@@ -15,6 +15,7 @@
 
 package com.pingcap.tispark.datasource
 
+import com.pingcap.tikv.exception.ConvertOverflowException
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types._
 
@@ -77,7 +78,7 @@ class AutoIncrementSuite extends BaseDataSourceTest("test_datasource_auto_increm
     assert(5 == sql(s"select * from $dbtableWithPrefix").collect().length)
   }
 
-  test("signed tidb overflow") {
+  test("bigint signed tidb overflow") {
     if (!supportBatchWrite) {
       cancel
     }
@@ -110,7 +111,7 @@ class AutoIncrementSuite extends BaseDataSourceTest("test_datasource_auto_increm
     assert(caught.getMessage.equals("Failed to read auto-increment value from storage engine"))
   }
 
-  test("signed tispark overflow") {
+  test("bigint signed tispark overflow") {
     if (!supportBatchWrite) {
       cancel
     }
@@ -145,7 +146,7 @@ class AutoIncrementSuite extends BaseDataSourceTest("test_datasource_auto_increm
     assert(caught.getMessage.equals("cannot allocate ids for this write"))
   }
 
-  test("unsigned tidb overflow") {
+  test("bigint unsigned tidb overflow") {
     if (!supportBatchWrite) {
       cancel
     }
@@ -177,7 +178,7 @@ class AutoIncrementSuite extends BaseDataSourceTest("test_datasource_auto_increm
     assert(caught.getMessage.equals("Failed to read auto-increment value from storage engine"))
   }
 
-  test("unsigned tispark overflow") {
+  test("bigint unsigned tispark overflow") {
     if (!supportBatchWrite) {
       cancel
     }
@@ -210,6 +211,139 @@ class AutoIncrementSuite extends BaseDataSourceTest("test_datasource_auto_increm
       tidbWrite((1L to 1L).map(Row(_)).toList, schema)
     }
     assert(caught.getMessage.equals("cannot allocate ids for this write"))
+  }
+
+  test("tinyint signed tidb overflow") {
+    if (!supportBatchWrite) {
+      cancel
+    }
+
+    val schema = StructType(List(StructField("j", LongType)))
+
+    dropTable()
+
+    jdbcUpdate(
+      s"create table $dbtable(i tinyint NOT NULL AUTO_INCREMENT, j int NOT NULL, primary key (i))")
+
+    // TiSpark insert
+    tidbWrite((1L to 1L).map(Row(_)).toList, schema)
+
+    // hack: update AllocateId on TiKV to a huge number to trigger overflow
+    val size = 125
+    val allocator = allocateID(size)
+    println(s"start: \t${getLongBinaryString(allocator.getStart)}")
+    println(s"end: \t${getLongBinaryString(allocator.getEnd)}")
+
+    // TiDB insert
+    jdbcUpdate(s"insert into $dbtable (j) values(1)")
+
+    sql(s"select * from $dbtableWithPrefix").show(false)
+
+    // TiDB insert overflow
+    val caught = intercept[java.sql.SQLException] {
+      jdbcUpdate(s"insert into $dbtable (j) values(1)")
+    }
+    assert(caught.getMessage.equals("Data truncation: constant 128 overflows tinyint"))
+  }
+
+  test("tinyint signed tispark overflow") {
+    if (!supportBatchWrite) {
+      cancel
+    }
+
+    val schema = StructType(List(StructField("j", LongType)))
+
+    dropTable()
+
+    jdbcUpdate(
+      s"create table $dbtable(i tinyint NOT NULL AUTO_INCREMENT, j int NOT NULL, primary key (i))")
+
+    // TiSpark insert
+    tidbWrite((1L to 1L).map(Row(_)).toList, schema)
+
+    // hack: update AllocateId on TiKV to a huge number to trigger overflow
+    val size = 125
+    val allocator = allocateID(size)
+    println(s"start: \t${getLongBinaryString(allocator.getStart)}")
+    println(s"end: \t${getLongBinaryString(allocator.getEnd)}")
+
+    // TiSpark insert
+    tidbWrite((1L to 1L).map(Row(_)).toList, schema)
+
+    sql(s"select * from $dbtableWithPrefix").show(false)
+
+    // TiSpark insert overflow
+    val caught = intercept[org.apache.spark.SparkException] {
+      tidbWrite((1L to 1L).map(Row(_)).toList, schema)
+    }
+    assert(caught.getCause.isInstanceOf[ConvertOverflowException])
+    assert(caught.getCause.getMessage.equals("value 128 > upperBound 127"))
+  }
+
+  test("tinyint unsigned tidb overflow") {
+    if (!supportBatchWrite) {
+      cancel
+    }
+
+    val schema = StructType(List(StructField("j", LongType)))
+
+    dropTable()
+
+    jdbcUpdate(
+      s"create table $dbtable(i tinyint unsigned NOT NULL AUTO_INCREMENT, j int NOT NULL, primary key (i))")
+
+    // TiSpark insert
+    tidbWrite((1L to 1L).map(Row(_)).toList, schema)
+
+    // hack: update AllocateId on TiKV to a huge number to trigger overflow
+    val size = 253
+    val allocator = allocateID(size)
+    println(s"start: \t${getLongBinaryString(allocator.getStart)}")
+    println(s"end: \t${getLongBinaryString(allocator.getEnd)}")
+
+    // TiDB insert
+    jdbcUpdate(s"insert into $dbtable (j) values(1)")
+    sql(s"select * from $dbtableWithPrefix").show(false)
+
+    // TiDB insert overflow
+    val caught = intercept[java.sql.SQLException] {
+      jdbcUpdate(s"insert into $dbtable (j) values(1)")
+    }
+    assert(caught.getMessage.equals("Data truncation: constant 256 overflows tinyint"))
+  }
+
+  test("tinyint unsigned tispark overflow") {
+    if (!supportBatchWrite) {
+      cancel
+    }
+
+    val schema = StructType(List(StructField("j", LongType)))
+
+    dropTable()
+
+    jdbcUpdate(
+      s"create table $dbtable(i tinyint unsigned NOT NULL AUTO_INCREMENT, j int NOT NULL, primary key (i))")
+
+    // TiSpark insert
+    tidbWrite((1L to 1L).map(Row(_)).toList, schema)
+
+    // hack: update AllocateId on TiKV to a huge number to trigger overflow
+    val size = 253
+    val allocator = allocateID(size)
+    println(s"start: \t${getLongBinaryString(allocator.getStart)}")
+    println(s"end: \t${getLongBinaryString(allocator.getEnd)}")
+
+    // TiSpark insert
+    tidbWrite((1L to 1L).map(Row(_)).toList, schema)
+
+    sql(s"select * from $dbtableWithPrefix").show(false)
+
+    // TiSpark insert overflow
+    val caught = intercept[org.apache.spark.SparkException] {
+      tidbWrite((1L to 1L).map(Row(_)).toList, schema)
+    }
+    assert(caught.getCause.isInstanceOf[ConvertOverflowException])
+    assert(caught.getCause.getMessage.equals("value 256 > upperBound 255"))
   }
 
   override def afterAll(): Unit =

--- a/core/src/test/scala/com/pingcap/tispark/datasource/ColumnMappingSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/ColumnMappingSuite.scala
@@ -92,7 +92,7 @@ class ColumnMappingSuite
     // insert 2 rows
     //val (ref, insert) = generateData(1,10, List(2,0,1))
     var posMap = List(1, 0)
-    var data = generateData(0, 10, posMap, skipFirstCol = true)
+    var data = generateData(1, 10, posMap, skipFirstCol = true)
     var ans = data._1
 
     var writeSchema = StructType(List(schema.toList(posMap(0) + 1), schema.toList(posMap(1) + 1)))
@@ -100,7 +100,7 @@ class ColumnMappingSuite
     testTiDBSelect(ans)
 
     posMap = List(0, 1)
-    data = generateData(10, 10, posMap, skipFirstCol = true)
+    data = generateData(11, 10, posMap, skipFirstCol = true)
     ans = ans ::: data._1
     writeSchema = StructType(List(schema.toList(posMap(0) + 1), schema.toList(posMap(1) + 1)))
     tidbWrite(data._2, writeSchema)

--- a/core/src/test/scala/com/pingcap/tispark/datasource/ShardRowIDBitsSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/ShardRowIDBitsSuite.scala
@@ -15,24 +15,123 @@
 
 package com.pingcap.tispark.datasource
 
+import com.pingcap.tikv.allocator.RowIDAllocator
 import org.apache.spark.sql.Row
-import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
+import org.apache.spark.sql.types._
 
-class ShardRowIDBitsSuite extends BaseDataSourceTest("test_shard_row_id_bits") {
-  private val row = (0 to 12).map(x => Row(x.toString)).toArray
-  private val schema = StructType(List(StructField("a", StringType)))
+class ShardRowIDBitsSuite extends BaseDataSourceTest("test_datasource_shard_row_id_bits") {
+  private val schema = StructType(List(StructField("i", LongType)))
 
-  test("reading and writing a table with shard_row_id_bits") {
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+  }
+
+  test("tispark overflow") {
+    val maxShardRowIDBits = 15
+
+    dropTable()
+
+    jdbcUpdate(s"create table $dbtable(i int) SHARD_ROW_ID_BITS = $maxShardRowIDBits")
+
+    // TiSpark insert
+    tidbWrite((1L to 1L).map(Row(_)).toList, schema)
+
+    // hack: update AllocateId on TiKV to a huge number to trigger overflow
+    val size = Math.pow(2, 64 - maxShardRowIDBits - 1).toLong - 3
+    val allocator = allocateID(size)
+    println(s"start: \t${getLongBinaryString(allocator.getStart)}")
+    println(s"end: \t${getLongBinaryString(allocator.getEnd)}")
+
+    // TiSpark insert
+    tidbWrite((1L to 1L).map(Row(_)).toList, schema)
+
+    // TiSpark insert overflow
+
+    val caught = intercept[com.pingcap.tikv.exception.AllocateRowIDOverflowException] {
+      tidbWrite((1L to 1L).map(Row(_)).toList, schema)
+    }
+    assert(caught.getMessage.startsWith("Overflow when allocating row id"))
+  }
+
+  test("tidb overflow") {
+    val maxShardRowIDBits = 15
+
+    dropTable()
+
+    jdbcUpdate(s"create table $dbtable(i int) SHARD_ROW_ID_BITS = $maxShardRowIDBits")
+
+    // TiSpark insert
+    tidbWrite((1L to 1L).map(Row(_)).toList, schema)
+
+    // hack: update AllocateId on TiKV to a huge number to trigger overflow
+    val size = Math.pow(2, 64 - maxShardRowIDBits - 1).toLong - 3
+    val allocator = allocateID(size)
+    println(s"start: \t${getLongBinaryString(allocator.getStart)}")
+    println(s"end: \t${getLongBinaryString(allocator.getEnd)}")
+
+    // TiDB insert
+    jdbcUpdate(s"insert into $dbtable values(1)")
+
+    // TiDB insert overflow
+    val caught = intercept[java.sql.SQLException] {
+      jdbcUpdate(s"insert into $dbtable values(1)")
+    }
+    assert(caught.getMessage.equals("Failed to read auto-increment value from storage engine"))
+  }
+
+  test("test rowid overlap: tidb write -> tispark write -> tidb write") {
     if (!supportBatchWrite) {
       cancel
     }
 
-    dropTable()
-    jdbcUpdate(s"CREATE TABLE $dbtable( `a` varchar(11)) SHARD_ROW_ID_BITS=2 PRE_SPLIT_REGIONS=2")
-    jdbcUpdate(s"insert into $dbtable(a) values(null),('0'),('1'),('2'),('3'),('4')")
-    tidbWrite(List(row(5), row(6), row(7)), schema)
-    jdbcUpdate(s"insert into $dbtable values('8'),('9'),('10'),('11'),('12')")
+    val maxShardRowIDBits = 0
 
-    testTiDBSelect(List(Row(null)) ++ row.sortBy(r => r.getString(0)), sortCol = "a")
+    dropTable()
+
+    jdbcUpdate(s"create table $dbtable(i int) SHARD_ROW_ID_BITS = $maxShardRowIDBits")
+
+    // TiDB insert
+    jdbcUpdate(s"insert into $dbtable values(1)")
+
+    // TiSpark insert
+    tidbWrite((2L to 2L).map(Row(_)).toList, schema)
+    printTableWithTiDBRowID()
+    val tidbRowID = queryTiDBViaJDBC(s"select _tidb_rowid, i from $dbtable where i = 2").head.head
+      .asInstanceOf[Long]
+
+    // TiDB insert
+    generateDataViaTiDB(tidbRowID + 10000, 3L)
+    printTableWithTiDBRowID(where = "where i = 2")
+
+    // assert
+    val tidbRowID2 = queryTiDBViaJDBC(
+      s"select _tidb_rowid, i from $dbtable where i = 2").head.head.asInstanceOf[Long]
+    assert(tidbRowID == tidbRowID2)
   }
+
+  private def printTableWithTiDBRowID(where: String = ""): Unit = {
+    queryTiDBViaJDBC(s"select _tidb_rowid, i from $dbtable $where order by i").foreach { row =>
+      print(getLongBinaryString(row.head.asInstanceOf[Long]))
+      println("\t" + row)
+    }
+  }
+
+  private def getTableCount: Long = {
+    queryTiDBViaJDBC(s"select count(*) from $dbtable").head.head.asInstanceOf[Long]
+  }
+
+  private def generateDataViaTiDB(minCount: Long, value: Long) = {
+    (1 to 10).foreach(i => jdbcUpdate(s"insert into $dbtable values($value)"))
+
+    while (getTableCount < minCount) {
+      jdbcUpdate(s"insert into $dbtable select * from $dbtable where i = $value limit 200000")
+    }
+  }
+
+  override def afterAll(): Unit =
+    try {
+      dropTable()
+    } finally {
+      super.afterAll()
+    }
 }

--- a/core/src/test/scala/com/pingcap/tispark/overflow/BitOverflowSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/overflow/BitOverflowSuite.scala
@@ -110,7 +110,7 @@ class BitOverflowSuite extends BaseDataSourceTest("test_data_type_bit_overflow")
     val schema = StructType(List(StructField("c1", ByteType)))
     val jdbcErrorClass = classOf[java.sql.BatchUpdateException]
     val tidbErrorClass = classOf[com.pingcap.tikv.exception.ConvertOverflowException]
-    val tidbErrorMsg = "value -1 < lowerBound 0"
+    val tidbErrorMsg = null
 
     compareTiDBWriteFailureWithJDBC(
       List(row),
@@ -184,7 +184,7 @@ class BitOverflowSuite extends BaseDataSourceTest("test_data_type_bit_overflow")
     val schema = StructType(List(StructField("c1", ByteType)))
     val jdbcErrorClass = classOf[java.sql.BatchUpdateException]
     val tidbErrorClass = classOf[com.pingcap.tikv.exception.ConvertOverflowException]
-    val tidbErrorMsg = "value -1 < lowerBound 0"
+    val tidbErrorMsg = null
 
     compareTiDBWriteFailureWithJDBC(
       List(row),
@@ -245,7 +245,7 @@ class BitOverflowSuite extends BaseDataSourceTest("test_data_type_bit_overflow")
     val schema = StructType(List(StructField("c1", LongType)))
     val jdbcErrorClass = classOf[java.sql.BatchUpdateException]
     val tidbErrorClass = classOf[com.pingcap.tikv.exception.ConvertOverflowException]
-    val tidbErrorMsg = "value -1 < lowerBound 0"
+    val tidbErrorMsg = null
 
     compareTiDBWriteFailureWithJDBC(
       List(row),

--- a/core/src/test/scala/com/pingcap/tispark/overflow/UnsignedOverflowSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/overflow/UnsignedOverflowSuite.scala
@@ -113,7 +113,7 @@ class UnsignedOverflowSuite extends BaseDataSourceTest("test_data_type_unsigned_
     val schema = StructType(List(StructField("c1", IntegerType)))
     val jdbcErrorClass = classOf[java.sql.BatchUpdateException]
     val tidbErrorClass = classOf[com.pingcap.tikv.exception.ConvertOverflowException]
-    val tidbErrorMsg = "value -1 < lowerBound 0"
+    val tidbErrorMsg = null
 
     compareTiDBWriteFailureWithJDBC(
       List(row),
@@ -185,7 +185,7 @@ class UnsignedOverflowSuite extends BaseDataSourceTest("test_data_type_unsigned_
     val schema = StructType(List(StructField("c1", IntegerType)))
     val jdbcErrorClass = classOf[java.sql.BatchUpdateException]
     val tidbErrorClass = classOf[com.pingcap.tikv.exception.ConvertOverflowException]
-    val tidbErrorMsg = "value -1 < lowerBound 0"
+    val tidbErrorMsg = null
 
     compareTiDBWriteFailureWithJDBC(
       List(row),
@@ -257,7 +257,7 @@ class UnsignedOverflowSuite extends BaseDataSourceTest("test_data_type_unsigned_
     val schema = StructType(List(StructField("c1", IntegerType)))
     val jdbcErrorClass = classOf[java.sql.BatchUpdateException]
     val tidbErrorClass = classOf[com.pingcap.tikv.exception.ConvertOverflowException]
-    val tidbErrorMsg = "value -1 < lowerBound 0"
+    val tidbErrorMsg = null
 
     compareTiDBWriteFailureWithJDBC(
       List(row),

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/Converter.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/Converter.java
@@ -113,6 +113,7 @@ public class Converter {
     } else {
       throw new ConvertNotSupportException(value.getClass().getName(), "UNSIGNED");
     }
+
     long lowerBound = 0L;
     if (java.lang.Long.compareUnsigned(result, lowerBound) < 0) {
       throw ConvertOverflowException.newLowerBoundException(result, lowerBound);

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/Converter.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/Converter.java
@@ -113,11 +113,6 @@ public class Converter {
     } else {
       throw new ConvertNotSupportException(value.getClass().getName(), "UNSIGNED");
     }
-
-    if (!(value instanceof String) && result < 0) {
-      throw ConvertOverflowException.newLowerBoundException(result, 0);
-    }
-
     long lowerBound = 0L;
     if (java.lang.Long.compareUnsigned(result, lowerBound) < 0) {
       throw ConvertOverflowException.newLowerBoundException(result, lowerBound);

--- a/tikv-client/src/test/java/com/pingcap/tikv/allocator/RowIDAllocatorTest.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/allocator/RowIDAllocatorTest.java
@@ -15,6 +15,7 @@
 
 package com.pingcap.tikv.allocator;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -28,5 +29,116 @@ public class RowIDAllocatorTest {
     assertFalse(RowIDAllocator.shardRowBitsOverflow(0, 0xffffffffffffffL, 7, true));
     assertTrue(RowIDAllocator.shardRowBitsOverflow(0, 0x8000000000000000L, 2, false));
     assertFalse(RowIDAllocator.shardRowBitsOverflow(0, 0xff, 64 - 8, false));
+  }
+
+  @Test
+  public void TestGetShardRowId() {
+    {
+      long maxShardRowIDBits = 1L;
+      long partitionIndex = 0L;
+      assertEquals(
+          RowIDAllocator.getShardRowId(maxShardRowIDBits, partitionIndex, 0x0000000000000000L),
+          0x0000000000000000L);
+      assertEquals(
+          RowIDAllocator.getShardRowId(maxShardRowIDBits, partitionIndex, 0x0fffffffffffffffL),
+          0x0fffffffffffffffL);
+      assertEquals(
+          RowIDAllocator.getShardRowId(maxShardRowIDBits, partitionIndex, 0x10000000000000efL),
+          0x10000000000000efL);
+      assertEquals(
+          RowIDAllocator.getShardRowId(maxShardRowIDBits, partitionIndex, 0x200000000000000fL),
+          0x200000000000000fL);
+      assertEquals(
+          RowIDAllocator.getShardRowId(maxShardRowIDBits, partitionIndex, 0x3000000000000000L),
+          0x3000000000000000L);
+    }
+
+    {
+      long maxShardRowIDBits = 1L;
+      long partitionIndex = 1L;
+      assertEquals(
+          RowIDAllocator.getShardRowId(maxShardRowIDBits, partitionIndex, 0x0000000000000000L),
+          0x4000000000000000L);
+      assertEquals(
+          RowIDAllocator.getShardRowId(maxShardRowIDBits, partitionIndex, 0x0fffffffffffffffL),
+          0x4fffffffffffffffL);
+      assertEquals(
+          RowIDAllocator.getShardRowId(maxShardRowIDBits, partitionIndex, 0x10000000000000efL),
+          0x50000000000000efL);
+      assertEquals(
+          RowIDAllocator.getShardRowId(maxShardRowIDBits, partitionIndex, 0x200000000000000fL),
+          0x600000000000000fL);
+      assertEquals(
+          RowIDAllocator.getShardRowId(maxShardRowIDBits, partitionIndex, 0x3000000000000000L),
+          0x7000000000000000L);
+    }
+
+    {
+      long maxShardRowIDBits = 15L;
+      long partitionIndex = 0L;
+      assertEquals(
+          RowIDAllocator.getShardRowId(maxShardRowIDBits, partitionIndex, 0x0000000000000000L),
+          0x0000000000000000L);
+      assertEquals(
+          RowIDAllocator.getShardRowId(maxShardRowIDBits, partitionIndex, 0x0000ffffffffffffL),
+          0x0000ffffffffffffL);
+      assertEquals(
+          RowIDAllocator.getShardRowId(maxShardRowIDBits, partitionIndex, 0x00001000000000efL),
+          0x00001000000000efL);
+      assertEquals(
+          RowIDAllocator.getShardRowId(maxShardRowIDBits, partitionIndex, 0x0000ffffffffffffL),
+          0x0000ffffffffffffL);
+    }
+
+    {
+      long maxShardRowIDBits = 15L;
+      long partitionIndex = 1L;
+      assertEquals(
+          RowIDAllocator.getShardRowId(maxShardRowIDBits, partitionIndex, 0x0000000000000000L),
+          0x0001000000000000L);
+      assertEquals(
+          RowIDAllocator.getShardRowId(maxShardRowIDBits, partitionIndex, 0x0000ffffffffffffL),
+          0x0001ffffffffffffL);
+      assertEquals(
+          RowIDAllocator.getShardRowId(maxShardRowIDBits, partitionIndex, 0x00001000000000efL),
+          0x00011000000000efL);
+      assertEquals(
+          RowIDAllocator.getShardRowId(maxShardRowIDBits, partitionIndex, 0x0000ffffffffffffL),
+          0x0001ffffffffffffL);
+    }
+
+    {
+      long maxShardRowIDBits = 15L;
+      long partitionIndex = (1L << 15) - 2;
+      assertEquals(
+          RowIDAllocator.getShardRowId(maxShardRowIDBits, partitionIndex, 0x0000000000000000L),
+          0x7ffe000000000000L);
+      assertEquals(
+          RowIDAllocator.getShardRowId(maxShardRowIDBits, partitionIndex, 0x0000ffffffffffffL),
+          0x7ffeffffffffffffL);
+      assertEquals(
+          RowIDAllocator.getShardRowId(maxShardRowIDBits, partitionIndex, 0x00001000000000efL),
+          0x7ffe1000000000efL);
+      assertEquals(
+          RowIDAllocator.getShardRowId(maxShardRowIDBits, partitionIndex, 0x0000ffffffffffffL),
+          0x7ffeffffffffffffL);
+    }
+
+    {
+      long maxShardRowIDBits = 15L;
+      long partitionIndex = (1L << 15) - 1;
+      assertEquals(
+          RowIDAllocator.getShardRowId(maxShardRowIDBits, partitionIndex, 0x0000000000000000L),
+          0x7fff000000000000L);
+      assertEquals(
+          RowIDAllocator.getShardRowId(maxShardRowIDBits, partitionIndex, 0x0000ffffffffffffL),
+          0x7fffffffffffffffL);
+      assertEquals(
+          RowIDAllocator.getShardRowId(maxShardRowIDBits, partitionIndex, 0x00001000000000efL),
+          0x7fff1000000000efL);
+      assertEquals(
+          RowIDAllocator.getShardRowId(maxShardRowIDBits, partitionIndex, 0x0000ffffffffffffL),
+          0x7fffffffffffffffL);
+    }
   }
 }


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
currently `ShardRowIDBits` is ignored when generating row id

### What is changed and how it works?
use `ShardRowIDBits` to generate row id

fix a bug:
- tidb starts row id with `1`
- but tispark starts with `0`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
