### PR TITLE
Fix partition table on tiflash

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/execution/CoprocessorRDD.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/CoprocessorRDD.scala
@@ -52,12 +52,13 @@ trait LeafColumnarExecRDD extends LeafExecNode {
   override def verboseString: String =
     if (tiRDDs.lengthCompare(1) > 0) {
       val b = new mutable.StringBuilder()
-      b.append(s"TiSpark $nodeName on partition table:\n")
-      tiRDDs.zipWithIndex.map {
-        case (_, i) => b.append(s" partition p$i")
+      b.append("partition table[\n")
+      tiRDDs.zipWithIndex.foreach { z =>
+        val zr = z._1.dagRequest
+        b.append(s" ${zr.getStoreType.name()} $nodeName{$zr} ${TiUtil.getReqEstCountStr(zr)}\n")
       }
-      b.append(s" with dag request: $dagRequest")
-      b.toString()
+      b.append("]")
+      b.toString
     } else {
       s"${dagRequest.getStoreType.name()} $nodeName{$dagRequest}" +
         s"${TiUtil.getReqEstCountStr(dagRequest)}"
@@ -205,7 +206,7 @@ case class ColumnarRegionTaskExec(
         indexTasks.addAll(
           RangeSplitter
             .newSplitter(session.getRegionManager)
-            .splitAndSortHandlesByRegion(dagRequest.getIds, handles))
+            .splitAndSortHandlesByRegion(dagRequest.getPrunedPhysicalIds, handles))
         indexTasks
       }
 

--- a/core/src/test/scala/org/apache/spark/sql/test/SharedSQLContext.scala
+++ b/core/src/test/scala/org/apache/spark/sql/test/SharedSQLContext.scala
@@ -111,7 +111,7 @@ trait SharedSQLContext
 
     if (check.isEmpty) {
       throw new RuntimeException(
-        s"$tableName not found in TiDB after load. Load SQL file failed.")
+        s"$tableName not found in TiDB after load. Load Data to TiFlash failed.")
     }
     logger.info(s"Table $tableName found present in ${check.head.head}")
     for (_ <- 0 until 60) {

--- a/tikv-client/src/main/java/com/pingcap/tikv/meta/TiDAGRequest.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/meta/TiDAGRequest.java
@@ -114,7 +114,7 @@ public class TiDAGRequest implements Serializable {
   private TiStoreType storeType = TiStoreType.TiKV;
   private TiIndexInfo indexInfo;
   private List<Long> prunedPhysicalIds = new ArrayList<>();
-  private Map<Long, String> prunedPartNames = new HashMap<>();
+  private final Map<Long, String> prunedPartNames = new HashMap<>();
   private long physicalId;
   private int pushDownLimits;
   private int limit;
@@ -157,13 +157,15 @@ public class TiDAGRequest implements Serializable {
 
   public void setPrunedParts(List<TiPartitionDef> prunedParts) {
     this.prunedParts = prunedParts;
-    List<Long> ids = new ArrayList<>();
-    prunedPartNames.clear();
-    for (TiPartitionDef pDef : prunedParts) {
-      ids.add(pDef.getId());
-      prunedPartNames.put(pDef.getId(), pDef.getName());
+    if (prunedParts != null) {
+      List<Long> ids = new ArrayList<>();
+      prunedPartNames.clear();
+      for (TiPartitionDef pDef : prunedParts) {
+        ids.add(pDef.getId());
+        prunedPartNames.put(pDef.getId(), pDef.getName());
+      }
+      this.prunedPhysicalIds = ids;
     }
-    this.prunedPhysicalIds = ids;
   }
 
   public List<Long> getPrunedPhysicalIds() {

--- a/tikv-client/src/main/java/com/pingcap/tikv/operation/iterator/IndexScanIterator.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/operation/iterator/IndexScanIterator.java
@@ -71,7 +71,7 @@ public class IndexScanIterator implements Iterator<Row> {
           completionService.submit(
               () -> {
                 List<RegionTask> tasks = new ArrayList<>();
-                List<Long> ids = dagReq.getIds();
+                List<Long> ids = dagReq.getPrunedPhysicalIds();
                 tasks.addAll(
                     RangeSplitter.newSplitter(session.getRegionManager())
                         .splitAndSortHandlesByRegion(ids, handles));

--- a/tikv-client/src/main/java/com/pingcap/tikv/predicates/TiKVScanAnalyzer.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/predicates/TiKVScanAnalyzer.java
@@ -502,6 +502,8 @@ public class TiKVScanAnalyzer {
     }
 
     public static class Builder {
+      private final String tableName;
+      private final Logger logger = LoggerFactory.getLogger(getClass().getName());
       private Map<Long, List<KeyRange>> keyRanges;
       private Set<Expression> filters;
       private double cost;
@@ -510,8 +512,6 @@ public class TiKVScanAnalyzer {
       private double estimatedRowCount = -1;
       private List<TiPartitionDef> prunedParts;
       private TiStoreType storeType = TiStoreType.TiKV;
-      private final String tableName;
-      private final Logger logger = LoggerFactory.getLogger(getClass().getName());
 
       private Builder(String tableName) {
         this.tableName = tableName;


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
Close #1587 

### What is changed and how it works?
Partition table should use physical id rather than table id when building request.

Also, fix a performance issue relating to partition tables by only sending key ranges of one physical id at a time.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test

Related changes

 - Need to cherry-pick to the release branch
 - Need to be included in the release note
