### PR TITLE
Increase gRPC response default limit size to 2G

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ The configurations in the table below can be put together with `spark-defaults.c
 |    Key    | Default Value | Description |
 | ---------- | --- | --- |
 | `spark.tispark.pd.addresses` |  `127.0.0.1:2379` | The addresses of PD cluster, which are split by comma |
-| `spark.tispark.grpc.framesize` |  `268435456` | The maximum frame size of gRPC response |
+| `spark.tispark.grpc.framesize` |  `2147483647` | The maximum frame size of gRPC response in bytes (default 2G) |
 | `spark.tispark.grpc.timeout_in_sec` |  `10` | The gRPC timeout time in seconds |
 | `spark.tispark.plan.allow_agg_pushdown` |  `true` | Whether aggregations are allowed to push down to TiKV (in case of busy TiKV nodes) |
 | `spark.tispark.plan.allow_index_read` |  `true` |  Whether index is enabled in planning (which might cause heavy pressure on TiKV) |

--- a/tikv-client/src/main/java/com/pingcap/tikv/TiConfiguration.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/TiConfiguration.java
@@ -37,7 +37,7 @@ public class TiConfiguration implements Serializable {
   private static final int DEF_SCAN_BATCH_SIZE = 100;
   private static final boolean DEF_IGNORE_TRUNCATE = true;
   private static final boolean DEF_TRUNCATE_AS_WARNING = false;
-  private static final int DEF_MAX_FRAME_SIZE = 268435456 * 2; // 256 * 2 MB
+  private static final int DEF_MAX_FRAME_SIZE = 2147483647; // 2 GB
   private static final int DEF_INDEX_SCAN_BATCH_SIZE = 20000;
   private static final int DEF_REGION_SCAN_DOWNGRADE_THRESHOLD = 10000000;
   // if keyRange size per request exceeds this limit, the request might be too large to be accepted


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
Increase gRPC response default limit size to 2G. Because the region response may be larger than expected.

### What is changed and how it works?
Modify doc's and config's default value.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `tidb-ansible` repository
 - Need to be included in the release note
