### PR TITLE
update txnPrewriteBatchSize & txnCommitBatchSize default value to 16K

### DIFF
--- a/core/src/main/scala/com/pingcap/tispark/write/TiDBOptions.scala
+++ b/core/src/main/scala/com/pingcap/tispark/write/TiDBOptions.scala
@@ -84,10 +84,10 @@ class TiDBOptions(@transient val parameters: CaseInsensitiveMap[String]) extends
   val writeTaskNumber: Int = getOrDefault(TIDB_WRITE_TASK_NUMBER, "0").toInt
   val prewriteBackOfferMS: Int = getOrDefault(TIDB_PREWRITE_BACKOFFER_MS, "240000").toInt
   val commitBackOfferMS: Int = getOrDefault(TIDB_COMMIT_BACKOFFER_MS, "20000").toInt
-  // 728 * 1024
-  val txnPrewriteBatchSize: Long = getOrDefault(TIDB_TXN_PREWITE_BATCH_SIZE, "786432").toLong
-  // 728 * 1024
-  val txnCommitBatchSize: Long = getOrDefault(TIDB_TXN_COMMIT_BATCH_SIZE, "786432").toLong
+  // 16 * 1024 = 16K
+  val txnPrewriteBatchSize: Long = getOrDefault(TIDB_TXN_PREWITE_BATCH_SIZE, "16384").toLong
+  // 16 * 1024 = 16K
+  val txnCommitBatchSize: Long = getOrDefault(TIDB_TXN_COMMIT_BATCH_SIZE, "16384").toLong
   // 32 * 1024
   val writeBufferSize: Int = getOrDefault(TIDB_WRITE_BUFFER_SIZE, "32768").toInt
   val writeThreadPerTask: Int = getOrDefault(TIDB_WRITE_THREAD_PER_TASK, "1").toInt


### PR DESCRIPTION
benchmark:

### txnPrewriteBatchSize & txnCommitBatchSize = 786432
6kw data
prewrite: 7.1min
commit: 3.9min

### txnPrewriteBatchSize & txnCommitBatchSize = 16384
6kw data
prewrite: 4.5min
commit: 2.4min