### PR TITLE
optimize region split

### DIFF
--- a/core/src/main/scala/com/pingcap/tispark/write/TiDBOptions.scala
+++ b/core/src/main/scala/com/pingcap/tispark/write/TiDBOptions.scala
@@ -85,6 +85,7 @@ class TiDBOptions(@transient val parameters: CaseInsensitiveMap[String]) extends
 
   // region split
   val enableRegionSplit: Boolean = getOrDefault(TIDB_ENABLE_REGION_SPLIT, "true").toBoolean
+  val getRegionSplitPointMethod: String = getOrDefault(TIDB_GET_REGION_SPLIT_POINT_METHOD, "v2")
   val regionSplitNum: Int = getOrDefault(TIDB_REGION_SPLIT_NUM, "0").toInt
   val sampleSplitFrac: Int = getOrDefault(TIDB_SAMPLE_SPLIT_FRAC, "1000").toInt
   val scatterWaitMS: Int = getOrDefault(TIDB_SCATTER_WAIT_MS, "300000").toInt
@@ -199,6 +200,7 @@ object TiDBOptions {
 
   // region split
   val TIDB_ENABLE_REGION_SPLIT: String = newOption("enableRegionSplit")
+  val TIDB_GET_REGION_SPLIT_POINT_METHOD: String = newOption("getRegionSplitPointMethod")
   val TIDB_REGION_SPLIT_NUM: String = newOption("regionSplitNum")
   val TIDB_SAMPLE_SPLIT_FRAC: String = newOption("sampleSplitFrac")
   val TIDB_SCATTER_WAIT_MS: String = newOption("scatterWaitMS")

--- a/core/src/test/scala/com/pingcap/tispark/index/LineItemSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/index/LineItemSuite.scala
@@ -54,7 +54,7 @@ class LineItemSuite extends BaseTiSparkTest {
       df,
       ti,
       new TiDBOptions(
-        tidbOptions + ("database" -> s"$database", "table" -> tableToWrite, "isTest" -> "true", "regionSplitMethod" -> "v2")))
+        tidbOptions + ("database" -> s"$database", "table" -> tableToWrite, "isTest" -> "true")))
 
     // refresh
     refreshConnections(TestTables(database, tableToWrite))


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
size of `row data` and `index data` are different.
but we use the average size when calculating the region split points.

### What is changed and how it works?
we should calculate the region split points for each index. 

add parameter: `getRegionSplitPointMethod`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
