### PR TITLE
Fix scala match error when predicate includes boolean type conversion

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/execution/TiConverter.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/TiConverter.scala
@@ -27,6 +27,7 @@ object TiConverter {
     // TODO: review type system
     // pending: https://internal.pingcap.net/jira/browse/TISPARK-99
     tp match {
+      case _: sql.types.BooleanType => BitType.BIT
       case _: sql.types.BinaryType => BytesType.BLOB
       case _: sql.types.StringType => StringType.VARCHAR
       case _: sql.types.LongType => IntegerType.BIGINT

--- a/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
@@ -21,6 +21,20 @@ import org.apache.spark.sql.functions.{col, sum}
 
 class IssueTestSuite extends BaseTiSparkTest {
 
+  test("Scala match error when predicate includes boolean type conversion") {
+    tidbStmt.execute("drop table if exists t")
+    tidbStmt.execute("""
+                       |CREATE TABLE `t` (
+                       |  `id` varchar(11) DEFAULT NULL,
+                       |  `flag` boolean DEFAULT NULL
+                       |) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
+                       |""".stripMargin)
+
+    tidbStmt.execute("insert into t values('1', true), ('2', false), ('3', true), ('4', false)")
+
+    explainAndRunTest(s"SELECT * FROM t WHERE FLAG = 'true' and SUBSTR(ID, 1, 2) = '1'")
+  }
+
   test("large column number + double read") {
     tidbStmt.execute(
       resourceToString(


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix #1619

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to be included in the release note
