### PR TITLE
Fix multiple database scan test bug

### DIFF
--- a/tikv-client/src/main/java/com/pingcap/tikv/operation/iterator/ScanIterator.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/operation/iterator/ScanIterator.java
@@ -94,10 +94,7 @@ public abstract class ScanIterator implements Iterator<Kvrpcpb.KvPair> {
         lastKey = Key.toRawKey(curRegionEndKey);
       } else if (currentCache.size() > limit) {
         throw new IndexOutOfBoundsException(
-            "current cache size = "
-                + currentCache.size()
-                + ", larger than "
-                + conf.getScanBatchSize());
+            "current cache size = " + currentCache.size() + ", larger than " + limit);
       } else {
         // Start new scan from exact next key in current region
         lastKey = Key.toRawKey(currentCache.get(currentCache.size() - 1).getKey());

--- a/tikv-client/src/main/java/com/pingcap/tikv/operation/iterator/ScanIterator.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/operation/iterator/ScanIterator.java
@@ -89,10 +89,10 @@ public abstract class ScanIterator implements Iterator<Kvrpcpb.KvPair> {
       // Session should be single-threaded itself
       // so that we don't worry about conf change in the middle
       // of a transaction. Otherwise below code might lose data
-      if (currentCache.size() < conf.getScanBatchSize()) {
+      if (currentCache.size() < limit) {
         startKey = curRegionEndKey;
         lastKey = Key.toRawKey(curRegionEndKey);
-      } else if (currentCache.size() > conf.getScanBatchSize()) {
+      } else if (currentCache.size() > limit) {
         throw new IndexOutOfBoundsException(
             "current cache size = "
                 + currentCache.size()

--- a/tikv-client/src/main/java/com/pingcap/tikv/operation/iterator/ScanIterator.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/operation/iterator/ScanIterator.java
@@ -89,12 +89,15 @@ public abstract class ScanIterator implements Iterator<Kvrpcpb.KvPair> {
       // Session should be single-threaded itself
       // so that we don't worry about conf change in the middle
       // of a transaction. Otherwise below code might lose data
-      if (currentCache.size() < limit) {
+      if (currentCache.size() < conf.getScanBatchSize()) {
         startKey = curRegionEndKey;
         lastKey = Key.toRawKey(curRegionEndKey);
-      } else if (currentCache.size() > limit) {
+      } else if (currentCache.size() > conf.getScanBatchSize()) {
         throw new IndexOutOfBoundsException(
-            "current cache size = " + currentCache.size() + ", larger than " + limit);
+            "current cache size = "
+                + currentCache.size()
+                + ", larger than "
+                + conf.getScanBatchSize());
       } else {
         // Start new scan from exact next key in current region
         lastKey = Key.toRawKey(currentCache.get(currentCache.size() - 1).getKey());

--- a/tikv-client/src/test/java/com/pingcap/tikv/KVMockServer.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/KVMockServer.java
@@ -248,6 +248,7 @@ public class KVMockServer extends TikvGrpc.TikvImplBase {
         builder.addAllPairs(
             kvs.entrySet()
                 .stream()
+                .limit(request.getLimit())
                 .map(
                     kv ->
                         Kvrpcpb.KvPair.newBuilder()

--- a/tikv-client/src/test/java/com/pingcap/tikv/catalog/CatalogTransactionTest.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/catalog/CatalogTransactionTest.java
@@ -55,6 +55,36 @@ public class CatalogTransactionTest extends CatalogTest {
   }
 
   @Test
+  public void getMultipleDatabasesTest() {
+    MetaMockHelper helper = new MetaMockHelper(pdServer, kvServer);
+    helper.preparePDForRegionRead();
+    helper.addDatabase(130, "global_temp");
+    for (int i = 1; i <= 200; i++) {
+      helper.addDatabase(263 + i, String.format("TPCH_%03d", i));
+    }
+
+    CatalogTransaction trx = new CatalogTransaction(session.createSnapshot());
+    List<TiDBInfo> dbs = trx.getDatabases();
+    assertEquals(201, dbs.size());
+    assertEquals(130, dbs.get(0).getId());
+    assertEquals("global_temp", dbs.get(0).getName());
+
+    assertEquals(264, dbs.get(1).getId());
+    assertEquals("tpch_001", dbs.get(1).getName());
+
+    assertEquals(463, dbs.get(200).getId());
+    assertEquals("tpch_200", dbs.get(200).getName());
+
+    TiDBInfo db0 = trx.getDatabase(130);
+    assertEquals(130, db0.getId());
+    assertEquals("global_temp", db0.getName());
+
+    TiDBInfo db1 = trx.getDatabase(400);
+    assertEquals(400, db1.getId());
+    assertEquals("tpch_137", db1.getName());
+  }
+
+  @Test
   public void getTablesTest() {
     MetaMockHelper helper = new MetaMockHelper(pdServer, kvServer);
     helper.preparePDForRegionRead();


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
Possible bug when meta data of database number is more than 100 in one region. 

### What is changed and how it works?
fix scanIterator.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Related changes

 - Need to cherry-pick to the release branch
 - Need to be included in the release note
