### PR TITLE
Fix encoder v2 with type convertion and set default batch write version to v2

### DIFF
--- a/core/src/test/scala/com/pingcap/tispark/BatchWriteIssueSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/BatchWriteIssueSuite.scala
@@ -15,7 +15,7 @@
 
 package com.pingcap.tispark
 
-import com.pingcap.tispark.datasource.BaseDataSourceTest
+import com.pingcap.tispark.datasource.BaseBatchWriteTest
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types.{
   IntegerType,
@@ -25,7 +25,7 @@ import org.apache.spark.sql.types.{
   TimestampType
 }
 
-class BatchWriteIssueSuite extends BaseDataSourceTest("test_batchwrite_issue") {
+class BatchWriteIssueSuite extends BaseBatchWriteTest("test_batchwrite_issue") {
   override def beforeAll(): Unit = {
     super.beforeAll()
   }
@@ -43,9 +43,6 @@ class BatchWriteIssueSuite extends BaseDataSourceTest("test_batchwrite_issue") {
   }
 
   test("Index for timestamp was written multiple times") {
-    if (!supportBatchWrite) {
-      cancel
-    }
 
     val schema = StructType(
       List(
@@ -81,17 +78,8 @@ class BatchWriteIssueSuite extends BaseDataSourceTest("test_batchwrite_issue") {
     }
   }
 
-  override def afterAll(): Unit =
-    try {
-      dropTable()
-    } finally {
-      super.afterAll()
-    }
-
   private def doTestNullValues(createTableSQL: String): Unit = {
-    if (!supportBatchWrite) {
-      cancel
-    }
+
     val schema = StructType(
       List(
         StructField("a", IntegerType),

--- a/core/src/test/scala/com/pingcap/tispark/BatchWriteIssueSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/BatchWriteIssueSuite.scala
@@ -26,9 +26,6 @@ import org.apache.spark.sql.types.{
 }
 
 class BatchWriteIssueSuite extends BaseBatchWriteTest("test_batchwrite_issue") {
-  override def beforeAll(): Unit = {
-    super.beforeAll()
-  }
 
   test("Combine unique index with null value test") {
     doTestNullValues(s"create table $dbtable(a int, b varchar(64), CONSTRAINT ab UNIQUE (a, b))")
@@ -43,7 +40,6 @@ class BatchWriteIssueSuite extends BaseBatchWriteTest("test_batchwrite_issue") {
   }
 
   test("Index for timestamp was written multiple times") {
-
     val schema = StructType(
       List(
         StructField("a", IntegerType),
@@ -51,7 +47,6 @@ class BatchWriteIssueSuite extends BaseBatchWriteTest("test_batchwrite_issue") {
         StructField("c", TimestampType)))
     val options = Some(Map("replace" -> "true"))
 
-    dropTable()
     jdbcUpdate(
       s"create table $dbtable(a int, b varchar(64), c datetime, CONSTRAINT xx UNIQUE (b), key `dt_index` (c))")
 
@@ -79,7 +74,6 @@ class BatchWriteIssueSuite extends BaseBatchWriteTest("test_batchwrite_issue") {
   }
 
   private def doTestNullValues(createTableSQL: String): Unit = {
-
     val schema = StructType(
       List(
         StructField("a", IntegerType),
@@ -88,7 +82,6 @@ class BatchWriteIssueSuite extends BaseBatchWriteTest("test_batchwrite_issue") {
 
     val options = Some(Map("replace" -> "true"))
 
-    dropTable()
     jdbcUpdate(createTableSQL)
     jdbcUpdate(s"alter table $dbtable add column to_delete int")
     jdbcUpdate(s"alter table $dbtable add column c varchar(64) default 'c33'")

--- a/core/src/test/scala/com/pingcap/tispark/TiBatchWriteSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/TiBatchWriteSuite.scala
@@ -49,9 +49,6 @@ class TiBatchWriteSuite extends BaseTiSparkTest {
   }
 
   test("ti batch write") {
-    if (!supportBatchWrite) {
-      cancel
-    }
 
     for (table <- tables) {
       logDebug(s"start test table [$table]")
@@ -82,9 +79,6 @@ class TiBatchWriteSuite extends BaseTiSparkTest {
   }
 
   test("ti batch write: isPkHandle") {
-    if (!supportBatchWrite) {
-      cancel
-    }
 
     for (table <- tables) {
       logDebug(s"start test table [$table]")
@@ -210,9 +204,6 @@ class TiBatchWriteSuite extends BaseTiSparkTest {
   }
 
   test("ti batch write: replace + isPkHandle") {
-    if (!supportBatchWrite) {
-      cancel
-    }
 
     for (table <- tables) {
       logDebug(s"start test table [$table]")
@@ -378,9 +369,6 @@ class TiBatchWriteSuite extends BaseTiSparkTest {
   }
 
   test("ti batch write: replace + uniqueKey") {
-    if (!supportBatchWrite) {
-      cancel
-    }
 
     for (table <- tables) {
       logDebug(s"start test table [$table]")
@@ -547,9 +535,6 @@ class TiBatchWriteSuite extends BaseTiSparkTest {
   }
 
   test("table not exists") {
-    if (!supportBatchWrite) {
-      cancel
-    }
 
     // select
     val df = sql(s"select * from CUSTOMER")

--- a/core/src/test/scala/com/pingcap/tispark/TiBatchWriteSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/TiBatchWriteSuite.scala
@@ -16,10 +16,10 @@
 package com.pingcap.tispark
 
 import com.pingcap.tispark.write.{TiBatchWrite, TiDBOptions}
-import org.apache.spark.sql.BaseTiSparkTest
+import org.apache.spark.sql.BaseTiSparkEnableBatchWriteTest
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException
 
-class TiBatchWriteSuite extends BaseTiSparkTest {
+class TiBatchWriteSuite extends BaseTiSparkEnableBatchWriteTest {
 
   private val tables =
     "CUSTOMER" ::
@@ -49,7 +49,6 @@ class TiBatchWriteSuite extends BaseTiSparkTest {
   }
 
   test("ti batch write") {
-
     for (table <- tables) {
       logDebug(s"start test table [$table]")
 
@@ -79,7 +78,6 @@ class TiBatchWriteSuite extends BaseTiSparkTest {
   }
 
   test("ti batch write: isPkHandle") {
-
     for (table <- tables) {
       logDebug(s"start test table [$table]")
       val tableToWrite = s"${batchWriteTablePrefix}_${isPkHandlePrefix}_$table"
@@ -204,7 +202,6 @@ class TiBatchWriteSuite extends BaseTiSparkTest {
   }
 
   test("ti batch write: replace + isPkHandle") {
-
     for (table <- tables) {
       logDebug(s"start test table [$table]")
 
@@ -369,7 +366,6 @@ class TiBatchWriteSuite extends BaseTiSparkTest {
   }
 
   test("ti batch write: replace + uniqueKey") {
-
     for (table <- tables) {
       logDebug(s"start test table [$table]")
 
@@ -535,7 +531,6 @@ class TiBatchWriteSuite extends BaseTiSparkTest {
   }
 
   test("table not exists") {
-
     // select
     val df = sql(s"select * from CUSTOMER")
 

--- a/core/src/test/scala/com/pingcap/tispark/concurrency/ConcurrencyTest.scala
+++ b/core/src/test/scala/com/pingcap/tispark/concurrency/ConcurrencyTest.scala
@@ -15,7 +15,7 @@
 
 package com.pingcap.tispark.concurrency
 
-import com.pingcap.tispark.datasource.BaseDataSourceTest
+import com.pingcap.tispark.datasource.BaseBatchWriteTest
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
@@ -26,7 +26,7 @@ case class ConcurrencyTestResult(
     var isEmpty: Boolean = true,
     var obj: String = null)
 
-class ConcurrencyTest extends BaseDataSourceTest("test_concurrency_write_read") {
+class ConcurrencyTest extends BaseBatchWriteTest("test_concurrency_write_read") {
 
   protected val row1 = Row(1, "Value1")
   protected val row2 = Row(2, "Value2")

--- a/core/src/test/scala/com/pingcap/tispark/concurrency/ConcurrencyTest.scala
+++ b/core/src/test/scala/com/pingcap/tispark/concurrency/ConcurrencyTest.scala
@@ -40,18 +40,6 @@ class ConcurrencyTest extends BaseBatchWriteTest("test_concurrency_write_read") 
   protected val sleepBeforeQuery = 10000
   protected val sleepAfterGetCommitTS = 480000
 
-  override def beforeAll(): Unit = {
-    super.beforeAll()
-  }
-
-  override def afterAll(): Unit = {
-    try {
-      dropTable()
-    } finally {
-      super.afterAll()
-    }
-  }
-
   override protected def dropTable(): Unit = {
     try {
       jdbcUpdate(s"admin cleanup table lock $dbtable")

--- a/core/src/test/scala/com/pingcap/tispark/concurrency/WriteDDLConflictSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/concurrency/WriteDDLConflictSuite.scala
@@ -21,9 +21,6 @@ import org.apache.spark.sql.Row
 
 class WriteDDLConflictSuite extends ConcurrencyTest {
   test("write ddl conflict using TableLock") {
-    if (!supportBatchWrite) {
-      cancel
-    }
 
     if (!isEnableTableLock) {
       cancel
@@ -46,9 +43,6 @@ class WriteDDLConflictSuite extends ConcurrencyTest {
   }
 
   test("write ddl conflict using SchemaVersionCheck") {
-    if (!supportBatchWrite) {
-      cancel
-    }
 
     dropTable()
     jdbcUpdate(s"create table $dbtable(i int, s varchar(128))")

--- a/core/src/test/scala/com/pingcap/tispark/concurrency/WriteDDLConflictSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/concurrency/WriteDDLConflictSuite.scala
@@ -21,12 +21,10 @@ import org.apache.spark.sql.Row
 
 class WriteDDLConflictSuite extends ConcurrencyTest {
   test("write ddl conflict using TableLock") {
-
     if (!isEnableTableLock) {
       cancel
     }
 
-    dropTable()
     jdbcUpdate(s"create table $dbtable(i int, s varchar(128))")
     jdbcUpdate(s"insert into $dbtable values(4, 'null')")
 
@@ -43,8 +41,6 @@ class WriteDDLConflictSuite extends ConcurrencyTest {
   }
 
   test("write ddl conflict using SchemaVersionCheck") {
-
-    dropTable()
     jdbcUpdate(s"create table $dbtable(i int, s varchar(128))")
     jdbcUpdate(s"insert into $dbtable values(4, 'null')")
 

--- a/core/src/test/scala/com/pingcap/tispark/concurrency/WriteDDLNotConflictSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/concurrency/WriteDDLNotConflictSuite.scala
@@ -36,9 +36,6 @@ class WriteDDLNotConflictSuite extends ConcurrencyTest {
   }
 
   private def doTest(ddl: String): Unit = {
-    if (!supportBatchWrite) {
-      cancel
-    }
 
     dropTable()
     jdbcUpdate(s"create table $dbtable(i int, s varchar(128))")

--- a/core/src/test/scala/com/pingcap/tispark/concurrency/WriteDDLNotConflictSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/concurrency/WriteDDLNotConflictSuite.scala
@@ -36,8 +36,6 @@ class WriteDDLNotConflictSuite extends ConcurrencyTest {
   }
 
   private def doTest(ddl: String): Unit = {
-
-    dropTable()
     jdbcUpdate(s"create table $dbtable(i int, s varchar(128))")
     jdbcUpdate(s"insert into $dbtable values(4, 'null')")
 

--- a/core/src/test/scala/com/pingcap/tispark/concurrency/WriteReadSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/concurrency/WriteReadSuite.scala
@@ -53,9 +53,6 @@ class WriteReadSuite extends ConcurrencyTest {
   }
 
   def doTestJDBC(createTable: String, pkIsHandle: Boolean, hasIndex: Boolean) = {
-    if (!supportBatchWrite) {
-      cancel
-    }
 
     dropTable()
     jdbcUpdate(createTable)
@@ -112,9 +109,6 @@ class WriteReadSuite extends ConcurrencyTest {
   }
 
   def doTestTiSpark(createTable: String, hasIndex: Boolean) = {
-    if (!supportBatchWrite) {
-      cancel
-    }
 
     dropTable()
     jdbcUpdate(createTable)

--- a/core/src/test/scala/com/pingcap/tispark/concurrency/WriteReadSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/concurrency/WriteReadSuite.scala
@@ -15,6 +15,8 @@
 
 package com.pingcap.tispark.concurrency
 
+import org.scalatest.Assertion
+
 class WriteReadSuite extends ConcurrencyTest {
 
   test("read conflict using jdbc") {
@@ -52,9 +54,7 @@ class WriteReadSuite extends ConcurrencyTest {
     doTestTiSpark(s"create table $dbtable(i int, s varchar(128), UNIQUE KEY(i))", hasIndex = true)
   }
 
-  def doTestJDBC(createTable: String, pkIsHandle: Boolean, hasIndex: Boolean) = {
-
-    dropTable()
+  def doTestJDBC(createTable: String, pkIsHandle: Boolean, hasIndex: Boolean): Assertion = {
     jdbcUpdate(createTable)
     jdbcUpdate(s"insert into $dbtable values(2, 'v2')")
     jdbcUpdate(s"insert into $dbtable values(3, 'v3')")
@@ -108,9 +108,7 @@ class WriteReadSuite extends ConcurrencyTest {
     }
   }
 
-  def doTestTiSpark(createTable: String, hasIndex: Boolean) = {
-
-    dropTable()
+  def doTestTiSpark(createTable: String, hasIndex: Boolean): Assertion = {
     jdbcUpdate(createTable)
     jdbcUpdate(s"insert into $dbtable values(2, 'v2')")
     jdbcUpdate(s"insert into $dbtable values(3, 'v3')")

--- a/core/src/test/scala/com/pingcap/tispark/concurrency/WriteWriteConflictSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/concurrency/WriteWriteConflictSuite.scala
@@ -20,9 +20,6 @@ import org.apache.spark.sql.Row
 
 class WriteWriteConflictSuite extends ConcurrencyTest {
   test("write write conflict using TableLock & jdbc") {
-    if (!supportBatchWrite) {
-      cancel
-    }
 
     if (!isEnableTableLock) {
       cancel
@@ -45,9 +42,6 @@ class WriteWriteConflictSuite extends ConcurrencyTest {
   }
 
   test("write write conflict using TableLock & tispark") {
-    if (!supportBatchWrite) {
-      cancel
-    }
 
     if (!isEnableTableLock) {
       cancel

--- a/core/src/test/scala/com/pingcap/tispark/concurrency/WriteWriteConflictSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/concurrency/WriteWriteConflictSuite.scala
@@ -20,12 +20,10 @@ import org.apache.spark.sql.Row
 
 class WriteWriteConflictSuite extends ConcurrencyTest {
   test("write write conflict using TableLock & jdbc") {
-
     if (!isEnableTableLock) {
       cancel
     }
 
-    dropTable()
     jdbcUpdate(s"create table $dbtable(i int, s varchar(128))")
     jdbcUpdate(s"insert into $dbtable values(4, 'null')")
 
@@ -42,12 +40,10 @@ class WriteWriteConflictSuite extends ConcurrencyTest {
   }
 
   test("write write conflict using TableLock & tispark") {
-
     if (!isEnableTableLock) {
       cancel
     }
 
-    dropTable()
     jdbcUpdate(s"create table $dbtable(i int, s varchar(128))")
     jdbcUpdate(s"insert into $dbtable values(4, 'null')")
 

--- a/core/src/test/scala/com/pingcap/tispark/convert/ToBitSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/convert/ToBitSuite.scala
@@ -15,7 +15,7 @@
 
 package com.pingcap.tispark.convert
 
-import com.pingcap.tispark.datasource.BaseDataSourceTest
+import com.pingcap.tispark.datasource.BaseBatchWriteTest
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types.{StructField, _}
 
@@ -23,7 +23,7 @@ import org.apache.spark.sql.types.{StructField, _}
  * BIT type include:
  * 1. BIT
  */
-class ToBitSuite extends BaseDataSourceTest("test_data_type_convert_to_bit") {
+class ToBitSuite extends BaseBatchWriteTest("test_data_type_convert_to_bit") {
 
   private val readZero: java.lang.Long = 0L
   private val readOne: java.lang.Long = 1L
@@ -45,18 +45,7 @@ class ToBitSuite extends BaseDataSourceTest("test_data_type_convert_to_bit") {
       StructField("c2", LongType),
       StructField("c3", LongType)))
 
-  override def afterAll(): Unit =
-    try {
-      dropTable()
-    } finally {
-      super.afterAll()
-    }
-
   test("Test Convert from java.lang.Boolean to BIT") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // success
     // java.lang.Boolean -> BIT
     compareTiDBWriteWithJDBC {
@@ -95,10 +84,6 @@ class ToBitSuite extends BaseDataSourceTest("test_data_type_convert_to_bit") {
   }
 
   test("Test Convert from java.lang.Byte to BIT") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // success
     // java.lang.Byte -> BIT
     compareTiDBWriteWithJDBC {
@@ -133,10 +118,6 @@ class ToBitSuite extends BaseDataSourceTest("test_data_type_convert_to_bit") {
   }
 
   test("Test Convert from java.lang.Short to BIT") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // success
     // java.lang.Short -> BIT
     compareTiDBWriteWithJDBC {
@@ -171,10 +152,6 @@ class ToBitSuite extends BaseDataSourceTest("test_data_type_convert_to_bit") {
   }
 
   test("Test Convert from java.lang.Integer to BIT") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // success
     // java.lang.Integer -> BIT
     compareTiDBWriteWithJDBC {
@@ -209,10 +186,6 @@ class ToBitSuite extends BaseDataSourceTest("test_data_type_convert_to_bit") {
   }
 
   test("Test Convert from java.lang.Long to BIT") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // success
     // java.lang.Long -> BIT
     compareTiDBWriteWithJDBC {
@@ -247,10 +220,6 @@ class ToBitSuite extends BaseDataSourceTest("test_data_type_convert_to_bit") {
   }
 
   test("Test Convert from java.lang.Float to BIT") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // success
     // java.lang.Float -> BIT
     compareTiDBWriteWithJDBC {
@@ -287,10 +256,6 @@ class ToBitSuite extends BaseDataSourceTest("test_data_type_convert_to_bit") {
   }
 
   test("Test Convert from java.lang.Double to BIT") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // success
     // java.lang.Double -> BIT
     compareTiDBWriteWithJDBC {

--- a/core/src/test/scala/com/pingcap/tispark/convert/ToBytesSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/convert/ToBytesSuite.scala
@@ -15,7 +15,7 @@
 
 package com.pingcap.tispark.convert
 
-import com.pingcap.tispark.datasource.BaseDataSourceTest
+import com.pingcap.tispark.datasource.BaseBatchWriteTest
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types.{StructField, _}
 
@@ -28,20 +28,9 @@ import org.apache.spark.sql.types.{StructField, _}
  * 5. MEDIUMBLOB
  * 6. LONGBLOB
  */
-class ToBytesSuite extends BaseDataSourceTest("test_data_type_convert_to_bytes") {
-
-  override def afterAll(): Unit =
-    try {
-      dropTable()
-    } finally {
-      super.afterAll()
-    }
+class ToBytesSuite extends BaseBatchWriteTest("test_data_type_convert_to_bytes") {
 
   test("Test Convert from java.lang.Boolean to BYTES") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // success
     // java.lang.Boolean -> BYTES
     compareTiDBWriteWithJDBC {
@@ -101,10 +90,6 @@ class ToBytesSuite extends BaseDataSourceTest("test_data_type_convert_to_bytes")
   }
 
   test("Test Convert from java.lang.Byte to BYTES") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // success
     // java.lang.Byte -> BYTES
     compareTiDBWriteWithJDBC {
@@ -164,10 +149,6 @@ class ToBytesSuite extends BaseDataSourceTest("test_data_type_convert_to_bytes")
   }
 
   test("Test Convert from java.lang.Short to BYTES") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // success
     // java.lang.Short -> BYTES
     compareTiDBWriteWithJDBC {
@@ -227,10 +208,6 @@ class ToBytesSuite extends BaseDataSourceTest("test_data_type_convert_to_bytes")
   }
 
   test("Test Convert from java.lang.Integer to BYTES") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // success
     // java.lang.Integer -> BYTES
     compareTiDBWriteWithJDBC {
@@ -290,10 +267,6 @@ class ToBytesSuite extends BaseDataSourceTest("test_data_type_convert_to_bytes")
   }
 
   test("Test Convert from java.lang.Long to BYTES") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // success
     // java.lang.Long -> BYTES
     compareTiDBWriteWithJDBC {
@@ -353,10 +326,6 @@ class ToBytesSuite extends BaseDataSourceTest("test_data_type_convert_to_bytes")
   }
 
   test("Test Convert from String to BYTES") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // success
     // java.lang.String -> BYTES
     compareTiDBWriteWithJDBC {

--- a/core/src/test/scala/com/pingcap/tispark/convert/ToDateSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/convert/ToDateSuite.scala
@@ -15,7 +15,7 @@
 
 package com.pingcap.tispark.convert
 
-import com.pingcap.tispark.datasource.BaseDataSourceTest
+import com.pingcap.tispark.datasource.BaseBatchWriteTest
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types._
 
@@ -23,7 +23,7 @@ import org.apache.spark.sql.types._
  * DATE type include:
  * 1. DATE
  */
-class ToDateSuite extends BaseDataSourceTest("test_data_type_convert_to_date") {
+class ToDateSuite extends BaseBatchWriteTest("test_data_type_convert_to_date") {
 
   private val readSchema = StructType(
     List(
@@ -44,18 +44,7 @@ class ToDateSuite extends BaseDataSourceTest("test_data_type_convert_to_date") {
     readRow2 = Row(2, readA, readB)
   }
 
-  override def afterAll(): Unit =
-    try {
-      dropTable()
-    } finally {
-      super.afterAll()
-    }
-
   test("Test Convert from java.lang.Long to DATE") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // success
     // java.lang.Long -> DATE
     compareTiDBWriteWithJDBC {
@@ -85,10 +74,6 @@ class ToDateSuite extends BaseDataSourceTest("test_data_type_convert_to_date") {
   }
 
   test("Test Convert from String to DATE") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // success
     // String -> DATE
     compareTiDBWriteWithJDBC {
@@ -115,10 +100,6 @@ class ToDateSuite extends BaseDataSourceTest("test_data_type_convert_to_date") {
   }
 
   test("Test Convert from java.sql.Date to DATE") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // success
     // java.sql.Date -> DATE
     compareTiDBWriteWithJDBC {
@@ -145,10 +126,6 @@ class ToDateSuite extends BaseDataSourceTest("test_data_type_convert_to_date") {
   }
 
   test("Test Convert from java.sql.Timestamp to DATE") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // success
     // java.sql.Timestamp -> DATE
     compareTiDBWriteWithJDBC {

--- a/core/src/test/scala/com/pingcap/tispark/convert/ToDateTimeSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/convert/ToDateTimeSuite.scala
@@ -15,7 +15,7 @@
 
 package com.pingcap.tispark.convert
 
-import com.pingcap.tispark.datasource.BaseDataSourceTest
+import com.pingcap.tispark.datasource.BaseBatchWriteTest
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types._
 
@@ -23,7 +23,7 @@ import org.apache.spark.sql.types._
  * DATETIME type include:
  * 1. DATETIME
  */
-class ToDateTimeSuite extends BaseDataSourceTest("test_data_type_convert_to_datetime") {
+class ToDateTimeSuite extends BaseBatchWriteTest("test_data_type_convert_to_datetime") {
 
   private val readSchema = StructType(
     List(
@@ -45,18 +45,7 @@ class ToDateTimeSuite extends BaseDataSourceTest("test_data_type_convert_to_date
     readRow2 = Row(2, readA, readB, readC)
   }
 
-  override def afterAll(): Unit =
-    try {
-      dropTable()
-    } finally {
-      super.afterAll()
-    }
-
   test("Test Convert from String to DATETIME") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // success
     // String -> DATETIME
     compareTiDBWriteWithJDBC {
@@ -82,10 +71,6 @@ class ToDateTimeSuite extends BaseDataSourceTest("test_data_type_convert_to_date
   }
 
   test("Test Convert from java.sql.Date to DATETIME") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // success
     // java.sql.Date -> DATETIME
     compareTiDBWriteWithJDBC {
@@ -114,10 +99,6 @@ class ToDateTimeSuite extends BaseDataSourceTest("test_data_type_convert_to_date
   }
 
   test("Test Convert from java.sql.Timestamp to DATETIME") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // success
     // java.sql.Timestamp -> DATETIME
     compareTiDBWriteWithJDBC {

--- a/core/src/test/scala/com/pingcap/tispark/convert/ToDecimalSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/convert/ToDecimalSuite.scala
@@ -15,7 +15,7 @@
 
 package com.pingcap.tispark.convert
 
-import com.pingcap.tispark.datasource.BaseDataSourceTest
+import com.pingcap.tispark.datasource.BaseBatchWriteTest
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types.{StructField, _}
 
@@ -23,7 +23,7 @@ import org.apache.spark.sql.types.{StructField, _}
  * DECIMAL type include:
  * 1. DECIMAL
  */
-class ToDecimalSuite extends BaseDataSourceTest("test_data_type_convert_to_decimal") {
+class ToDecimalSuite extends BaseBatchWriteTest("test_data_type_convert_to_decimal") {
 
   private val readSchema = StructType(
     List(
@@ -35,18 +35,7 @@ class ToDecimalSuite extends BaseDataSourceTest("test_data_type_convert_to_decim
       StructField("c5", DecimalType(38, 5)),
       StructField("c6", DecimalType(38, 6))))
 
-  override def afterAll(): Unit =
-    try {
-      dropTable()
-    } finally {
-      super.afterAll()
-    }
-
   test("Test Convert from java.lang.Boolean to DECIMAL") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // success
     // java.lang.Boolean -> DECIMAL
     compareTiDBWriteWithJDBC {
@@ -101,10 +90,6 @@ class ToDecimalSuite extends BaseDataSourceTest("test_data_type_convert_to_decim
   }
 
   test("Test Convert from java.lang.Byte to DECIMAL") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // success
     // java.lang.Byte -> DECIMAL
     compareTiDBWriteWithJDBC {
@@ -140,10 +125,6 @@ class ToDecimalSuite extends BaseDataSourceTest("test_data_type_convert_to_decim
   }
 
   test("Test Convert from java.lang.Short to DECIMAL") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // success
     // java.lang.Short -> DECIMAL
     compareTiDBWriteWithJDBC {
@@ -179,10 +160,6 @@ class ToDecimalSuite extends BaseDataSourceTest("test_data_type_convert_to_decim
   }
 
   test("Test Convert from java.lang.Integer to DECIMAL") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // success
     // java.lang.Integer -> DECIMAL
     compareTiDBWriteWithJDBC {
@@ -218,10 +195,6 @@ class ToDecimalSuite extends BaseDataSourceTest("test_data_type_convert_to_decim
   }
 
   test("Test Convert from java.lang.Long to DECIMAL") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // success
     // java.lang.Long -> DECIMAL
     compareTiDBWriteWithJDBC {
@@ -257,10 +230,6 @@ class ToDecimalSuite extends BaseDataSourceTest("test_data_type_convert_to_decim
   }
 
   test("Test Convert from java.lang.Float to DECIMAL") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // success
     // java.lang.Float -> DECIMAL
     compareTiDBWriteWithJDBC {
@@ -305,10 +274,6 @@ class ToDecimalSuite extends BaseDataSourceTest("test_data_type_convert_to_decim
   }
 
   test("Test Convert from java.lang.Double to DECIMAL") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // success
     // java.lang.Double -> DECIMAL
     compareTiDBWriteWithJDBC {
@@ -352,10 +317,6 @@ class ToDecimalSuite extends BaseDataSourceTest("test_data_type_convert_to_decim
   }
 
   test("Test Convert from String to DECIMAL") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // success
     // java.lang.String -> DECIMAL
     compareTiDBWriteWithJDBC {
@@ -396,10 +357,6 @@ class ToDecimalSuite extends BaseDataSourceTest("test_data_type_convert_to_decim
   }
 
   test("Test Convert from java.math.BigDecimal to DECIMAL") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // failure
     // java.math.BigDecimal -> DECIMAL
     compareTiDBWriteWithJDBC {

--- a/core/src/test/scala/com/pingcap/tispark/convert/ToEnumSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/convert/ToEnumSuite.scala
@@ -15,7 +15,7 @@
 
 package com.pingcap.tispark.convert
 
-import com.pingcap.tispark.datasource.BaseDataSourceTest
+import com.pingcap.tispark.datasource.BaseBatchWriteTest
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types.{StructField, _}
 
@@ -23,7 +23,7 @@ import org.apache.spark.sql.types.{StructField, _}
  * ENUM type include:
  * 1. ENUM
  */
-class ToEnumSuite extends BaseDataSourceTest("test_data_type_convert_to_enum") {
+class ToEnumSuite extends BaseBatchWriteTest("test_data_type_convert_to_enum") {
 
   private val readOne: java.lang.String = java.lang.String.valueOf("male")
   private val readTwo: java.lang.String = java.lang.String.valueOf("female")
@@ -48,18 +48,7 @@ class ToEnumSuite extends BaseDataSourceTest("test_data_type_convert_to_enum") {
       StructField("c5", StringType),
       StructField("c6", StringType)))
 
-  override def afterAll(): Unit =
-    try {
-      dropTable()
-    } finally {
-      super.afterAll()
-    }
-
   test("Test Convert from java.lang.Boolean to ENUM") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // success
     // java.lang.Boolean -> ENUM
     compareTiDBWriteWithJDBC {
@@ -98,10 +87,6 @@ class ToEnumSuite extends BaseDataSourceTest("test_data_type_convert_to_enum") {
   }
 
   test("Test Convert from java.lang.Byte to ENUM") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // success
     // java.lang.Byte -> ENUM
     compareTiDBWriteWithJDBC {
@@ -141,10 +126,6 @@ class ToEnumSuite extends BaseDataSourceTest("test_data_type_convert_to_enum") {
   }
 
   test("Test Convert from java.lang.Short to ENUM") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // success
     // java.lang.Short -> ENUM
     compareTiDBWriteWithJDBC {
@@ -184,10 +165,6 @@ class ToEnumSuite extends BaseDataSourceTest("test_data_type_convert_to_enum") {
   }
 
   test("Test Convert from java.lang.Integer to ENUM") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // success
     // java.lang.Integer -> ENUM
     compareTiDBWriteWithJDBC {
@@ -227,10 +204,6 @@ class ToEnumSuite extends BaseDataSourceTest("test_data_type_convert_to_enum") {
   }
 
   test("Test Convert from java.lang.Long to ENUM") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // success
     // java.lang.Long -> ENUM
     compareTiDBWriteWithJDBC {
@@ -270,10 +243,6 @@ class ToEnumSuite extends BaseDataSourceTest("test_data_type_convert_to_enum") {
   }
 
   test("Test Convert from java.lang.Float to ENUM") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // success
     // java.lang.Float -> ENUM
     compareTiDBWriteWithJDBC {
@@ -313,10 +282,6 @@ class ToEnumSuite extends BaseDataSourceTest("test_data_type_convert_to_enum") {
   }
 
   test("Test Convert from java.lang.Double to ENUM") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // success
     // java.lang.Double -> ENUM
     compareTiDBWriteWithJDBC {
@@ -356,10 +321,6 @@ class ToEnumSuite extends BaseDataSourceTest("test_data_type_convert_to_enum") {
   }
 
   test("Test Convert from String to ENUM") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // success
     // java.lang.String -> ENUM
     compareTiDBWriteWithJDBC {

--- a/core/src/test/scala/com/pingcap/tispark/convert/ToRealSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/convert/ToRealSuite.scala
@@ -15,7 +15,7 @@
 
 package com.pingcap.tispark.convert
 
-import com.pingcap.tispark.datasource.BaseDataSourceTest
+import com.pingcap.tispark.datasource.BaseBatchWriteTest
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types._
 
@@ -24,7 +24,7 @@ import org.apache.spark.sql.types._
  * 1. FLOAT
  * 2. DOUBLE
  */
-class ToRealSuite extends BaseDataSourceTest("test_data_type_convert_to_real") {
+class ToRealSuite extends BaseBatchWriteTest("test_data_type_convert_to_real") {
 
   //  + 1.0E-40f because of this issue: https://github.com/pingcap/tidb/issues/10587
   private val minFloat: java.lang.Float = java.lang.Float.MIN_VALUE + 1.0e-40f
@@ -38,17 +38,7 @@ class ToRealSuite extends BaseDataSourceTest("test_data_type_convert_to_real") {
       StructField("c1", FloatType),
       StructField("c2", DoubleType)))
 
-  override def afterAll(): Unit =
-    try {
-      dropTable()
-    } finally {
-      super.afterAll()
-    }
-
   test("Test Convert from java.lang.Boolean to REAL") {
-    if (!supportBatchWrite) {
-      cancel
-    }
 
     // success
     // java.lang.Boolean -> FLOAT
@@ -81,10 +71,6 @@ class ToRealSuite extends BaseDataSourceTest("test_data_type_convert_to_real") {
   }
 
   test("Test Convert from java.lang.Byte to REAL") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // success
     // java.lang.Byte -> FLOAT
     // java.lang.Byte -> DOUBLE
@@ -114,10 +100,6 @@ class ToRealSuite extends BaseDataSourceTest("test_data_type_convert_to_real") {
   }
 
   test("Test Convert from java.lang.Short to REAL") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // success
     // java.lang.Short -> FLOAT
     // java.lang.Short -> DOUBLE
@@ -147,10 +129,6 @@ class ToRealSuite extends BaseDataSourceTest("test_data_type_convert_to_real") {
   }
 
   test("Test Convert from java.lang.Integer to REAL") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // success
     // java.lang.Integer -> FLOAT
     // java.lang.Integer -> DOUBLE
@@ -183,10 +161,6 @@ class ToRealSuite extends BaseDataSourceTest("test_data_type_convert_to_real") {
   }
 
   test("Test Convert from java.lang.Long to REAL") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // success
     // java.lang.Long -> FLOAT
     // java.lang.Long -> DOUBLE
@@ -213,10 +187,6 @@ class ToRealSuite extends BaseDataSourceTest("test_data_type_convert_to_real") {
   }
 
   test("Test Convert from java.lang.Float to REAL") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // success
     // java.lang.Float -> FLOAT
     // java.lang.Float -> DOUBLE
@@ -258,10 +228,6 @@ class ToRealSuite extends BaseDataSourceTest("test_data_type_convert_to_real") {
   }
 
   test("Test Convert from java.lang.Double to REAL") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // success
     // java.lang.Double -> FLOAT
     // java.lang.Double -> DOUBLE
@@ -300,10 +266,6 @@ class ToRealSuite extends BaseDataSourceTest("test_data_type_convert_to_real") {
   }
 
   test("Test Convert from String to REAL") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // success
     // String -> FLOAT
     // String -> DOUBLE

--- a/core/src/test/scala/com/pingcap/tispark/convert/ToSignedSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/convert/ToSignedSuite.scala
@@ -15,7 +15,7 @@
 
 package com.pingcap.tispark.convert
 
-import com.pingcap.tispark.datasource.BaseDataSourceTest
+import com.pingcap.tispark.datasource.BaseBatchWriteTest
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types._
 
@@ -28,7 +28,7 @@ import org.apache.spark.sql.types._
  * 5. BIGINT SINGED
  * 6. BOOLEAN
  */
-class ToSignedSuite extends BaseDataSourceTest("test_data_type_convert_to_signed") {
+class ToSignedSuite extends BaseBatchWriteTest("test_data_type_convert_to_signed") {
 
   private val readSchema = StructType(
     List(
@@ -40,18 +40,7 @@ class ToSignedSuite extends BaseDataSourceTest("test_data_type_convert_to_signed
       StructField("c5", LongType),
       StructField("c6", LongType)))
 
-  override def afterAll(): Unit =
-    try {
-      dropTable()
-    } finally {
-      super.afterAll()
-    }
-
   test("Test Convert from java.lang.Boolean to SINGED") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // success
     // java.lang.Boolean -> {TINYINT SMALLINT MEDIUMINT INT BIGINT} SIGNED BOOLEAN
     compareTiDBWriteWithJDBC {
@@ -92,10 +81,6 @@ class ToSignedSuite extends BaseDataSourceTest("test_data_type_convert_to_signed
   }
 
   test("Test Convert from java.lang.Byte to SIGNED") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // success
     // java.lang.Byte -> {TINYINT SMALLINT MEDIUMINT INT BIGINT} SIGNED BOOLEAN
     compareTiDBWriteWithJDBC {
@@ -134,10 +119,6 @@ class ToSignedSuite extends BaseDataSourceTest("test_data_type_convert_to_signed
   }
 
   test("Test Convert from java.lang.Short to SIGNED") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // success
     // java.lang.Short -> {TINYINT SMALLINT MEDIUMINT INT BIGINT} SIGNED BOOLEAN
     compareTiDBWriteWithJDBC {
@@ -179,10 +160,6 @@ class ToSignedSuite extends BaseDataSourceTest("test_data_type_convert_to_signed
   }
 
   test("Test Convert from java.lang.Integer to SIGNED") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // success
     // java.lang.Integer -> {TINYINT SMALLINT MEDIUMINT INT BIGINT} SIGNED BOOLEAN
     compareTiDBWriteWithJDBC {
@@ -226,10 +203,6 @@ class ToSignedSuite extends BaseDataSourceTest("test_data_type_convert_to_signed
   }
 
   test("Test Convert from java.lang.Long to SIGNED") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // success
     // java.lang.Long -> {TINYINT SMALLINT MEDIUMINT INT BIGINT} SIGNED BOOLEAN
     compareTiDBWriteWithJDBC {
@@ -275,10 +248,6 @@ class ToSignedSuite extends BaseDataSourceTest("test_data_type_convert_to_signed
   }
 
   test("Test Convert from java.lang.Float to SIGNED") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // success
     // java.lang.Float -> {TINYINT SMALLINT MEDIUMINT INT BIGINT} SIGNED BOOLEAN
     compareTiDBWriteWithJDBC {
@@ -325,10 +294,6 @@ class ToSignedSuite extends BaseDataSourceTest("test_data_type_convert_to_signed
   }
 
   test("Test Convert from java.lang.Double to SIGNED") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // success
     // java.lang.Double -> {TINYINT SMALLINT MEDIUMINT INT BIGINT} SIGNED BOOLEAN
     compareTiDBWriteWithJDBC {
@@ -372,10 +337,6 @@ class ToSignedSuite extends BaseDataSourceTest("test_data_type_convert_to_signed
   }
 
   test("Test Convert from String to SIGNED") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // success
     // String -> {TINYINT SMALLINT MEDIUMINT INT BIGINT} SIGNED BOOLEAN
     compareTiDBWriteWithJDBC {

--- a/core/src/test/scala/com/pingcap/tispark/convert/ToStringSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/convert/ToStringSuite.scala
@@ -15,7 +15,7 @@
 
 package com.pingcap.tispark.convert
 
-import com.pingcap.tispark.datasource.BaseDataSourceTest
+import com.pingcap.tispark.datasource.BaseBatchWriteTest
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types.{StructField, _}
 
@@ -28,7 +28,7 @@ import org.apache.spark.sql.types.{StructField, _}
  * 5. MEDIUMTEXT
  * 6. LONGTEXT
  */
-class ToStringSuite extends BaseDataSourceTest("test_data_type_convert_to_string") {
+class ToStringSuite extends BaseBatchWriteTest("test_data_type_convert_to_string") {
 
   private val readSchema = StructType(
     List(
@@ -40,18 +40,7 @@ class ToStringSuite extends BaseDataSourceTest("test_data_type_convert_to_string
       StructField("c5", StringType),
       StructField("c6", StringType)))
 
-  override def afterAll(): Unit =
-    try {
-      dropTable()
-    } finally {
-      super.afterAll()
-    }
-
   test("Test Convert from java.lang.Boolean to STRING") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // success
     // java.lang.Boolean -> STRING
     compareTiDBWriteWithJDBC {
@@ -96,10 +85,6 @@ class ToStringSuite extends BaseDataSourceTest("test_data_type_convert_to_string
   }
 
   test("Test Convert from java.lang.Byte to STRING") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // success
     // java.lang.Byte -> STRING
     compareTiDBWriteWithJDBC {
@@ -148,10 +133,6 @@ class ToStringSuite extends BaseDataSourceTest("test_data_type_convert_to_string
   }
 
   test("Test Convert from java.lang.Short to STRING") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // success
     // java.lang.Short -> STRING
     compareTiDBWriteWithJDBC {
@@ -200,10 +181,6 @@ class ToStringSuite extends BaseDataSourceTest("test_data_type_convert_to_string
   }
 
   test("Test Convert from java.lang.Integer to STRING") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // success
     // java.lang.Integer -> STRING
     compareTiDBWriteWithJDBC {
@@ -252,10 +229,6 @@ class ToStringSuite extends BaseDataSourceTest("test_data_type_convert_to_string
   }
 
   test("Test Convert from java.lang.Long to STRING") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // success
     // java.lang.Long -> STRING
     compareTiDBWriteWithJDBC {
@@ -306,10 +279,6 @@ class ToStringSuite extends BaseDataSourceTest("test_data_type_convert_to_string
   // TODO: float -> string problem
   // 3.4028235E38 -> 340282350000000000000000000000000000000
   ignore("Test Convert from java.lang.Float to STRING") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // success
     // java.lang.Float -> STRING
     compareTiDBWriteWithJDBC {
@@ -362,10 +331,6 @@ class ToStringSuite extends BaseDataSourceTest("test_data_type_convert_to_string
 
   // TODO: java.sql.BatchUpdateException: Data truncation: Data too long for column 'c1' at row 1
   ignore("Test Convert from java.lang.Double to STRING") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // success
     // java.lang.Double -> STRING
     compareTiDBWriteWithJDBC {
@@ -401,10 +366,6 @@ class ToStringSuite extends BaseDataSourceTest("test_data_type_convert_to_string
   }
 
   test("Test Convert from String to STRING") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // success
     // java.lang.String -> STRING
     compareTiDBWriteWithJDBC {
@@ -440,10 +401,6 @@ class ToStringSuite extends BaseDataSourceTest("test_data_type_convert_to_string
   }
 
   test("Test Convert from java.math.BigDecimal to STRING") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // failure
     // java.math.BigDecimal -> STRING
     compareTiDBWriteWithJDBC {
@@ -492,10 +449,6 @@ class ToStringSuite extends BaseDataSourceTest("test_data_type_convert_to_string
   }
 
   test("Test Convert from java.sql.Date to STRING") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // failure
     // java.sql.Date -> STRING
     compareTiDBWriteWithJDBC {
@@ -544,10 +497,6 @@ class ToStringSuite extends BaseDataSourceTest("test_data_type_convert_to_string
   }
 
   test("Test Convert from java.sql.Timestamp to STRING") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // success
     // java.sql.Timestamp -> STRING
     compareTiDBWriteWithJDBC {

--- a/core/src/test/scala/com/pingcap/tispark/convert/ToTimestampSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/convert/ToTimestampSuite.scala
@@ -15,7 +15,7 @@
 
 package com.pingcap.tispark.convert
 
-import com.pingcap.tispark.datasource.BaseDataSourceTest
+import com.pingcap.tispark.datasource.BaseBatchWriteTest
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types._
 
@@ -23,7 +23,7 @@ import org.apache.spark.sql.types._
  * TIMESTAMP type include:
  * 1. TIMESTAMP
  */
-class ToTimestampSuite extends BaseDataSourceTest("test_data_type_convert_to_timestamp") {
+class ToTimestampSuite extends BaseBatchWriteTest("test_data_type_convert_to_timestamp") {
 
   private val readSchema = StructType(
     List(
@@ -31,18 +31,7 @@ class ToTimestampSuite extends BaseDataSourceTest("test_data_type_convert_to_tim
       StructField("c1", TimestampType),
       StructField("c2", TimestampType)))
 
-  override def afterAll(): Unit =
-    try {
-      dropTable()
-    } finally {
-      super.afterAll()
-    }
-
   ignore("Test Convert from java.lang.Long to TIMESTAMP") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // success
     // java.lang.Long -> TIMESTAMP
     compareTiDBWriteWithJDBC {
@@ -78,10 +67,6 @@ class ToTimestampSuite extends BaseDataSourceTest("test_data_type_convert_to_tim
   }
 
   test("Test Convert from String to TIMESTAMP") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // success
     // String -> TIMESTAMP
     compareTiDBWriteWithJDBC {
@@ -113,10 +98,6 @@ class ToTimestampSuite extends BaseDataSourceTest("test_data_type_convert_to_tim
   }
 
   test("Test Convert from java.sql.Date to TIMESTAMP") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // success
     // java.sql.Date -> TIMESTAMP
     compareTiDBWriteWithJDBC {
@@ -152,10 +133,6 @@ class ToTimestampSuite extends BaseDataSourceTest("test_data_type_convert_to_tim
   }
 
   test("Test Convert from java.sql.Timestamp to TIMESTAMP") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // success
     // java.sql.Timestamp -> TIMESTAMP
     compareTiDBWriteWithJDBC {

--- a/core/src/test/scala/com/pingcap/tispark/convert/ToUnsignedSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/convert/ToUnsignedSuite.scala
@@ -15,7 +15,7 @@
 
 package com.pingcap.tispark.convert
 
-import com.pingcap.tispark.datasource.BaseDataSourceTest
+import com.pingcap.tispark.datasource.BaseBatchWriteTest
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types._
 
@@ -27,7 +27,7 @@ import org.apache.spark.sql.types._
  * 4. INT UNSIGNED
  * 5. BIGINT UNSIGNED
  */
-class ToUnsignedSuite extends BaseDataSourceTest("test_data_type_convert_to_unsigned") {
+class ToUnsignedSuite extends BaseBatchWriteTest("test_data_type_convert_to_unsigned") {
   private val readSchema = StructType(
     List(
       StructField("i", IntegerType),
@@ -37,18 +37,7 @@ class ToUnsignedSuite extends BaseDataSourceTest("test_data_type_convert_to_unsi
       StructField("c4", LongType),
       StructField("c5", LongType)))
 
-  override def afterAll(): Unit =
-    try {
-      dropTable()
-    } finally {
-      super.afterAll()
-    }
-
   test("Test Convert from java.lang.Boolean to UNSIGNED") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // success
     // java.lang.Boolean -> {TINYINT SMALLINT MEDIUMINT INT BIGINT} UNSIGNED
     compareTiDBWriteWithJDBC {
@@ -88,10 +77,6 @@ class ToUnsignedSuite extends BaseDataSourceTest("test_data_type_convert_to_unsi
   }
 
   test("Test Convert from java.lang.Byte to UNSIGNED") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // success
     // java.lang.Byte -> {TINYINT SMALLINT MEDIUMINT INT BIGINT} UNSIGNED
     compareTiDBWriteWithJDBC {
@@ -127,10 +112,6 @@ class ToUnsignedSuite extends BaseDataSourceTest("test_data_type_convert_to_unsi
   }
 
   test("Test Convert from java.lang.Short to UNSIGNED") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // success
     // java.lang.Short -> {TINYINT SMALLINT MEDIUMINT INT BIGINT} UNSIGNED
     compareTiDBWriteWithJDBC {
@@ -168,10 +149,6 @@ class ToUnsignedSuite extends BaseDataSourceTest("test_data_type_convert_to_unsi
   }
 
   test("Test Convert from java.lang.Integer to UNSIGNED") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // success
     // java.lang.Integer -> {TINYINT SMALLINT MEDIUMINT INT BIGINT} UNSIGNED
     compareTiDBWriteWithJDBC {
@@ -210,10 +187,6 @@ class ToUnsignedSuite extends BaseDataSourceTest("test_data_type_convert_to_unsi
   }
 
   test("Test Convert from java.lang.Long to UNSIGNED") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // success
     // java.lang.Long -> {TINYINT SMALLINT MEDIUMINT INT BIGINT} UNSIGNED
     compareTiDBWriteWithJDBC {
@@ -253,10 +226,6 @@ class ToUnsignedSuite extends BaseDataSourceTest("test_data_type_convert_to_unsi
   }
 
   test("Test Convert from java.lang.Float to UNSIGNED") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // success
     // java.lang.Float -> {TINYINT SMALLINT MEDIUMINT INT BIGINT} UNSIGNED
     compareTiDBWriteWithJDBC {
@@ -313,10 +282,6 @@ class ToUnsignedSuite extends BaseDataSourceTest("test_data_type_convert_to_unsi
   }
 
   test("Test Convert from java.lang.Double to UNSIGNED") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // success
     // java.lang.Double -> {TINYINT SMALLINT MEDIUMINT INT BIGINT} UNSIGNED
     compareTiDBWriteWithJDBC {
@@ -372,10 +337,6 @@ class ToUnsignedSuite extends BaseDataSourceTest("test_data_type_convert_to_unsi
   }
 
   test("Test Convert from String to UNSIGNED") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // success
     // String -> {TINYINT SMALLINT MEDIUMINT INT BIGINT} UNSIGNED
     compareTiDBWriteWithJDBC {

--- a/core/src/test/scala/com/pingcap/tispark/datasource/AddingIndexInsertSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/AddingIndexInsertSuite.scala
@@ -20,7 +20,7 @@ import org.apache.spark.sql.Row
 import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
 
 // TODO: once exception message is stable, we need also check the exception's message.
-class AddingIndexInsertSuite extends BaseDataSourceTest("adding_index_insert") {
+class AddingIndexInsertSuite extends BaseBatchWriteTest("adding_index_insert") {
   private val row1 = Row(1, 1, "Hello")
   private val row2 = Row(2, 2, "TiDB")
   private val row3 = Row(3, 3, "Spark")
@@ -34,11 +34,6 @@ class AddingIndexInsertSuite extends BaseDataSourceTest("adding_index_insert") {
       StructField("s", StringType)))
 
   test("test column type can be truncated") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
-    dropTable()
     jdbcUpdate(s"create table $dbtable(pk int, i int, s varchar(128), unique index(s(2)))")
     jdbcUpdate(s"insert into $dbtable values(1, 1, 'Hello')")
     // insert row2 row3
@@ -52,11 +47,6 @@ class AddingIndexInsertSuite extends BaseDataSourceTest("adding_index_insert") {
   }
 
   test("no pk, no unique index case") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
-    dropTable()
     jdbcUpdate(s"create table $dbtable(pk int, i int, s varchar(128), index(i))")
     jdbcUpdate(s"insert into $dbtable values(1, 1, 'Hello')")
     // insert row2 row3
@@ -71,11 +61,6 @@ class AddingIndexInsertSuite extends BaseDataSourceTest("adding_index_insert") {
   }
 
   test("pk is not handle adding unique index") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
-    dropTable()
     jdbcUpdate(
       s"create table $dbtable(pk int, i int, s varchar(128), unique index(i), primary key(s))")
     jdbcUpdate(s"insert into $dbtable values(1, 1, 'Hello')")
@@ -90,11 +75,6 @@ class AddingIndexInsertSuite extends BaseDataSourceTest("adding_index_insert") {
   }
 
   test("pk is handle adding unique index") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
-    dropTable()
     jdbcUpdate(
       s"create table $dbtable(pk int, i int, s varchar(128), unique index(i), primary key(pk))")
     jdbcUpdate(s"insert into $dbtable values(1, 1, 'Hello')")
@@ -109,11 +89,6 @@ class AddingIndexInsertSuite extends BaseDataSourceTest("adding_index_insert") {
   }
 
   test("Test no pk adding unique index") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
-    dropTable()
     jdbcUpdate(s"create table $dbtable(pk int, i int, s varchar(128), unique index(i))")
     jdbcUpdate(s"insert into $dbtable values(1, 1, 'Hello')")
 
@@ -126,11 +101,4 @@ class AddingIndexInsertSuite extends BaseDataSourceTest("adding_index_insert") {
       tidbWrite(List(row2, row4), schema)
     }
   }
-
-  override def afterAll(): Unit =
-    try {
-      dropTable()
-    } finally {
-      super.afterAll()
-    }
 }

--- a/core/src/test/scala/com/pingcap/tispark/datasource/AddingIndexReplaceSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/AddingIndexReplaceSuite.scala
@@ -18,7 +18,7 @@ package com.pingcap.tispark.datasource
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
 
-class AddingIndexReplaceSuite extends BaseDataSourceTest("adding_index_replace") {
+class AddingIndexReplaceSuite extends BaseBatchWriteTest("adding_index_replace") {
   private val row1 = Row(1, 1, 1, "Hello")
   private val row2 = Row(2, 2, 2, "TiDB")
   private val row3 = Row(3, 3, 3, "Spark")
@@ -36,11 +36,6 @@ class AddingIndexReplaceSuite extends BaseDataSourceTest("adding_index_replace")
       StructField("s", StringType)))
 
   test("test unique index replace with primary key is handle and index") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
-    dropTable()
     jdbcUpdate(
       s"create table $dbtable(pk int, c1 int, c2 int, s varchar(128), primary key(pk), unique index(c1), unique index(c2), index(s))")
     jdbcUpdate(s"insert into $dbtable values(1, 1, 1, 'Hello')")
@@ -58,11 +53,6 @@ class AddingIndexReplaceSuite extends BaseDataSourceTest("adding_index_replace")
   }
 
   test("test same key in one rdd") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
-    dropTable()
     jdbcUpdate(s"create table $dbtable(pk int, c1 int, c2 int, s varchar(128), primary key(pk))")
     jdbcUpdate(s"insert into $dbtable values(1, 1, 1, 'Hello')")
 
@@ -76,11 +66,6 @@ class AddingIndexReplaceSuite extends BaseDataSourceTest("adding_index_replace")
   }
 
   test("test unique index replace with primary key is handle") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
-    dropTable()
     jdbcUpdate(
       s"create table $dbtable(pk int, c1 int, c2 int, s varchar(128), primary key(pk), unique index(c1), unique index(c2))")
     jdbcUpdate(s"insert into $dbtable values(1, 1, 1, 'Hello')")
@@ -98,11 +83,6 @@ class AddingIndexReplaceSuite extends BaseDataSourceTest("adding_index_replace")
   }
 
   test("test unique index replace without primary key") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
-    dropTable()
     jdbcUpdate(
       s"create table $dbtable(pk int, c1 int, c2 int, s varchar(128), unique index(c1), unique index(c2))")
     jdbcUpdate(s"insert into $dbtable values(1, 1, 1, 'Hello')")
@@ -116,11 +96,6 @@ class AddingIndexReplaceSuite extends BaseDataSourceTest("adding_index_replace")
   }
 
   test("test pk is handle") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
-    dropTable()
     jdbcUpdate(s"create table $dbtable(pk int, c1 int, c2 int, s varchar(128), primary key(pk))")
     jdbcUpdate(s"insert into $dbtable values(1, 1, 1, 'Hello')")
     // insert row2 row3
@@ -128,10 +103,4 @@ class AddingIndexReplaceSuite extends BaseDataSourceTest("adding_index_replace")
     testTiDBSelect(Seq(row1, row2, row3, row4), "c1")
   }
 
-  override def afterAll(): Unit =
-    try {
-      dropTable()
-    } finally {
-      super.afterAll()
-    }
 }

--- a/core/src/test/scala/com/pingcap/tispark/datasource/AutoIncrementSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/AutoIncrementSuite.scala
@@ -19,18 +19,11 @@ import com.pingcap.tikv.exception.ConvertOverflowException
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types._
 
-class AutoIncrementSuite extends BaseDataSourceTest("test_datasource_auto_increment") {
-
-  override def beforeAll(): Unit =
-    super.beforeAll()
+class AutoIncrementSuite extends BaseBatchWriteTest("test_datasource_auto_increment") {
 
   // Duplicate entry '2' for key 'PRIMARY'
   // currently user provided auto increment value is not supported!
   ignore("auto increment: user provide id") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     val row1 = Row(1L, 1L)
     val row2 = Row(2L, 2L)
     val row3 = Row(3L, 3L)
@@ -54,10 +47,6 @@ class AutoIncrementSuite extends BaseDataSourceTest("test_datasource_auto_increm
   }
 
   test("auto increment: tispark generate id") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     val row2 = Row(2L)
     val row3 = Row(3L)
     val row4 = Row(4L)
@@ -79,13 +68,7 @@ class AutoIncrementSuite extends BaseDataSourceTest("test_datasource_auto_increm
   }
 
   test("bigint signed tidb overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     val schema = StructType(List(StructField("j", LongType)))
-
-    dropTable()
 
     jdbcUpdate(
       s"create table $dbtable(i bigint NOT NULL AUTO_INCREMENT, j int NOT NULL, primary key (i))")
@@ -112,13 +95,8 @@ class AutoIncrementSuite extends BaseDataSourceTest("test_datasource_auto_increm
   }
 
   test("bigint signed tispark overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
 
     val schema = StructType(List(StructField("j", LongType)))
-
-    dropTable()
 
     jdbcUpdate(
       s"create table $dbtable(i bigint NOT NULL AUTO_INCREMENT, j int NOT NULL, primary key (i))")
@@ -147,13 +125,8 @@ class AutoIncrementSuite extends BaseDataSourceTest("test_datasource_auto_increm
   }
 
   test("bigint unsigned tidb overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
 
     val schema = StructType(List(StructField("j", LongType)))
-
-    dropTable()
 
     jdbcUpdate(
       s"create table $dbtable(i bigint unsigned NOT NULL AUTO_INCREMENT, j int NOT NULL, primary key (i))")
@@ -179,13 +152,7 @@ class AutoIncrementSuite extends BaseDataSourceTest("test_datasource_auto_increm
   }
 
   test("bigint unsigned tispark overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     val schema = StructType(List(StructField("j", LongType)))
-
-    dropTable()
 
     jdbcUpdate(
       s"create table $dbtable(i bigint unsigned NOT NULL AUTO_INCREMENT, j int NOT NULL, primary key (i))")
@@ -214,13 +181,7 @@ class AutoIncrementSuite extends BaseDataSourceTest("test_datasource_auto_increm
   }
 
   test("tinyint signed tidb overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     val schema = StructType(List(StructField("j", LongType)))
-
-    dropTable()
 
     jdbcUpdate(
       s"create table $dbtable(i tinyint NOT NULL AUTO_INCREMENT, j int NOT NULL, primary key (i))")
@@ -247,13 +208,7 @@ class AutoIncrementSuite extends BaseDataSourceTest("test_datasource_auto_increm
   }
 
   test("tinyint signed tispark overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     val schema = StructType(List(StructField("j", LongType)))
-
-    dropTable()
 
     jdbcUpdate(
       s"create table $dbtable(i tinyint NOT NULL AUTO_INCREMENT, j int NOT NULL, primary key (i))")
@@ -281,13 +236,7 @@ class AutoIncrementSuite extends BaseDataSourceTest("test_datasource_auto_increm
   }
 
   test("tinyint unsigned tidb overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     val schema = StructType(List(StructField("j", LongType)))
-
-    dropTable()
 
     jdbcUpdate(
       s"create table $dbtable(i tinyint unsigned NOT NULL AUTO_INCREMENT, j int NOT NULL, primary key (i))")
@@ -313,13 +262,7 @@ class AutoIncrementSuite extends BaseDataSourceTest("test_datasource_auto_increm
   }
 
   test("tinyint unsigned tispark overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     val schema = StructType(List(StructField("j", LongType)))
-
-    dropTable()
 
     jdbcUpdate(
       s"create table $dbtable(i tinyint unsigned NOT NULL AUTO_INCREMENT, j int NOT NULL, primary key (i))")
@@ -345,11 +288,4 @@ class AutoIncrementSuite extends BaseDataSourceTest("test_datasource_auto_increm
     assert(caught.getCause.isInstanceOf[ConvertOverflowException])
     assert(caught.getCause.getMessage.equals("value 256 > upperBound 255"))
   }
-
-  override def afterAll(): Unit =
-    try {
-      dropTable()
-    } finally {
-      super.afterAll()
-    }
 }

--- a/core/src/test/scala/com/pingcap/tispark/datasource/AutoIncrementSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/AutoIncrementSuite.scala
@@ -31,8 +31,6 @@ class AutoIncrementSuite extends BaseBatchWriteTest("test_datasource_auto_increm
 
     val schema = StructType(List(StructField("i", LongType), StructField("j", LongType)))
 
-    dropTable()
-
     jdbcUpdate(
       s"create table $dbtable(i int NOT NULL AUTO_INCREMENT, j int NOT NULL, primary key (i))")
 
@@ -52,8 +50,6 @@ class AutoIncrementSuite extends BaseBatchWriteTest("test_datasource_auto_increm
     val row4 = Row(4L)
 
     val schema = StructType(List(StructField("j", LongType)))
-
-    dropTable()
 
     jdbcUpdate(
       s"create table $dbtable(i int NOT NULL AUTO_INCREMENT, j int NOT NULL, primary key (i))")

--- a/core/src/test/scala/com/pingcap/tispark/datasource/BaseBatchWriteTest.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/BaseBatchWriteTest.scala
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2020 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pingcap.tispark.datasource
+
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.types.StructType
+
+class BaseBatchWriteTest(
+    override val table: String,
+    override val database: String = "tispark_test")
+    extends BaseDataSourceTest(table, database) {
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    if (!supportBatchWrite) {
+      cancel
+    }
+    dropTable()
+  }
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+  }
+
+  override def afterAll(): Unit =
+    try {
+      dropTable()
+    } finally {
+      super.afterAll()
+    }
+
+  protected def compareTiDBWriteWithJDBC(
+      testCode: ((List[Row], StructType, Option[Map[String, String]]) => Unit, String) => Unit)
+      : Unit = {
+    testCode(tidbWrite, "tidbWrite")
+    testCode(jdbcWrite, "jdbcWrite")
+  }
+
+  protected def compareTiDBSelectWithJDBC_V2(sortCol: String = "i"): Unit = {
+    compareTiDBSelectWithJDBCWithTable_V2(table, sortCol)
+  }
+
+  protected def compareTiDBSelectWithJDBCWithTable_V2(
+      tblName: String,
+      sortCol: String = "i"): Unit = {
+    val sql = s"select * from `$database`.`$tblName` order by $sortCol"
+
+    // check jdbc result & data source result
+    val jdbcResult = queryTiDBViaJDBC(sql)
+    val df = queryDatasourceTiDBWithTable(sortCol, tableName = tblName)
+    val tidbResult = seqRowToList(df.collect(), df.schema)
+
+    if (!compResult(jdbcResult, tidbResult)) {
+      logger.error(s"""Failed on $tblName\n
+                      |DataSourceAPI result: ${listToString(jdbcResult)}\n
+                      |TiDB via JDBC result: ${listToString(tidbResult)}""".stripMargin)
+      fail()
+    }
+  }
+}

--- a/core/src/test/scala/com/pingcap/tispark/datasource/BaseBatchWriteWithoutDropTableTest.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/BaseBatchWriteWithoutDropTableTest.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pingcap.tispark.datasource
+
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.types.StructType
+
+class BaseBatchWriteWithoutDropTableTest(
+    override val table: String,
+    override val database: String = "tispark_test")
+    extends BaseDataSourceTest(table, database) {
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    if (!supportBatchWrite) {
+      cancel
+    }
+  }
+
+  override def afterAll(): Unit =
+    try {
+      dropTable()
+    } finally {
+      super.afterAll()
+    }
+
+  protected def compareTiDBWriteWithJDBC(
+      testCode: ((List[Row], StructType, Option[Map[String, String]]) => Unit, String) => Unit)
+      : Unit = {
+    testCode(tidbWrite, "tidbWrite")
+    testCode(jdbcWrite, "jdbcWrite")
+  }
+
+  protected def compareTiDBSelectWithJDBC_V2(sortCol: String = "i"): Unit = {
+    compareTiDBSelectWithJDBCWithTable_V2(table, sortCol)
+  }
+
+  protected def compareTiDBSelectWithJDBCWithTable_V2(
+      tblName: String,
+      sortCol: String = "i"): Unit = {
+    val sql = s"select * from `$database`.`$tblName` order by $sortCol"
+
+    // check jdbc result & data source result
+    val jdbcResult = queryTiDBViaJDBC(sql)
+    val df = queryDatasourceTiDBWithTable(sortCol, tableName = tblName)
+    val tidbResult = seqRowToList(df.collect(), df.schema)
+
+    if (!compResult(jdbcResult, tidbResult)) {
+      logger.error(s"""Failed on $tblName\n
+                      |DataSourceAPI result: ${listToString(jdbcResult)}\n
+                      |TiDB via JDBC result: ${listToString(tidbResult)}""".stripMargin)
+      fail()
+    }
+  }
+}

--- a/core/src/test/scala/com/pingcap/tispark/datasource/BasicBatchWriteSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/BasicBatchWriteSuite.scala
@@ -20,7 +20,7 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
 
-class BasicBatchWriteSuite extends BaseBatchWriteTest("test_datasource_basic") {
+class BasicBatchWriteSuite extends BaseBatchWriteWithoutDropTableTest("test_datasource_basic") {
   private val row1 = Row(null, "Hello")
   private val row2 = Row(2, "TiDB")
   private val row3 = Row(3, "Spark")

--- a/core/src/test/scala/com/pingcap/tispark/datasource/BasicBatchWriteSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/BasicBatchWriteSuite.scala
@@ -20,7 +20,7 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
 
-class BasicDataSourceSuite extends BaseDataSourceTest("test_datasource_basic") {
+class BasicBatchWriteSuite extends BaseBatchWriteTest("test_datasource_basic") {
   private val row1 = Row(null, "Hello")
   private val row2 = Row(2, "TiDB")
   private val row3 = Row(3, "Spark")
@@ -31,25 +31,15 @@ class BasicDataSourceSuite extends BaseDataSourceTest("test_datasource_basic") {
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-
-    dropTable()
     jdbcUpdate(s"create table $dbtable(i int, s varchar(128))")
     jdbcUpdate(s"insert into $dbtable values(null, 'Hello'), (2, 'TiDB')")
   }
 
   test("Test Select") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     testTiDBSelect(Seq(row1, row2))
   }
 
   test("Test Write Append") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     val data: RDD[Row] = sc.makeRDD(List(row3, row4))
     val df = sqlContext.createDataFrame(data, schema)
 
@@ -65,10 +55,6 @@ class BasicDataSourceSuite extends BaseDataSourceTest("test_datasource_basic") {
   }
 
   test("Test Write Overwrite") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     val data: RDD[Row] = sc.makeRDD(List(row3, row4))
     val df = sqlContext.createDataFrame(data, schema)
 
@@ -86,11 +72,4 @@ class BasicDataSourceSuite extends BaseDataSourceTest("test_datasource_basic") {
       caught.getMessage
         .equals("SaveMode: Overwrite is not supported. TiSpark only support SaveMode.Append."))
   }
-
-  override def afterAll(): Unit =
-    try {
-      dropTable()
-    } finally {
-      super.afterAll()
-    }
 }

--- a/core/src/test/scala/com/pingcap/tispark/datasource/BasicSQLSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/BasicSQLSuite.scala
@@ -20,7 +20,7 @@ import org.apache.spark.sql.Row
 
 import scala.util.Random
 
-class BasicSQLSuite extends BaseDataSourceTest("test_datasource_sql") {
+class BasicSQLSuite extends BaseBatchWriteTest("test_datasource_sql") {
   private val row1 = Row(null, "Hello")
   private val row2 = Row(2, "TiDB")
   private val row3 = Row(3, "Spark")
@@ -28,25 +28,15 @@ class BasicSQLSuite extends BaseDataSourceTest("test_datasource_sql") {
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-
-    dropTable()
     jdbcUpdate(s"create table $dbtable(i int, s varchar(128))")
     jdbcUpdate(s"insert into $dbtable values(null, 'Hello'), (2, 'TiDB')")
   }
 
   test("Test Select") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     testSelectSQL(Seq(row1, row2))
   }
 
   test("Test Insert Into") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     val tmpTable = "default.testInsert"
     sqlContext.sql(s"""
                       |CREATE TABLE $tmpTable
@@ -70,10 +60,6 @@ class BasicSQLSuite extends BaseDataSourceTest("test_datasource_sql") {
   }
 
   test("Test Insert Overwrite") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     val tmpTable = "default.testOverwrite"
     sqlContext.sql(s"""
                       |CREATE TABLE $tmpTable
@@ -99,13 +85,6 @@ class BasicSQLSuite extends BaseDataSourceTest("test_datasource_sql") {
       caught.getMessage
         .equals("SaveMode: Overwrite is not supported. TiSpark only support SaveMode.Append."))
   }
-
-  override def afterAll(): Unit =
-    try {
-      dropTable()
-    } finally {
-      super.afterAll()
-    }
 
   private def testSelectSQL(expectedAnswer: Seq[Row]): Unit = {
     val tmpName =

--- a/core/src/test/scala/com/pingcap/tispark/datasource/BasicSQLSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/BasicSQLSuite.scala
@@ -20,7 +20,7 @@ import org.apache.spark.sql.Row
 
 import scala.util.Random
 
-class BasicSQLSuite extends BaseBatchWriteTest("test_datasource_sql") {
+class BasicSQLSuite extends BaseBatchWriteWithoutDropTableTest("test_datasource_sql") {
   private val row1 = Row(null, "Hello")
   private val row2 = Row(2, "TiDB")
   private val row3 = Row(3, "Spark")

--- a/core/src/test/scala/com/pingcap/tispark/datasource/CheckUnsupportedSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/CheckUnsupportedSuite.scala
@@ -19,18 +19,12 @@ import com.pingcap.tikv.exception.TiBatchWriteException
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
 
-class CheckUnsupportedSuite extends BaseDataSourceTest("test_datasource_check_unsupported") {
+class CheckUnsupportedSuite extends BaseBatchWriteTest("test_datasource_check_unsupported") {
 
   override def beforeAll(): Unit =
     super.beforeAll()
 
   test("Test write to partition table") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
-    dropTable()
-
     tidbStmt.execute("set @@tidb_enable_table_partition = 1")
 
     jdbcUpdate(
@@ -56,11 +50,6 @@ class CheckUnsupportedSuite extends BaseDataSourceTest("test_datasource_check_un
   }
 
   test("Check Virtual Generated Column") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
-    dropTable()
     jdbcUpdate(s"create table $dbtable(i INT, c1 INT, c2 INT,  c3 INT AS (c1 + c2))")
 
     val row1 = Row(1, 2, 3)
@@ -80,11 +69,6 @@ class CheckUnsupportedSuite extends BaseDataSourceTest("test_datasource_check_un
   }
 
   test("Check Stored Generated Column") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
-    dropTable()
     jdbcUpdate(s"create table $dbtable(i INT, c1 INT, c2 INT,  c3 INT AS (c1 + c2) STORED)")
 
     val row1 = Row(1, 2, 3)
@@ -101,11 +85,4 @@ class CheckUnsupportedSuite extends BaseDataSourceTest("test_datasource_check_un
         .equals("tispark currently does not support write data to table with generated column!"))
 
   }
-
-  override def afterAll(): Unit =
-    try {
-      dropTable()
-    } finally {
-      super.afterAll()
-    }
 }

--- a/core/src/test/scala/com/pingcap/tispark/datasource/ColumnMappingSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/ColumnMappingSuite.scala
@@ -21,7 +21,7 @@ import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructT
 import scala.collection.mutable.ArrayBuffer
 
 class ColumnMappingSuite
-    extends BaseDataSourceTest("test_datasource_insert_with_different_column_order") {
+    extends BaseBatchWriteTest("test_datasource_insert_with_different_column_order") {
 
   private val schema = StructType(
     List(
@@ -29,20 +29,8 @@ class ColumnMappingSuite
       StructField("s", StringType),
       StructField("c", StringType)))
 
-  override def afterAll(): Unit =
-    try {
-      dropTable()
-    } finally {
-      super.afterAll()
-    }
-
   // currently user provided auto increment value is not supported!
   ignore("Test different column order with full schema") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
-    dropTable()
     jdbcUpdate(
       s"create table $dbtable(i int primary key auto_increment, s varchar(128), c varchar(128))")
 
@@ -81,11 +69,6 @@ class ColumnMappingSuite
   }
 
   test("Test different column order without auto increment column") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
-    dropTable()
     jdbcUpdate(
       s"create table $dbtable(i int primary key auto_increment, s varchar(128), c varchar(128))")
 

--- a/core/src/test/scala/com/pingcap/tispark/datasource/EdgeConditionSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/EdgeConditionSuite.scala
@@ -18,28 +18,19 @@ package com.pingcap.tispark.datasource
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types._
 
-class EdgeConditionSuite extends BaseDataSourceTest("test_datasource_edge_condition") {
+class EdgeConditionSuite extends BaseBatchWriteTest("test_datasource_edge_condition") {
 
   private val TEST_LARGE_DATA_SIZE = 25600
 
   private val TEST_LARGE_COLUMN_SIZE = 512
 
-  override def beforeAll(): Unit =
-    super.beforeAll()
-
   test("Write to table with one column (primary key long type)") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     val row1 = Row(1L)
     val row2 = Row(2L)
     val row3 = Row(3L)
     val row4 = Row(4L)
 
     val schema = StructType(List(StructField("i", LongType)))
-
-    dropTable()
 
     jdbcUpdate(s"create table $dbtable(i int, primary key (i))")
     jdbcUpdate(s"insert into $dbtable values(1)")
@@ -48,18 +39,12 @@ class EdgeConditionSuite extends BaseDataSourceTest("test_datasource_edge_condit
   }
 
   test("Write to table with one column (primary key int type)") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     val row1 = Row(1)
     val row2 = Row(2)
     val row3 = Row(3)
     val row4 = Row(4)
 
     val schema = StructType(List(StructField("i", IntegerType)))
-
-    dropTable()
 
     jdbcUpdate(s"create table $dbtable(i int, primary key (i))")
     jdbcUpdate(s"insert into $dbtable values(1)")
@@ -69,9 +54,6 @@ class EdgeConditionSuite extends BaseDataSourceTest("test_datasource_edge_condit
 
   // currently user provided auto increment value is not supported!
   ignore("Write to table with one column (primary key + auto increase)") {
-    if (!supportBatchWrite) {
-      cancel
-    }
 
     val row1 = Row(1L)
     val row2 = Row(2L)
@@ -80,8 +62,6 @@ class EdgeConditionSuite extends BaseDataSourceTest("test_datasource_edge_condit
 
     val schema = StructType(List(StructField("i", LongType)))
 
-    dropTable()
-
     jdbcUpdate(s"create table $dbtable(i int NOT NULL AUTO_INCREMENT, primary key (i))")
     jdbcUpdate(s"insert into $dbtable values(1)")
     tidbWrite(List(row2, row3, row4), schema)
@@ -89,18 +69,12 @@ class EdgeConditionSuite extends BaseDataSourceTest("test_datasource_edge_condit
   }
 
   test("Write to table with one column (no primary key)") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     val row1 = Row(null)
     val row2 = Row("Hello")
     val row3 = Row("Spark")
     val row4 = Row("TiDB")
 
     val schema = StructType(List(StructField("i", StringType)))
-
-    dropTable()
 
     jdbcUpdate(s"create table $dbtable(i varchar(128))")
     jdbcUpdate(s"insert into $dbtable values('Hello')")
@@ -109,10 +83,6 @@ class EdgeConditionSuite extends BaseDataSourceTest("test_datasource_edge_condit
   }
 
   test("Write to table with many columns") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     val types = ("int", LongType) :: ("varchar(128)", StringType) :: Nil
     val data1 = 1L :: "TiDB" :: Nil
     val data2 = 2L :: "Spark" :: Nil
@@ -137,8 +107,6 @@ class EdgeConditionSuite extends BaseDataSourceTest("test_datasource_edge_condit
       }
       .mkString(", ")
 
-    dropTable()
-
     jdbcUpdate(s"create table $dbtable($createTableSchemaStr)")
 
     tidbWrite(List(row1, row2), schema)
@@ -146,15 +114,9 @@ class EdgeConditionSuite extends BaseDataSourceTest("test_datasource_edge_condit
   }
 
   test("Write Empty data") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     val row1 = Row(1L)
 
     val schema = StructType(List(StructField("i", LongType)))
-
-    dropTable()
 
     jdbcUpdate(s"create table $dbtable(i int, primary key (i))")
     jdbcUpdate(s"insert into $dbtable values(1)")
@@ -163,10 +125,6 @@ class EdgeConditionSuite extends BaseDataSourceTest("test_datasource_edge_condit
   }
 
   test("Write large amount of data") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     var list: List[Row] = Nil
     for (i <- 0 until TEST_LARGE_DATA_SIZE) {
       list = Row(i.toLong) :: list
@@ -174,8 +132,6 @@ class EdgeConditionSuite extends BaseDataSourceTest("test_datasource_edge_condit
     list = list.reverse
 
     val schema = StructType(List(StructField("i", LongType)))
-
-    dropTable()
 
     jdbcUpdate(s"create table $dbtable(i int, primary key (i))")
     tidbWrite(list, schema)
@@ -190,11 +146,4 @@ class EdgeConditionSuite extends BaseDataSourceTest("test_datasource_edge_condit
     tidbWrite(list2, schema)
     testTiDBSelect(list ::: list2)
   }
-
-  override def afterAll(): Unit =
-    try {
-      dropTable()
-    } finally {
-      super.afterAll()
-    }
 }

--- a/core/src/test/scala/com/pingcap/tispark/datasource/ExceptionTestSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/ExceptionTestSuite.scala
@@ -19,22 +19,13 @@ import com.pingcap.tikv.exception.TiBatchWriteException
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types.{LongType, StringType, StructField, StructType}
 
-class ExceptionTestSuite extends BaseDataSourceTest("test_datasource_exception_test") {
-
-  override def beforeAll(): Unit =
-    super.beforeAll()
+class ExceptionTestSuite extends BaseBatchWriteTest("test_datasource_exception_test") {
 
   test("Test write to table does not exist") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     val row1 = Row(null, "Hello")
     val row2 = Row(2L, "TiDB")
 
     val schema = StructType(List(StructField("i", LongType), StructField("s", StringType)))
-
-    dropTable()
 
     val caught = intercept[TiBatchWriteException] {
       tidbWrite(List(row1, row2), schema)
@@ -43,15 +34,9 @@ class ExceptionTestSuite extends BaseDataSourceTest("test_datasource_exception_t
   }
 
   test("Test column does not exist") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     val row1 = Row(2L, 3L)
 
     val schema = StructType(List(StructField("i", LongType), StructField("i2", LongType)))
-
-    dropTable()
 
     jdbcUpdate(s"create table $dbtable(i int)")
 
@@ -67,15 +52,9 @@ class ExceptionTestSuite extends BaseDataSourceTest("test_datasource_exception_t
   }
 
   test("Missing insert column") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     val row1 = Row(2L, 3L)
 
     val schema = StructType(List(StructField("i", LongType), StructField("i2", LongType)))
-
-    dropTable()
 
     jdbcUpdate(s"create table $dbtable(i int, i2 int, i3 int)")
 
@@ -91,10 +70,6 @@ class ExceptionTestSuite extends BaseDataSourceTest("test_datasource_exception_t
   }
 
   test("Insert null value to Not Null Column") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     val row1 = Row(null, 3L)
     val row2 = Row(4L, null)
 
@@ -113,11 +88,4 @@ class ExceptionTestSuite extends BaseDataSourceTest("test_datasource_exception_t
           .equals("Insert null value to not null column! rows contain illegal null values!"))
     }
   }
-
-  override def afterAll(): Unit =
-    try {
-      dropTable()
-    } finally {
-      super.afterAll()
-    }
 }

--- a/core/src/test/scala/com/pingcap/tispark/datasource/ExceptionTestSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/ExceptionTestSuite.scala
@@ -75,8 +75,6 @@ class ExceptionTestSuite extends BaseBatchWriteTest("test_datasource_exception_t
 
     val schema = StructType(List(StructField("i", LongType), StructField("i2", LongType)))
 
-    dropTable()
-
     jdbcUpdate(s"create table $dbtable(i int, i2 int NOT NULL)")
 
     {

--- a/core/src/test/scala/com/pingcap/tispark/datasource/FilterPushdownSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/FilterPushdownSuite.scala
@@ -17,7 +17,7 @@ package com.pingcap.tispark.datasource
 
 import org.apache.spark.sql.Row
 
-class FilterPushdownSuite extends BaseDataSourceTest("test_datasource_filter_pushdown") {
+class FilterPushdownSuite extends BaseBatchWriteTest("test_datasource_filter_pushdown") {
   private val row1 = Row(null, "Hello")
   private val row2 = Row(2, "TiDB")
   private val row3 = Row(3, "Spark")
@@ -25,37 +25,23 @@ class FilterPushdownSuite extends BaseDataSourceTest("test_datasource_filter_pus
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-
-    dropTable()
     jdbcUpdate(s"create table $dbtable(i int, s varchar(128))")
     jdbcUpdate(
       s"insert into $dbtable values(null, 'Hello'), (2, 'TiDB'), (3, 'Spark'), (4, null)")
   }
 
   test("Test Simple Comparisons") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     testTiDBSelectFilter("s = 'Hello'", Seq(row1))
     testTiDBSelectFilter("i > 2", Seq(row3, row4))
     testTiDBSelectFilter("i < 3", Seq(row2))
   }
 
   test("Test >= and <=") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     testTiDBSelectFilter("i >= 2", Seq(row2, row3, row4))
     testTiDBSelectFilter("i <= 3", Seq(row2, row3))
   }
 
   test("Test logical operators") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     testTiDBSelectFilter("i >= 2 AND i <= 3", Seq(row2, row3))
     testTiDBSelectFilter("NOT i = 3", Seq(row2, row4))
     testTiDBSelectFilter("NOT i = 3 OR i IS NULL", Seq(row1, row2, row4))
@@ -63,17 +49,6 @@ class FilterPushdownSuite extends BaseDataSourceTest("test_datasource_filter_pus
   }
 
   test("Test IN") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     testTiDBSelectFilter("i IN ( 2, 3)", Seq(row2, row3))
   }
-
-  override def afterAll(): Unit =
-    try {
-      dropTable()
-    } finally {
-      super.afterAll()
-    }
 }

--- a/core/src/test/scala/com/pingcap/tispark/datasource/FilterPushdownSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/FilterPushdownSuite.scala
@@ -17,7 +17,8 @@ package com.pingcap.tispark.datasource
 
 import org.apache.spark.sql.Row
 
-class FilterPushdownSuite extends BaseBatchWriteTest("test_datasource_filter_pushdown") {
+class FilterPushdownSuite
+    extends BaseBatchWriteWithoutDropTableTest("test_datasource_filter_pushdown") {
   private val row1 = Row(null, "Hello")
   private val row2 = Row(2, "TiDB")
   private val row3 = Row(3, "Spark")

--- a/core/src/test/scala/com/pingcap/tispark/datasource/InsertSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/InsertSuite.scala
@@ -21,7 +21,7 @@ import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructT
 
 import scala.collection.mutable.ArrayBuffer
 
-class InsertSuite extends BaseDataSourceTest("test.datasource_insert") {
+class InsertSuite extends BaseBatchWriteTest("test.datasource_insert") {
   private val row1 = Row(null, "Hello")
   private val row5 = Row(5, "Duplicate")
 
@@ -30,23 +30,11 @@ class InsertSuite extends BaseDataSourceTest("test.datasource_insert") {
   private val schema = StructType(
     List(StructField("i", IntegerType), StructField("s", StringType)))
 
-  override def afterAll(): Unit =
-    try {
-      dropTable()
-    } finally {
-      super.afterAll()
-    }
-
   private def compareRow(r1: Row, r2: Row): Boolean = {
     r1.getAs[Int](0) < r2.getAs[Int](0)
   }
 
   test("Test insert to table without primary key") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
-    dropTable()
     jdbcUpdate(s"create table $dbtable(i int, s varchar(128))")
     jdbcUpdate(s"insert into $dbtable values(null, 'Hello')")
 
@@ -79,11 +67,6 @@ class InsertSuite extends BaseDataSourceTest("test.datasource_insert") {
   }
 
   test("Test insert to table with primary key (primary key is handle)") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
-    dropTable()
     jdbcUpdate(s"create table $dbtable(i int primary key, s varchar(128))")
     jdbcUpdate(s"insert into $dbtable values(2, 'TiDB')")
 
@@ -114,11 +97,6 @@ class InsertSuite extends BaseDataSourceTest("test.datasource_insert") {
   }
 
   test("Test insert to table with primary key with tiny int") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
-    dropTable()
     jdbcUpdate(s"create table $dbtable(i tinyint primary key, s varchar(128))")
     jdbcUpdate(s"insert into $dbtable values(2, 'TiDB')")
 
@@ -131,11 +109,6 @@ class InsertSuite extends BaseDataSourceTest("test.datasource_insert") {
   }
 
   test("Test insert to table with primary key with small int") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
-    dropTable()
     jdbcUpdate(s"create table $dbtable(i smallint primary key, s varchar(128))")
     jdbcUpdate(s"insert into $dbtable values(2, 'TiDB')")
 
@@ -148,11 +121,6 @@ class InsertSuite extends BaseDataSourceTest("test.datasource_insert") {
   }
 
   test("Test insert to table with primary key with medium int") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
-    dropTable()
     jdbcUpdate(s"create table $dbtable(i mediumint primary key, s varchar(128))")
     jdbcUpdate(s"insert into $dbtable values(2, 'TiDB')")
 
@@ -166,11 +134,6 @@ class InsertSuite extends BaseDataSourceTest("test.datasource_insert") {
 
   // currently user provided auto increment value is not supported!
   ignore("Test insert to table with primary key (auto increase case 1)") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
-    dropTable()
     jdbcUpdate(s"create table $dbtable(i int primary key AUTO_INCREMENT, s varchar(128))")
     jdbcUpdate(s"insert into $dbtable values(2, 'TiDB')")
 
@@ -209,11 +172,6 @@ class InsertSuite extends BaseDataSourceTest("test.datasource_insert") {
   }
 
   test("Test insert to table with primary key (auto increase case 2)") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
-    dropTable()
     jdbcUpdate(s"create table $dbtable(i int primary key AUTO_INCREMENT, s varchar(128))")
     jdbcUpdate(s"insert into $dbtable(s) values('Hello')")
 

--- a/core/src/test/scala/com/pingcap/tispark/datasource/MissingParameterSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/MissingParameterSuite.scala
@@ -19,18 +19,13 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
 
-class MissingParameterSuite extends BaseDataSourceTest("test_datasource_missing_parameter") {
+class MissingParameterSuite extends BaseBatchWriteTest("test_datasource_missing_parameter") {
   private val row1 = Row(null, "Hello")
 
   private val schema = StructType(
     List(StructField("i", IntegerType), StructField("s", StringType)))
 
   test("Missing parameter: database") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
-    dropTable()
     jdbcUpdate(s"create table $dbtable(i int, s varchar(128))")
 
     val caught = intercept[IllegalArgumentException] {
@@ -48,11 +43,4 @@ class MissingParameterSuite extends BaseDataSourceTest("test_datasource_missing_
       caught.getMessage
         .equals("requirement failed: Option 'database' is required."))
   }
-
-  override def afterAll(): Unit =
-    try {
-      dropTable()
-    } finally {
-      super.afterAll()
-    }
 }

--- a/core/src/test/scala/com/pingcap/tispark/datasource/OnlyOnePkSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/OnlyOnePkSuite.scala
@@ -19,7 +19,7 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types.{IntegerType, StructField, StructType}
 
-class OnlyOnePkSuite extends BaseDataSourceTest("test_datasource_only_one_pk") {
+class OnlyOnePkSuite extends BaseBatchWriteTest("test_datasource_only_one_pk") {
   private val row3 = Row(3)
   private val row4 = Row(4)
 
@@ -27,16 +27,10 @@ class OnlyOnePkSuite extends BaseDataSourceTest("test_datasource_only_one_pk") {
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-
-    dropTable()
     jdbcUpdate(s"create table $dbtable(i int primary key)")
   }
 
   test("Test Write Append") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     val data: RDD[Row] = sc.makeRDD(List(row3, row4))
     val df = sqlContext.createDataFrame(data, schema)
 
@@ -50,11 +44,4 @@ class OnlyOnePkSuite extends BaseDataSourceTest("test_datasource_only_one_pk") {
 
     testTiDBSelect(Seq(row3, row4))
   }
-
-  override def afterAll(): Unit =
-    try {
-      dropTable()
-    } finally {
-      super.afterAll()
-    }
 }

--- a/core/src/test/scala/com/pingcap/tispark/datasource/OnlyOnePkSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/OnlyOnePkSuite.scala
@@ -19,7 +19,7 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types.{IntegerType, StructField, StructType}
 
-class OnlyOnePkSuite extends BaseBatchWriteTest("test_datasource_only_one_pk") {
+class OnlyOnePkSuite extends BaseBatchWriteWithoutDropTableTest("test_datasource_only_one_pk") {
   private val row3 = Row(3)
   private val row4 = Row(4)
 

--- a/core/src/test/scala/com/pingcap/tispark/datasource/RowIDAllocatorSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/RowIDAllocatorSuite.scala
@@ -20,9 +20,6 @@ import org.apache.spark.sql.BaseTiSparkTest
 
 class RowIDAllocatorSuite extends BaseTiSparkTest {
   test("test unsigned allocator") {
-    if (!supportBatchWrite) {
-      cancel
-    }
 
     tidbStmt.execute("drop table if exists rowid_allocator")
     tidbStmt.execute("""CREATE TABLE `rowid_allocator` (
@@ -42,9 +39,6 @@ class RowIDAllocatorSuite extends BaseTiSparkTest {
   }
 
   test("test signed allocator") {
-    if (!supportBatchWrite) {
-      cancel
-    }
 
     tidbStmt.execute("drop table if exists t")
     tidbStmt.execute("""CREATE TABLE `t` (

--- a/core/src/test/scala/com/pingcap/tispark/datasource/RowIDAllocatorSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/RowIDAllocatorSuite.scala
@@ -20,7 +20,6 @@ import org.apache.spark.sql.BaseTiSparkTest
 
 class RowIDAllocatorSuite extends BaseTiSparkTest {
   test("test unsigned allocator") {
-
     tidbStmt.execute("drop table if exists rowid_allocator")
     tidbStmt.execute("""CREATE TABLE `rowid_allocator` (
                        |  `a` int(11) DEFAULT NULL
@@ -39,7 +38,6 @@ class RowIDAllocatorSuite extends BaseTiSparkTest {
   }
 
   test("test signed allocator") {
-
     tidbStmt.execute("drop table if exists t")
     tidbStmt.execute("""CREATE TABLE `t` (
                        |  `a` int(11) DEFAULT NULL

--- a/core/src/test/scala/com/pingcap/tispark/datasource/ShardRowIDBitsSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/ShardRowIDBitsSuite.scala
@@ -15,7 +15,6 @@
 
 package com.pingcap.tispark.datasource
 
-import com.pingcap.tikv.allocator.RowIDAllocator
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types._
 

--- a/core/src/test/scala/com/pingcap/tispark/datasource/TiSparkTypeSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/TiSparkTypeSuite.scala
@@ -18,7 +18,7 @@ package com.pingcap.tispark.datasource
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types.{LongType, StringType, StructField, StructType}
 
-class TiSparkTypeSuite extends BaseDataSourceTest("type_test") {
+class TiSparkTypeSuite extends BaseBatchWriteTest("type_test") {
   private val row1 = Row(null, "Hello")
   private val row2 = Row(2L, "TiDB")
   private val row3 = Row(3L, "Spark")
@@ -26,9 +26,6 @@ class TiSparkTypeSuite extends BaseDataSourceTest("type_test") {
 
   private val schema = StructType(List(StructField("i", LongType), StructField("s", StringType)))
   test("bigint test") {
-    if (!supportBatchWrite) {
-      cancel
-    }
 
     dropTable()
     jdbcUpdate(s"create table $dbtable(i bigint, s varchar(128))")

--- a/core/src/test/scala/com/pingcap/tispark/datasource/TiSparkTypeSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/TiSparkTypeSuite.scala
@@ -26,8 +26,6 @@ class TiSparkTypeSuite extends BaseBatchWriteTest("type_test") {
 
   private val schema = StructType(List(StructField("i", LongType), StructField("s", StringType)))
   test("bigint test") {
-
-    dropTable()
     jdbcUpdate(s"create table $dbtable(i bigint, s varchar(128))")
     jdbcUpdate(s"insert into $dbtable values(null, 'Hello'), (2, 'TiDB')")
 

--- a/core/src/test/scala/com/pingcap/tispark/datasource/UpperCaseColumnNameSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/UpperCaseColumnNameSuite.scala
@@ -20,7 +20,7 @@ import org.apache.spark.sql.Row
 import org.apache.spark.sql.types.{IntegerType, StructField, StructType}
 
 class UpperCaseColumnNameSuite
-    extends BaseBatchWriteTest("test_datasource_uppser_case_column_name") {
+    extends BaseBatchWriteWithoutDropTableTest("test_datasource_uppser_case_column_name") {
 
   private val row1 = Row(1, 2)
 

--- a/core/src/test/scala/com/pingcap/tispark/datasource/UpperCaseColumnNameSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/UpperCaseColumnNameSuite.scala
@@ -20,7 +20,7 @@ import org.apache.spark.sql.Row
 import org.apache.spark.sql.types.{IntegerType, StructField, StructType}
 
 class UpperCaseColumnNameSuite
-    extends BaseDataSourceTest("test_datasource_uppser_case_column_name") {
+    extends BaseBatchWriteTest("test_datasource_uppser_case_column_name") {
 
   private val row1 = Row(1, 2)
 
@@ -30,7 +30,6 @@ class UpperCaseColumnNameSuite
   override def beforeAll(): Unit = {
     super.beforeAll()
 
-    dropTable()
     jdbcUpdate(s"""
                   |CREATE TABLE $dbtable (O_ORDERKEY INTEGER NOT NULL,
                   |                       O_CUSTKEY INTEGER NOT NULL);
@@ -38,10 +37,6 @@ class UpperCaseColumnNameSuite
   }
 
   test("Test insert upper case column name") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     val data: RDD[Row] = sc.makeRDD(List(row1))
     val df = sqlContext.createDataFrame(data, schema)
     df.write
@@ -52,11 +47,4 @@ class UpperCaseColumnNameSuite
       .mode("append")
       .save()
   }
-
-  override def afterAll(): Unit =
-    try {
-      dropTable()
-    } finally {
-      super.afterAll()
-    }
 }

--- a/core/src/test/scala/com/pingcap/tispark/datatype/BatchWriteDataTypeSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datatype/BatchWriteDataTypeSuite.scala
@@ -19,18 +19,13 @@ import java.sql.{Date, Timestamp}
 import java.util.Calendar
 
 import com.pingcap.tikv.exception.TiBatchWriteException
-import com.pingcap.tispark.datasource.BaseDataSourceTest
+import com.pingcap.tispark.datasource.BaseBatchWriteTest
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types._
 
-class BatchWriteDataTypeSuite extends BaseDataSourceTest("test_data_type", "test") {
+class BatchWriteDataTypeSuite extends BaseBatchWriteTest("test_data_type", "test") {
 
   test("Test Read different types") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
-    dropTable()
     jdbcUpdate(s"""
                   |create table $dbtable(
                   |i INT,
@@ -111,11 +106,6 @@ class BatchWriteDataTypeSuite extends BaseDataSourceTest("test_data_type", "test
 
   //todo support TIME/YEAR/BINARY/SET
   test("Test different data type") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
-    dropTable()
     jdbcUpdate(s"""
                   |create table $dbtable(
                   |i INT primary key,
@@ -302,7 +292,6 @@ class BatchWriteDataTypeSuite extends BaseDataSourceTest("test_data_type", "test
 
   test("Test integer pk") {
     // integer pk
-    dropTable()
     jdbcUpdate(s"""
                   |create table $dbtable(
                   |i INT primary key,
@@ -324,12 +313,7 @@ class BatchWriteDataTypeSuite extends BaseDataSourceTest("test_data_type", "test
   }
 
   test("Test decimal pk") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // decimal pk
-    dropTable()
     jdbcUpdate(s"""
                   |create table $dbtable(
                   |i decimal(3,2) primary key,
@@ -352,12 +336,7 @@ class BatchWriteDataTypeSuite extends BaseDataSourceTest("test_data_type", "test
   }
 
   test("Test char pk") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // char pk
-    dropTable()
     jdbcUpdate(s"""
                   |create table $dbtable(
                   |i char(4) primary key,
@@ -379,12 +358,7 @@ class BatchWriteDataTypeSuite extends BaseDataSourceTest("test_data_type", "test
   }
 
   test("Test varchar pk") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // char pk
-    dropTable()
     jdbcUpdate(s"""
                   |create table $dbtable(
                   |i varchar(4) primary key,
@@ -406,12 +380,7 @@ class BatchWriteDataTypeSuite extends BaseDataSourceTest("test_data_type", "test
   }
 
   test("Test date pk") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // char pk
-    dropTable()
     jdbcUpdate(s"""
                   |create table $dbtable(
                   |i date primary key,
@@ -435,12 +404,7 @@ class BatchWriteDataTypeSuite extends BaseDataSourceTest("test_data_type", "test
   }
 
   test("Test datetime pk") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // datetime pk
-    dropTable()
     jdbcUpdate(s"""
                   |create table $dbtable(
                   |i DATETIME primary key,
@@ -464,12 +428,7 @@ class BatchWriteDataTypeSuite extends BaseDataSourceTest("test_data_type", "test
   }
 
   test("Test timestamp pk") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // timestamp pk
-    dropTable()
     jdbcUpdate(s"""
                   |create table $dbtable(
                   |i timestamp primary key,
@@ -493,12 +452,7 @@ class BatchWriteDataTypeSuite extends BaseDataSourceTest("test_data_type", "test
   }
 
   test("Test text pk") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // timestamp pk
-    dropTable()
     jdbcUpdate(s"""
                   |create table $dbtable(
                   |i text,
@@ -521,12 +475,7 @@ class BatchWriteDataTypeSuite extends BaseDataSourceTest("test_data_type", "test
   }
 
   test("Test blob pk") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // blob pk
-    dropTable()
     jdbcUpdate(s"""
                   |create table $dbtable(
                   |i blob,
@@ -550,12 +499,7 @@ class BatchWriteDataTypeSuite extends BaseDataSourceTest("test_data_type", "test
   }
 
   test("Test enum pk") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // enum pk
-    dropTable()
     jdbcUpdate(s"""
                   |create table $dbtable(
                   |i ENUM('male','female','both','unknown') primary key,
@@ -577,12 +521,7 @@ class BatchWriteDataTypeSuite extends BaseDataSourceTest("test_data_type", "test
   }
 
   test("Test composite pk") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     // enum pk
-    dropTable()
     jdbcUpdate(s"""
                   |create table $dbtable(
                   |i int,
@@ -608,11 +547,4 @@ class BatchWriteDataTypeSuite extends BaseDataSourceTest("test_data_type", "test
       tidbWrite(data, schema)
     }
   }
-
-  override def afterAll(): Unit =
-    try {
-      dropTable()
-    } finally {
-      super.afterAll()
-    }
 }

--- a/core/src/test/scala/com/pingcap/tispark/index/LineItemSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/index/LineItemSuite.scala
@@ -16,10 +16,10 @@
 package com.pingcap.tispark.index
 
 import com.pingcap.tispark.write.{TiBatchWrite, TiDBOptions}
-import org.apache.spark.sql.BaseTiSparkTest
+import org.apache.spark.sql.BaseTiSparkEnableBatchWriteTest
 import org.apache.spark.sql.functions._
 
-class LineItemSuite extends BaseTiSparkTest {
+class LineItemSuite extends BaseTiSparkEnableBatchWriteTest {
 
   private val table = "LINEITEM"
   private val where = "where L_PARTKEY < 3100000"
@@ -39,7 +39,6 @@ class LineItemSuite extends BaseTiSparkTest {
   }
 
   test("ti batch write: lineitem") {
-
     val tableToWrite = s"${batchWriteTablePrefix}_$table"
 
     // select
@@ -69,7 +68,6 @@ class LineItemSuite extends BaseTiSparkTest {
   }
 
   test("ti batch write: isPkHandle: lineitem") {
-
     val tableToWrite = s"${batchWriteTablePrefix}_${isPkHandlePrefix}_$table"
     tidbStmt.execute(s"drop table if exists `$tableToWrite`")
     val createTableSQL =
@@ -131,7 +129,6 @@ class LineItemSuite extends BaseTiSparkTest {
   }
 
   test("ti batch write: replace + isPkHandle: lineitem") {
-
     val tableToWrite = s"${batchWriteTablePrefix}_${replacePKHandlePrefix}_$table"
     tidbStmt.execute(s"drop table if exists `$tableToWrite`")
     val createTableSQL =
@@ -206,7 +203,6 @@ class LineItemSuite extends BaseTiSparkTest {
   }
 
   test("ti batch write: replace + uniqueKey: lineitem") {
-
     val tableToWrite = s"${batchWriteTablePrefix}_${replaceUniquePrefix}_$table"
     tidbStmt.execute(s"drop table if exists `$tableToWrite`")
     val createTableSQL =

--- a/core/src/test/scala/com/pingcap/tispark/index/LineItemSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/index/LineItemSuite.scala
@@ -39,9 +39,6 @@ class LineItemSuite extends BaseTiSparkTest {
   }
 
   test("ti batch write: lineitem") {
-    if (!supportBatchWrite) {
-      cancel
-    }
 
     val tableToWrite = s"${batchWriteTablePrefix}_$table"
 
@@ -72,9 +69,6 @@ class LineItemSuite extends BaseTiSparkTest {
   }
 
   test("ti batch write: isPkHandle: lineitem") {
-    if (!supportBatchWrite) {
-      cancel
-    }
 
     val tableToWrite = s"${batchWriteTablePrefix}_${isPkHandlePrefix}_$table"
     tidbStmt.execute(s"drop table if exists `$tableToWrite`")
@@ -137,9 +131,6 @@ class LineItemSuite extends BaseTiSparkTest {
   }
 
   test("ti batch write: replace + isPkHandle: lineitem") {
-    if (!supportBatchWrite) {
-      cancel
-    }
 
     val tableToWrite = s"${batchWriteTablePrefix}_${replacePKHandlePrefix}_$table"
     tidbStmt.execute(s"drop table if exists `$tableToWrite`")
@@ -215,9 +206,6 @@ class LineItemSuite extends BaseTiSparkTest {
   }
 
   test("ti batch write: replace + uniqueKey: lineitem") {
-    if (!supportBatchWrite) {
-      cancel
-    }
 
     val tableToWrite = s"${batchWriteTablePrefix}_${replaceUniquePrefix}_$table"
     tidbStmt.execute(s"drop table if exists `$tableToWrite`")

--- a/core/src/test/scala/com/pingcap/tispark/multitable/MultiTableWriteSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/multitable/MultiTableWriteSuite.scala
@@ -39,9 +39,6 @@ class MultiTableWriteSuite extends BaseTiSparkTest {
   }
 
   test("multi table batch write") {
-    if (!supportBatchWrite) {
-      cancel
-    }
 
     val data = tables.map { table =>
       val tableToWrite = s"${batchWriteTablePrefix}_$table"

--- a/core/src/test/scala/com/pingcap/tispark/multitable/MultiTableWriteSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/multitable/MultiTableWriteSuite.scala
@@ -18,7 +18,7 @@ package com.pingcap.tispark.multitable
 import com.pingcap.tispark.write.{DBTable, TiBatchWrite}
 import org.apache.spark.sql._
 
-class MultiTableWriteSuite extends BaseTiSparkTest {
+class MultiTableWriteSuite extends BaseTiSparkEnableBatchWriteTest {
 
   private val tables =
     "CUSTOMER" ::
@@ -39,7 +39,6 @@ class MultiTableWriteSuite extends BaseTiSparkTest {
   }
 
   test("multi table batch write") {
-
     val data = tables.map { table =>
       val tableToWrite = s"${batchWriteTablePrefix}_$table"
       val dbTable = DBTable(database, tableToWrite)

--- a/core/src/test/scala/com/pingcap/tispark/overflow/BitOverflowSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/overflow/BitOverflowSuite.scala
@@ -15,7 +15,7 @@
 
 package com.pingcap.tispark.overflow
 
-import com.pingcap.tispark.datasource.BaseDataSourceTest
+import com.pingcap.tispark.datasource.BaseBatchWriteTest
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types._
 
@@ -23,45 +23,24 @@ import org.apache.spark.sql.types._
  * BIT type include:
  * 1. BIT
  */
-class BitOverflowSuite extends BaseDataSourceTest("test_data_type_bit_overflow") {
+class BitOverflowSuite extends BaseBatchWriteTest("test_data_type_bit_overflow") {
 
   test("Test BIT(1) Upper bound Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testBit1UpperBound(false)
   }
   test("Test BIT(1) as key Upper bound Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testBit1UpperBound(true)
   }
 
-  override def afterAll(): Unit =
-    try {
-      dropTable()
-    } finally {
-      super.afterAll()
-    }
-
   test("Test BIT(1) Lower bound Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testBit1LowerBound(false)
   }
 
   test("Test BIT(1) as key Lower bound Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testBit1LowerBound(true)
   }
 
   private def testBit1UpperBound(testKey: Boolean): Unit = {
-
-    dropTable()
     if (testKey) {
       jdbcUpdate(s"create table $dbtable(c1 BIT(1) primary key)")
     } else {
@@ -84,22 +63,14 @@ class BitOverflowSuite extends BaseDataSourceTest("test_data_type_bit_overflow")
   }
 
   test("Test BIT(4) Upper bound Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testBit4UpperBound(false)
   }
 
   test("Test BIT(4) as key Upper bound Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testBit4UpperBound(true)
   }
 
   private def testBit1LowerBound(testKey: Boolean): Unit = {
-
-    dropTable()
     if (testKey) {
       jdbcUpdate(s"create table $dbtable(c1 BIT(1) primary key)")
     } else {
@@ -122,21 +93,14 @@ class BitOverflowSuite extends BaseDataSourceTest("test_data_type_bit_overflow")
   }
 
   test("Test BIT(4) Lower bound Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testBit4LowerBound(false)
   }
 
   test("Test BIT(4) as key Lower bound Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testBit4LowerBound(true)
   }
 
   private def testBit4UpperBound(testKey: Boolean): Unit = {
-    dropTable()
     if (testKey) {
       jdbcUpdate(s"create table $dbtable(c1 BIT(4) primary key)")
     } else {
@@ -159,21 +123,14 @@ class BitOverflowSuite extends BaseDataSourceTest("test_data_type_bit_overflow")
   }
 
   test("Test BIT(8) Upper bound Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testBit8UpperBound(false)
   }
 
   test("Test BIT(8) as key Upper bound Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testBit8UpperBound(true)
   }
 
   private def testBit4LowerBound(testKey: Boolean): Unit = {
-    dropTable()
     if (testKey) {
       jdbcUpdate(s"create table $dbtable(c1 BIT(4) primary key)")
     } else {
@@ -196,22 +153,14 @@ class BitOverflowSuite extends BaseDataSourceTest("test_data_type_bit_overflow")
   }
 
   test("Test BIT(8) Lower bound Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testBit8LowerBound(false)
   }
 
   test("Test BIT(8) as key Lower bound Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testBit8LowerBound(true)
   }
 
   private def testBit8UpperBound(testKey: Boolean): Unit = {
-
-    dropTable()
     if (testKey) {
       jdbcUpdate(s"create table $dbtable(c1 BIT(8) primary key)")
     } else {
@@ -234,7 +183,6 @@ class BitOverflowSuite extends BaseDataSourceTest("test_data_type_bit_overflow")
   }
 
   private def testBit8LowerBound(testKey: Boolean): Unit = {
-    dropTable()
     if (testKey) {
       jdbcUpdate(s"create table $dbtable(c1 BIT(8) primary key)")
     } else {

--- a/core/src/test/scala/com/pingcap/tispark/overflow/BytesOverflowSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/overflow/BytesOverflowSuite.scala
@@ -15,7 +15,7 @@
 
 package com.pingcap.tispark.overflow
 
-import com.pingcap.tispark.datasource.BaseDataSourceTest
+import com.pingcap.tispark.datasource.BaseBatchWriteTest
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types._
 
@@ -28,45 +28,25 @@ import org.apache.spark.sql.types._
  * 5. MEDIUMBLOB
  * 6. LONGBLOB
  */
-class BytesOverflowSuite extends BaseDataSourceTest("test_data_type_bytes_overflow") {
+class BytesOverflowSuite extends BaseBatchWriteTest("test_data_type_bytes_overflow") {
 
   test("Test BINARY Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testBinaryOverflow(false)
   }
 
   test("Test BINARY as key Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testBinaryOverflow(true)
   }
 
-  override def afterAll(): Unit =
-    try {
-      dropTable()
-    } finally {
-      super.afterAll()
-    }
-
   test("Test VARBINARY Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testVarbinaryOverflow(false)
   }
 
   test("Test VARBINARY as key Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testVarbinaryOverflow(true)
   }
 
   private def testBinaryOverflow(testKey: Boolean): Unit = {
-    dropTable()
     if (testKey) {
       jdbcUpdate(s"create table $dbtable(c1 BINARY(8), primary key (c1(4)))")
     } else {
@@ -88,21 +68,14 @@ class BytesOverflowSuite extends BaseDataSourceTest("test_data_type_bytes_overfl
   }
 
   test("Test TINYBLOB Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testTinyBlobOverflow(false)
   }
 
   test("Test TINYBLOB as key Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testTinyBlobOverflow(true)
   }
 
   private def testVarbinaryOverflow(testKey: Boolean): Unit = {
-    dropTable()
     if (testKey) {
       jdbcUpdate(s"create table $dbtable(c1 VARBINARY(8), primary key (c1(4)))")
     } else {
@@ -124,7 +97,6 @@ class BytesOverflowSuite extends BaseDataSourceTest("test_data_type_bytes_overfl
   }
 
   private def testTinyBlobOverflow(testKey: Boolean): Unit = {
-    dropTable()
     if (testKey) {
       jdbcUpdate(s"create table $dbtable(c1 TINYBLOB, primary key (c1(4)))")
     } else {

--- a/core/src/test/scala/com/pingcap/tispark/overflow/DateOverflowSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/overflow/DateOverflowSuite.scala
@@ -16,7 +16,7 @@
 package com.pingcap.tispark.overflow
 
 import com.pingcap.tikv.exception.TiDBConvertException
-import com.pingcap.tispark.datasource.BaseDataSourceTest
+import com.pingcap.tispark.datasource.BaseBatchWriteTest
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types._
 
@@ -24,45 +24,25 @@ import org.apache.spark.sql.types._
  * DATE type include:
  * 1. DATE
  */
-class DateOverflowSuite extends BaseDataSourceTest("test_data_type_date_overflow") {
+class DateOverflowSuite extends BaseBatchWriteTest("test_data_type_date_overflow") {
 
   test("Test DATE YEAR Upper bound Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testYearOverflow(false)
   }
 
   test("Test DATE as key YEAR Upper bound Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testYearOverflow(true)
   }
 
-  override def afterAll(): Unit =
-    try {
-      dropTable()
-    } finally {
-      super.afterAll()
-    }
-
   test("Test DATE Month Upper bound Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testMonthOverflow(false)
   }
 
   test("Test DATE as key Month Upper bound Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testMonthOverflow(true)
   }
 
   private def testYearOverflow(testKey: Boolean): Unit = {
-    dropTable()
     if (testKey) {
       jdbcUpdate(s"create table $dbtable(c1 DATE primary key)")
     } else {
@@ -84,7 +64,6 @@ class DateOverflowSuite extends BaseDataSourceTest("test_data_type_date_overflow
   }
 
   private def testMonthOverflow(testKey: Boolean): Unit = {
-    dropTable()
     if (testKey) {
       jdbcUpdate(s"create table $dbtable(c1 DATE primary key)")
     } else {

--- a/core/src/test/scala/com/pingcap/tispark/overflow/DateTimeOverflowSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/overflow/DateTimeOverflowSuite.scala
@@ -16,7 +16,7 @@
 package com.pingcap.tispark.overflow
 
 import com.pingcap.tikv.exception.TiDBConvertException
-import com.pingcap.tispark.datasource.BaseDataSourceTest
+import com.pingcap.tispark.datasource.BaseBatchWriteTest
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types._
 
@@ -24,32 +24,17 @@ import org.apache.spark.sql.types._
  * DATETIME type include:
  * 1. DATETIME
  */
-class DateTimeOverflowSuite extends BaseDataSourceTest("test_data_type_datetime_overflow") {
+class DateTimeOverflowSuite extends BaseBatchWriteTest("test_data_type_datetime_overflow") {
 
   test("Test DATETIME YEAR Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testDateTimeOverflow(false)
   }
 
   test("Test DATETIME as key YEAR Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testDateTimeOverflow(true)
   }
 
-  override def afterAll(): Unit =
-    try {
-      dropTable()
-    } finally {
-      super.afterAll()
-    }
-
   private def testDateTimeOverflow(testKey: Boolean): Unit = {
-
-    dropTable()
     if (testKey) {
       jdbcUpdate(s"create table $dbtable(c1 DATETIME(6) primary key)")
     } else {

--- a/core/src/test/scala/com/pingcap/tispark/overflow/DecimalOverflowSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/overflow/DecimalOverflowSuite.scala
@@ -15,7 +15,7 @@
 
 package com.pingcap.tispark.overflow
 
-import com.pingcap.tispark.datasource.BaseDataSourceTest
+import com.pingcap.tispark.datasource.BaseBatchWriteTest
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types.{StructField, _}
 
@@ -23,20 +23,9 @@ import org.apache.spark.sql.types.{StructField, _}
  * DECIMAL type include:
  * 1. DECIMAL
  */
-class DecimalOverflowSuite extends BaseDataSourceTest("test_data_type_decimal_overflow") {
-
-  override def afterAll(): Unit =
-    try {
-      dropTable()
-    } finally {
-      super.afterAll()
-    }
+class DecimalOverflowSuite extends BaseBatchWriteTest("test_data_type_decimal_overflow") {
 
   test("Test DECIMAL Not Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     val testDataList =
       TestData(38, 0, 1.5d, 2L) ::
         TestData(38, 0, 1.4d, 1L) ::
@@ -85,10 +74,6 @@ class DecimalOverflowSuite extends BaseDataSourceTest("test_data_type_decimal_ov
   case class TestData(length: Int, precision: Int, writeData: Double, readData: Long) {}
 
   test("Test DECIMAL Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     val testDataList =
       OverflowTestData(10, 4, 1000000d) ::
         OverflowTestData(2, 0, 100d) ::

--- a/core/src/test/scala/com/pingcap/tispark/overflow/EnumOverflowSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/overflow/EnumOverflowSuite.scala
@@ -15,7 +15,7 @@
 
 package com.pingcap.tispark.overflow
 
-import com.pingcap.tispark.datasource.BaseDataSourceTest
+import com.pingcap.tispark.datasource.BaseBatchWriteTest
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types._
 
@@ -23,46 +23,25 @@ import org.apache.spark.sql.types._
  * ENUM type include:
  * 1. ENUM
  */
-class EnumOverflowSuite extends BaseDataSourceTest("test_data_type_enum_overflow") {
+class EnumOverflowSuite extends BaseBatchWriteTest("test_data_type_enum_overflow") {
 
   test("Test ENUM Value Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testEnumValueOverflow(false)
   }
 
   test("Test ENUM as key Value Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testEnumValueOverflow(true)
   }
 
-  override def afterAll(): Unit =
-    try {
-      dropTable()
-    } finally {
-      super.afterAll()
-    }
-
   test("Test ENUM Number Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testEnumNumberOverflow(false)
   }
 
   test("Test ENUM as key Number Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testEnumNumberOverflow(true)
   }
 
   private def testEnumValueOverflow(testKey: Boolean): Unit = {
-
-    dropTable()
     if (testKey) {
       jdbcUpdate(
         s"create table $dbtable(c1 ENUM('male', 'female', 'both', 'unknown') primary key)")
@@ -85,8 +64,6 @@ class EnumOverflowSuite extends BaseDataSourceTest("test_data_type_enum_overflow
   }
 
   private def testEnumNumberOverflow(testKey: Boolean): Unit = {
-
-    dropTable()
     if (testKey) {
       jdbcUpdate(
         s"create table $dbtable(c1 ENUM('male', 'female', 'both', 'unknown') primary key)")

--- a/core/src/test/scala/com/pingcap/tispark/overflow/SignedOverflowSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/overflow/SignedOverflowSuite.scala
@@ -16,7 +16,7 @@
 package com.pingcap.tispark.overflow
 
 import com.pingcap.tikv.exception.TiDBConvertException
-import com.pingcap.tispark.datasource.BaseDataSourceTest
+import com.pingcap.tispark.datasource.BaseBatchWriteTest
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types._
 
@@ -29,45 +29,25 @@ import org.apache.spark.sql.types._
  * 5. BIGINT SINGED
  * 6. BOOLEAN
  */
-class SignedOverflowSuite extends BaseDataSourceTest("test_data_type_signed_overflow") {
+class SignedOverflowSuite extends BaseBatchWriteTest("test_data_type_signed_overflow") {
 
   test("Test TINYINT Upper bound Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testTinyIntUpperBound(false)
   }
 
   test("Test TINYINT as key Upper bound Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testTinyIntUpperBound(true)
   }
 
-  override def afterAll(): Unit =
-    try {
-      dropTable()
-    } finally {
-      super.afterAll()
-    }
-
   test("Test TINYINT Lower bound Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testTinyIntLowerBound(false)
   }
 
   test("Test TINYINT as key Lower bound Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testTinyIntLowerBound(true)
   }
 
   private def testTinyIntUpperBound(testKey: Boolean): Unit = {
-    dropTable()
     if (testKey) {
       jdbcUpdate(s"create table $dbtable(c1 TINYINT primary key)")
     } else {
@@ -89,21 +69,14 @@ class SignedOverflowSuite extends BaseDataSourceTest("test_data_type_signed_over
   }
 
   test("Test SMALLINT Upper bound Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testSmallIntUpperBound(false)
   }
 
   test("Test SMALLINT as key Upper bound Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testSmallIntUpperBound(true)
   }
 
   private def testTinyIntLowerBound(testKey: Boolean): Unit = {
-    dropTable()
     if (testKey) {
       jdbcUpdate(s"create table $dbtable(c1 TINYINT primary key)")
     } else {
@@ -125,21 +98,14 @@ class SignedOverflowSuite extends BaseDataSourceTest("test_data_type_signed_over
   }
 
   test("Test SMALLINT Lower bound Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testSmallIntLowerBound(false)
   }
 
   test("Test SMALLINT as key Lower bound Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testSmallIntLowerBound(true)
   }
 
   private def testSmallIntUpperBound(testKey: Boolean): Unit = {
-    dropTable()
     if (testKey) {
       jdbcUpdate(s"create table $dbtable(c1 SMALLINT primary key)")
     } else {
@@ -161,21 +127,14 @@ class SignedOverflowSuite extends BaseDataSourceTest("test_data_type_signed_over
   }
 
   test("Test MEDIUMINT Upper bound Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testMediumIntUpperBound(false)
   }
 
   test("Test MEDIUMINT as key Upper bound Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testMediumIntUpperBound(true)
   }
 
   private def testSmallIntLowerBound(testKey: Boolean): Unit = {
-    dropTable()
     if (testKey) {
       jdbcUpdate(s"create table $dbtable(c1 SMALLINT primary key)")
     } else {
@@ -197,21 +156,14 @@ class SignedOverflowSuite extends BaseDataSourceTest("test_data_type_signed_over
   }
 
   test("Test MEDIUMINT Lower bound Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testMediumIntLowerBound(false)
   }
 
   test("Test MEDIUMINT as key Lower bound Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testMediumIntLowerBound(true)
   }
 
   private def testMediumIntUpperBound(testKey: Boolean): Unit = {
-    dropTable()
     if (testKey) {
       jdbcUpdate(s"create table $dbtable(c1 MEDIUMINT primary key)")
     } else {
@@ -233,21 +185,14 @@ class SignedOverflowSuite extends BaseDataSourceTest("test_data_type_signed_over
   }
 
   test("Test INT Upper bound Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testIntUpperBound(false)
   }
 
   test("Test INT as key Upper bound Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testIntUpperBound(true)
   }
 
   private def testMediumIntLowerBound(testKey: Boolean): Unit = {
-    dropTable()
     if (testKey) {
       jdbcUpdate(s"create table $dbtable(c1 MEDIUMINT primary key)")
     } else {
@@ -269,21 +214,14 @@ class SignedOverflowSuite extends BaseDataSourceTest("test_data_type_signed_over
   }
 
   test("Test INT Lower bound Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testIntLowerBound(false)
   }
 
   test("Test INT as key Lower bound Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testIntLowerBound(true)
   }
 
   private def testIntUpperBound(testKey: Boolean): Unit = {
-    dropTable()
     if (testKey) {
       jdbcUpdate(s"create table $dbtable(c1 INT primary key)")
     } else {
@@ -305,21 +243,14 @@ class SignedOverflowSuite extends BaseDataSourceTest("test_data_type_signed_over
   }
 
   test("Test BIGINT Upper bound Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testBigIntUpperBound(false)
   }
 
   test("Test BIGINT as key Upper bound Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testBigIntUpperBound(true)
   }
 
   private def testIntLowerBound(testKey: Boolean): Unit = {
-    dropTable()
     if (testKey) {
       jdbcUpdate(s"create table $dbtable(c1 INT primary key)")
     } else {
@@ -341,21 +272,14 @@ class SignedOverflowSuite extends BaseDataSourceTest("test_data_type_signed_over
   }
 
   test("Test BIGINT Lower bound Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testBigIntLowerBound(false)
   }
 
   test("Test BIGINT as key Lower bound Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testBigIntLowerBound(true)
   }
 
   private def testBigIntUpperBound(testKey: Boolean): Unit = {
-    dropTable()
     if (testKey) {
       jdbcUpdate(s"create table $dbtable(c1 BIGINT primary key)")
     } else {
@@ -377,21 +301,14 @@ class SignedOverflowSuite extends BaseDataSourceTest("test_data_type_signed_over
   }
 
   test("Test BOOLEAN Upper bound Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testBooleanUpperBound(false)
   }
 
   test("Test BOOLEAN as key Upper bound Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testBooleanUpperBound(true)
   }
 
   private def testBigIntLowerBound(testKey: Boolean): Unit = {
-    dropTable()
     if (testKey) {
       jdbcUpdate(s"create table $dbtable(c1 BIGINT primary key)")
     } else {
@@ -413,21 +330,14 @@ class SignedOverflowSuite extends BaseDataSourceTest("test_data_type_signed_over
   }
 
   test("Test BOOLEAN Lower bound Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testBooleanLowerBound(false)
   }
 
   test("Test BOOLEAN as key Lower bound Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testBooleanLowerBound(true)
   }
 
   private def testBooleanUpperBound(testKey: Boolean): Unit = {
-    dropTable()
     if (testKey) {
       jdbcUpdate(s"create table $dbtable(c1 BOOLEAN primary key)")
     } else {
@@ -449,7 +359,6 @@ class SignedOverflowSuite extends BaseDataSourceTest("test_data_type_signed_over
   }
 
   private def testBooleanLowerBound(testKey: Boolean): Unit = {
-    dropTable()
     if (testKey) {
       jdbcUpdate(s"create table $dbtable(c1 BOOLEAN primary key)")
     } else {

--- a/core/src/test/scala/com/pingcap/tispark/overflow/StringOverflowSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/overflow/StringOverflowSuite.scala
@@ -15,7 +15,7 @@
 
 package com.pingcap.tispark.overflow
 
-import com.pingcap.tispark.datasource.BaseDataSourceTest
+import com.pingcap.tispark.datasource.BaseBatchWriteTest
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types.{StructField, _}
 
@@ -28,45 +28,25 @@ import org.apache.spark.sql.types.{StructField, _}
  * 5. MEDIUMTEXT
  * 6. LONGTEXT
  */
-class StringOverflowSuite extends BaseDataSourceTest("test_data_type_string_overflow") {
+class StringOverflowSuite extends BaseBatchWriteTest("test_data_type_string_overflow") {
 
   test("Test CHAR Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testCharOverflow(false)
   }
 
   test("Test CHAR as key Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testCharOverflow(true)
   }
 
-  override def afterAll(): Unit =
-    try {
-      dropTable()
-    } finally {
-      super.afterAll()
-    }
-
   test("Test VARCHAR Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testVarcharOverflow(false)
   }
 
   test("Test VARCHAR as key Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testVarcharOverflow(true)
   }
 
   private def testCharOverflow(testKey: Boolean): Unit = {
-    dropTable()
     if (testKey) {
       jdbcUpdate(s"create table $dbtable(c1 CHAR(8) primary key)")
     } else {
@@ -88,21 +68,14 @@ class StringOverflowSuite extends BaseDataSourceTest("test_data_type_string_over
   }
 
   test("Test TINYTEXT Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testTinyTextOverflow(false)
   }
 
   test("Test TINYTEXT as key Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testTinyTextOverflow(true)
   }
 
   private def testVarcharOverflow(testKey: Boolean): Unit = {
-    dropTable()
     if (testKey) {
       jdbcUpdate(s"create table $dbtable(c1 VARCHAR(8) primary key)")
     } else {
@@ -124,21 +97,14 @@ class StringOverflowSuite extends BaseDataSourceTest("test_data_type_string_over
   }
 
   test("Test TEXT Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testTextOverflow(false)
   }
 
   test("Test TEXT as key Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testTextOverflow(true)
   }
 
   private def testTinyTextOverflow(testKey: Boolean): Unit = {
-    dropTable()
     if (testKey) {
       jdbcUpdate(s"create table $dbtable(c1 TINYTEXT, primary key (c1(4)))")
     } else {
@@ -165,7 +131,6 @@ class StringOverflowSuite extends BaseDataSourceTest("test_data_type_string_over
   }
 
   private def testTextOverflow(testKey: Boolean): Unit = {
-    dropTable()
     if (testKey) {
       jdbcUpdate(s"create table $dbtable(c1 TEXT(8), primary key (c1(4)))")
     } else {

--- a/core/src/test/scala/com/pingcap/tispark/overflow/UnsignedOverflowSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/overflow/UnsignedOverflowSuite.scala
@@ -16,7 +16,7 @@
 package com.pingcap.tispark.overflow
 
 import com.pingcap.tikv.exception.TiDBConvertException
-import com.pingcap.tispark.datasource.BaseDataSourceTest
+import com.pingcap.tispark.datasource.BaseBatchWriteTest
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types._
 
@@ -28,45 +28,25 @@ import org.apache.spark.sql.types._
  * 4. INT UNSIGNED
  * 5. BIGINT UNSIGNED
  */
-class UnsignedOverflowSuite extends BaseDataSourceTest("test_data_type_unsigned_overflow") {
+class UnsignedOverflowSuite extends BaseBatchWriteTest("test_data_type_unsigned_overflow") {
 
   test("Test TINYINT UNSIGNED Upper bound Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testTinyIntUnsignedUpperBound(false)
   }
 
   test("Test TINYINT UNSIGNED as key Upper bound Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testTinyIntUnsignedUpperBound(true)
   }
 
-  override def afterAll(): Unit =
-    try {
-      dropTable()
-    } finally {
-      super.afterAll()
-    }
-
   test("Test TINYINT UNSIGNED Lower bound Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testTinyIntUnsignedLowerBound(false)
   }
 
   test("Test TINYINT UNSIGNED as key Lower bound Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testTinyIntUnsignedLowerBound(false)
   }
 
   private def testTinyIntUnsignedUpperBound(testKey: Boolean): Unit = {
-    dropTable()
     if (testKey) {
       jdbcUpdate(s"create table $dbtable(c1 TINYINT UNSIGNED primary key)")
     } else {
@@ -88,21 +68,14 @@ class UnsignedOverflowSuite extends BaseDataSourceTest("test_data_type_unsigned_
   }
 
   test("Test SMALLINT UNSIGNED Upper bound Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testSmallIntUnsignedUpperBound(false)
   }
 
   test("Test SMALLINT UNSIGNED as key Upper bound Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testSmallIntUnsignedUpperBound(true)
   }
 
   private def testTinyIntUnsignedLowerBound(testKey: Boolean): Unit = {
-    dropTable()
     if (testKey) {
       jdbcUpdate(s"create table $dbtable(c1 TINYINT UNSIGNED primary key)")
     } else {
@@ -124,21 +97,14 @@ class UnsignedOverflowSuite extends BaseDataSourceTest("test_data_type_unsigned_
   }
 
   test("Test SMALLINT UNSIGNED Lower bound Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testSmallIntUnsignedLowerBound(false)
   }
 
   test("Test SMALLINT UNSIGNED as key Lower bound Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testSmallIntUnsignedLowerBound(true)
   }
 
   private def testSmallIntUnsignedUpperBound(testKey: Boolean): Unit = {
-    dropTable()
     if (testKey) {
       jdbcUpdate(s"create table $dbtable(c1 SMALLINT UNSIGNED primary key)")
     } else {
@@ -160,21 +126,14 @@ class UnsignedOverflowSuite extends BaseDataSourceTest("test_data_type_unsigned_
   }
 
   test("Test MEDIUMINT UNSIGNED Upper bound Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testMediumIntUnsignedUpperBound(false)
   }
 
   test("Test MEDIUMINT UNSIGNED as key Upper bound Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testMediumIntUnsignedUpperBound(true)
   }
 
   private def testSmallIntUnsignedLowerBound(testKey: Boolean): Unit = {
-    dropTable()
     if (testKey) {
       jdbcUpdate(s"create table $dbtable(c1 SMALLINT UNSIGNED primary key)")
     } else {
@@ -196,21 +155,14 @@ class UnsignedOverflowSuite extends BaseDataSourceTest("test_data_type_unsigned_
   }
 
   test("Test MEDIUMINT UNSIGNED Lower bound Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testMediumIntUnsignedLowerBound(false)
   }
 
   test("Test MEDIUMINT UNSIGNED as key Lower bound Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testMediumIntUnsignedLowerBound(true)
   }
 
   private def testMediumIntUnsignedUpperBound(testKey: Boolean): Unit = {
-    dropTable()
     if (testKey) {
       jdbcUpdate(s"create table $dbtable(c1 MEDIUMINT UNSIGNED primary key)")
     } else {
@@ -232,21 +184,14 @@ class UnsignedOverflowSuite extends BaseDataSourceTest("test_data_type_unsigned_
   }
 
   test("Test INT UNSIGNED Upper bound Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testIntUnsignedUpperBound(false)
   }
 
   test("Test INT UNSIGNED as key Upper bound Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testIntUnsignedUpperBound(true)
   }
 
   private def testMediumIntUnsignedLowerBound(testKey: Boolean): Unit = {
-    dropTable()
     if (testKey) {
       jdbcUpdate(s"create table $dbtable(c1 MEDIUMINT UNSIGNED primary key)")
     } else {
@@ -268,21 +213,14 @@ class UnsignedOverflowSuite extends BaseDataSourceTest("test_data_type_unsigned_
   }
 
   test("Test INT UNSIGNED Lower bound Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testIntUnsignedLowerBound(false)
   }
 
   test("Test INT UNSIGNED as key Lower bound Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testIntUnsignedLowerBound(true)
   }
 
   private def testIntUnsignedUpperBound(testKey: Boolean): Unit = {
-    dropTable()
     if (testKey) {
       jdbcUpdate(s"create table $dbtable(c1 INT UNSIGNED primary key)")
     } else {
@@ -304,21 +242,14 @@ class UnsignedOverflowSuite extends BaseDataSourceTest("test_data_type_unsigned_
   }
 
   test("Test BIGINT UNSIGNED Upper bound Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testBigIntUnsignedUpperBound(false)
   }
 
   test("Test BIGINT UNSIGNED as key Upper bound Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testBigIntUnsignedUpperBound(true)
   }
 
   private def testIntUnsignedLowerBound(testKey: Boolean): Unit = {
-    dropTable()
     if (testKey) {
       jdbcUpdate(s"create table $dbtable(c1 INT UNSIGNED primary key)")
     } else {
@@ -342,21 +273,14 @@ class UnsignedOverflowSuite extends BaseDataSourceTest("test_data_type_unsigned_
   }
 
   test("Test BIGINT UNSIGNED Lower bound Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testBigIntUnsignedLowerBound(false)
   }
 
   test("Test BIGINT UNSIGNED as key Lower bound Overflow") {
-    if (!supportBatchWrite) {
-      cancel
-    }
     testBigIntUnsignedLowerBound(true)
   }
 
   private def testBigIntUnsignedUpperBound(testKey: Boolean): Unit = {
-    dropTable()
     if (testKey) {
       jdbcUpdate(s"create table $dbtable(c1 BIGINT UNSIGNED primary key)")
     } else {
@@ -378,7 +302,6 @@ class UnsignedOverflowSuite extends BaseDataSourceTest("test_data_type_unsigned_
   }
 
   private def testBigIntUnsignedLowerBound(testKey: Boolean): Unit = {
-    dropTable()
     if (testKey) {
       jdbcUpdate(s"create table $dbtable(c1 BIGINT UNSIGNED primary key)")
     } else {

--- a/core/src/test/scala/com/pingcap/tispark/tablelock/TableLockSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/tablelock/TableLockSuite.scala
@@ -17,11 +17,18 @@ package com.pingcap.tispark.tablelock
 
 import com.pingcap.tikv.TiDBJDBCClient
 import com.pingcap.tispark.TiDBUtils
-import com.pingcap.tispark.datasource.BaseBatchWriteWithoutDropTableTest
+import com.pingcap.tispark.datasource.BaseDataSourceTest
 
-class TableLockSuite extends BaseBatchWriteWithoutDropTableTest("test_table_lock") {
+class TableLockSuite extends BaseDataSourceTest("test_table_lock") {
 
   private var tiDBJDBCClient: TiDBJDBCClient = _
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    if (!supportBatchWrite) {
+      cancel
+    }
+  }
 
   override def afterAll(): Unit = {
     try {

--- a/core/src/test/scala/com/pingcap/tispark/tablelock/TableLockSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/tablelock/TableLockSuite.scala
@@ -66,7 +66,6 @@ class TableLockSuite extends BaseBatchWriteTest("test_table_lock") {
     // init
     val conn = TiDBUtils.createConnectionFactory(jdbcUrl)()
     tiDBJDBCClient = new TiDBJDBCClient(conn)
-    dropTable()
     createTable()
 
     // lock table
@@ -91,7 +90,6 @@ class TableLockSuite extends BaseBatchWriteTest("test_table_lock") {
     // init
     val conn = TiDBUtils.createConnectionFactory(jdbcUrl)()
     tiDBJDBCClient = new TiDBJDBCClient(conn)
-    dropTable()
     createTable()
 
     // lock table
@@ -125,7 +123,6 @@ class TableLockSuite extends BaseBatchWriteTest("test_table_lock") {
     // init
     val conn = TiDBUtils.createConnectionFactory(jdbcUrl)()
     tiDBJDBCClient = new TiDBJDBCClient(conn)
-    dropTable()
     createTable()
 
     // lock table

--- a/core/src/test/scala/com/pingcap/tispark/tablelock/TableLockSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/tablelock/TableLockSuite.scala
@@ -17,9 +17,9 @@ package com.pingcap.tispark.tablelock
 
 import com.pingcap.tikv.TiDBJDBCClient
 import com.pingcap.tispark.TiDBUtils
-import com.pingcap.tispark.datasource.BaseBatchWriteTest
+import com.pingcap.tispark.datasource.BaseBatchWriteWithoutDropTableTest
 
-class TableLockSuite extends BaseBatchWriteTest("test_table_lock") {
+class TableLockSuite extends BaseBatchWriteWithoutDropTableTest("test_table_lock") {
 
   private var tiDBJDBCClient: TiDBJDBCClient = _
 

--- a/core/src/test/scala/com/pingcap/tispark/tablelock/TableLockSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/tablelock/TableLockSuite.scala
@@ -17,9 +17,9 @@ package com.pingcap.tispark.tablelock
 
 import com.pingcap.tikv.TiDBJDBCClient
 import com.pingcap.tispark.TiDBUtils
-import com.pingcap.tispark.datasource.BaseDataSourceTest
+import com.pingcap.tispark.datasource.BaseBatchWriteTest
 
-class TableLockSuite extends BaseDataSourceTest("test_table_lock") {
+class TableLockSuite extends BaseBatchWriteTest("test_table_lock") {
 
   private var tiDBJDBCClient: TiDBJDBCClient = _
 

--- a/core/src/test/scala/com/pingcap/tispark/tiflash/TiFlashSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/tiflash/TiFlashSuite.scala
@@ -70,10 +70,6 @@ class TiFlashSuite extends BaseTiSparkTest {
   test("lock on tiflash: not expired") {
     cancelIfTiFlashDisabled()
 
-    if (!supportBatchWrite) {
-      cancel
-    }
-
     dropTable()
 
     tidbStmt.execute("create table t(i int, s varchar(128))")
@@ -98,10 +94,6 @@ class TiFlashSuite extends BaseTiSparkTest {
 
   test("lock on tiflash: expired") {
     cancelIfTiFlashDisabled()
-
-    if (!supportBatchWrite) {
-      cancel
-    }
 
     dropTable()
 

--- a/core/src/test/scala/com/pingcap/tispark/ttl/LockTimeoutSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/ttl/LockTimeoutSuite.scala
@@ -17,12 +17,12 @@ package com.pingcap.tispark.ttl
 
 import com.pingcap.tikv.TTLManager
 import com.pingcap.tikv.exception.GrpcException
-import com.pingcap.tispark.datasource.BaseDataSourceTest
+import com.pingcap.tispark.datasource.BaseBatchWriteTest
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
 
-class LockTimeoutSuite extends BaseDataSourceTest("test_lock_timeout") {
+class LockTimeoutSuite extends BaseBatchWriteTest("test_lock_timeout") {
   private val row1 = Row(1, "Hello")
 
   private val schema = StructType(
@@ -30,7 +30,6 @@ class LockTimeoutSuite extends BaseDataSourceTest("test_lock_timeout") {
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    dropTable()
     jdbcUpdate(s"create table $dbtable(i int, s varchar(128))")
   }
 
@@ -70,11 +69,4 @@ class LockTimeoutSuite extends BaseDataSourceTest("test_lock_timeout") {
       grpcException.getCause.getCause.getMessage.startsWith(
         "Key exception occurred and the reason is retryable: \"Txn(Mvcc(TxnLockNotFound"))
   }
-
-  override def afterAll(): Unit =
-    try {
-      dropTable()
-    } finally {
-      super.afterAll()
-    }
 }

--- a/core/src/test/scala/com/pingcap/tispark/ttl/LockTimeoutSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/ttl/LockTimeoutSuite.scala
@@ -17,12 +17,12 @@ package com.pingcap.tispark.ttl
 
 import com.pingcap.tikv.TTLManager
 import com.pingcap.tikv.exception.GrpcException
-import com.pingcap.tispark.datasource.BaseBatchWriteTest
+import com.pingcap.tispark.datasource.BaseBatchWriteWithoutDropTableTest
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
 
-class LockTimeoutSuite extends BaseBatchWriteTest("test_lock_timeout") {
+class LockTimeoutSuite extends BaseBatchWriteWithoutDropTableTest("test_lock_timeout") {
   private val row1 = Row(1, "Hello")
 
   private val schema = StructType(

--- a/core/src/test/scala/org/apache/spark/sql/BaseTiSparkEnableBatchWriteTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/BaseTiSparkEnableBatchWriteTest.scala
@@ -13,15 +13,13 @@
  * limitations under the License.
  */
 
-package com.pingcap.tispark.datasource
+package org.apache.spark.sql
 
-class BaseBatchWriteTest(
-    override val table: String,
-    override val database: String = "tispark_test")
-    extends BaseBatchWriteWithoutDropTableTest(table, database) {
-
+class BaseTiSparkEnableBatchWriteTest extends BaseTiSparkTest {
   override def beforeEach(): Unit = {
     super.beforeEach()
-    dropTable()
+    if (!supportBatchWrite) {
+      cancel
+    }
   }
 }

--- a/core/src/test/scala/org/apache/spark/sql/BaseTiSparkTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/BaseTiSparkTest.scala
@@ -125,14 +125,6 @@ class BaseTiSparkTest extends QueryTest with SharedSQLContext {
     StoreVersion.minTiKVVersion(Version.RESOLVE_LOCK_V3, this.ti.tiSession.getPDClient)
   }
 
-  protected def supportBatchWrite: Boolean = {
-    // currently only the following versions support BatchWrite
-    // 3.0.x (x >= 14)
-    // 3.1.x (x >= 0)
-    // >= 4.0.0
-    StoreVersion.minTiKVVersion(Version.BATCH_WRITE, this.ti.tiSession.getPDClient)
-  }
-
   protected def blockingRead: Boolean = {
     !nonBlockingRead
   }

--- a/core/src/test/scala/org/apache/spark/sql/insertion/BatchWritePKAndUniqueIndexSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/insertion/BatchWritePKAndUniqueIndexSuite.scala
@@ -15,14 +15,14 @@
 
 package org.apache.spark.sql.insertion
 
-import com.pingcap.tispark.datasource.BaseDataSourceTest
+import com.pingcap.tispark.datasource.BaseBatchWriteTest
 import com.pingcap.tispark.utils.TiUtil
 import org.apache.spark.sql.test.generator.DataType.ReflectedDataType
 import org.apache.spark.sql.test.generator.Schema
 import org.apache.spark.sql.test.generator.TestDataGenerator._
 
 class BatchWritePKAndUniqueIndexSuite
-    extends BaseDataSourceTest(
+    extends BaseBatchWriteTest(
       "batch_write_insertion_pk_and_one_unique_index",
       "batch_write_test_pk_and_index")
     with EnumerateUniqueIndexDataTypeTestAction {
@@ -41,13 +41,6 @@ class BatchWritePKAndUniqueIndexSuite
 
   // this is only for mute the warning
   override def test(): Unit = {}
-
-  override def afterAll(): Unit =
-    try {
-      dropTable()
-    } finally {
-      super.afterAll()
-    }
 
   test("test pk and unique indices cases") {
     val schemas = genSchema(dataTypes, table)

--- a/core/src/test/scala/org/apache/spark/sql/insertion/BatchWritePkSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/insertion/BatchWritePkSuite.scala
@@ -15,14 +15,14 @@
 
 package org.apache.spark.sql.insertion
 
-import com.pingcap.tispark.datasource.BaseDataSourceTest
+import com.pingcap.tispark.datasource.BaseBatchWriteTest
 import com.pingcap.tispark.utils.TiUtil
 import org.apache.spark.sql.test.generator.DataType._
 import org.apache.spark.sql.test.generator.Schema
 import org.apache.spark.sql.test.generator.TestDataGenerator._
 
 class BatchWritePkSuite
-    extends BaseDataSourceTest("batch_write_insertion_pk", "batch_write_test_pk")
+    extends BaseBatchWriteTest("batch_write_insertion_pk", "batch_write_test_pk")
     with EnumeratePKDataTypeTestAction {
   // TODO: support binary insertion.
   override def dataTypes: List[ReflectedDataType] =
@@ -39,13 +39,6 @@ class BatchWritePkSuite
 
   // this is only for mute the warning
   override def test(): Unit = {}
-
-  override def afterAll(): Unit =
-    try {
-      dropTable()
-    } finally {
-      super.afterAll()
-    }
 
   test("test pk cases") {
     for (pk <- dataTypes) {

--- a/core/src/test/scala/org/apache/spark/sql/insertion/BatchWriteUniqueIndexSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/insertion/BatchWriteUniqueIndexSuite.scala
@@ -15,14 +15,14 @@
 
 package org.apache.spark.sql.insertion
 
-import com.pingcap.tispark.datasource.BaseDataSourceTest
+import com.pingcap.tispark.datasource.BaseBatchWriteTest
 import com.pingcap.tispark.utils.TiUtil
 import org.apache.spark.sql.test.generator.DataType.ReflectedDataType
 import org.apache.spark.sql.test.generator.Schema
 import org.apache.spark.sql.test.generator.TestDataGenerator._
 
 class BatchWriteUniqueIndexSuite
-    extends BaseDataSourceTest("batch_write_insertion_one_unique_index", "batch_write_test_index")
+    extends BaseBatchWriteTest("batch_write_insertion_one_unique_index", "batch_write_test_index")
     with EnumerateUniqueIndexDataTypeTestAction {
   // TODO: support binary insertion.
   override def dataTypes: List[ReflectedDataType] =
@@ -40,13 +40,6 @@ class BatchWriteUniqueIndexSuite
 
   // this is only for mute the warning
   override def test(): Unit = {}
-
-  override def afterAll(): Unit =
-    try {
-      dropTable()
-    } finally {
-      super.afterAll()
-    }
 
   test("test unique indices cases") {
     val schemas = genSchema(dataTypes, table)

--- a/tikv-client/src/main/java/com/pingcap/tikv/Version.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/Version.java
@@ -25,4 +25,6 @@ public class Version {
   public static final String RESOLVE_LOCK_V4 = "4.0.0";
 
   public static final String BATCH_WRITE = "3.0.14";
+
+  public static final String NEW_ROW_FORMAT = "4.0.0";
 }

--- a/tikv-client/src/main/java/com/pingcap/tikv/catalog/Catalog.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/catalog/Catalog.java
@@ -69,7 +69,7 @@ public class Catalog implements AutoCloseable {
 
   public List<TiTableInfo> listTables(TiDBInfo database) {
     Objects.requireNonNull(database, "database is null");
-    reloadCache();
+    reloadCache(true);
     if (showRowId) {
       return metaCache
           .listTables(database)
@@ -98,7 +98,7 @@ public class Catalog implements AutoCloseable {
   public TiTableInfo getTable(TiDBInfo database, String tableName) {
     Objects.requireNonNull(database, "database is null");
     Objects.requireNonNull(tableName, "tableName is null");
-    reloadCache();
+    reloadCache(true);
     TiTableInfo table = metaCache.getTable(database, tableName);
     if (showRowId && table != null) {
       return table.copyTableWithRowId();

--- a/tikv-client/src/main/java/com/pingcap/tikv/codec/RowEncoderV2.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/codec/RowEncoderV2.java
@@ -316,12 +316,19 @@ public class RowEncoderV2 {
   }
 
   private void encodeDecimal(CodecDataOutput cdo, Object value) {
-    MyDecimal dec = new MyDecimal();
-    BigDecimal decimal = (BigDecimal) value;
-    int prec = decimal.precision();
-    int frac = decimal.scale();
-    dec.fromString(((BigDecimal) value).toPlainString());
-    DecimalCodec.writeDecimal(cdo, dec, prec, frac);
+    if (value instanceof MyDecimal) {
+      MyDecimal dec = (MyDecimal) value;
+      DecimalCodec.writeDecimal(cdo, dec, dec.precision(), dec.frac());
+    } else if (value instanceof BigDecimal) {
+      MyDecimal dec = new MyDecimal();
+      BigDecimal decimal = (BigDecimal) value;
+      int prec = decimal.precision();
+      int frac = decimal.scale();
+      dec.fromString(((BigDecimal) value).toPlainString());
+      DecimalCodec.writeDecimal(cdo, dec, prec, frac);
+    } else {
+      throw new CodecException("invalid decimal type " + value.getClass());
+    }
   }
 
   private void encodeEnum(CodecDataOutput cdo, Object value, List<String> elems) {

--- a/tikv-client/src/main/java/com/pingcap/tikv/codec/RowEncoderV2.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/codec/RowEncoderV2.java
@@ -209,13 +209,11 @@ public class RowEncoderV2 {
       case TypeString:
       case TypeVarString:
       case TypeVarchar:
-        cdo.write(((String) value).getBytes(StandardCharsets.UTF_8));
-        break;
       case TypeBlob:
       case TypeTinyBlob:
       case TypeMediumBlob:
       case TypeLongBlob:
-        cdo.write(((byte[]) value));
+        encodeString(cdo, value);
         break;
       case TypeNewDecimal:
         encodeDecimal(cdo, value);
@@ -290,9 +288,15 @@ public class RowEncoderV2 {
 
   private void encodeBit(CodecDataOutput cdo, Object value) {
     long s = 0;
-    for (byte b : (byte[]) value) {
-      s <<= 8;
-      s |= b;
+    if (value instanceof Long) {
+      s = (long) value;
+    } else if (value instanceof byte[]) {
+      for (byte b : (byte[]) value) {
+        s <<= 8;
+        s |= b;
+      }
+    } else {
+      throw new CodecException("invalid bytes type " + value.getClass());
     }
     encodeInt(cdo, s);
   }
@@ -315,6 +319,16 @@ public class RowEncoderV2 {
     }
   }
 
+  private void encodeString(CodecDataOutput cdo, Object value) {
+    if (value instanceof byte[]) {
+      cdo.write((byte[]) value);
+    } else if (value instanceof String) {
+      cdo.write(((String) value).getBytes(StandardCharsets.UTF_8));
+    } else {
+      throw new CodecException("invalid string type " + value.getClass());
+    }
+  }
+
   private void encodeDecimal(CodecDataOutput cdo, Object value) {
     if (value instanceof MyDecimal) {
       MyDecimal dec = (MyDecimal) value;
@@ -332,8 +346,14 @@ public class RowEncoderV2 {
   }
 
   private void encodeEnum(CodecDataOutput cdo, Object value, List<String> elems) {
-    int val = EnumCodec.parseEnumName((String) value, elems);
-    encodeInt(cdo, val);
+    if (value instanceof Integer) {
+      encodeInt(cdo, (int) value);
+    } else if (value instanceof String) {
+      int val = EnumCodec.parseEnumName((String) value, elems);
+      encodeInt(cdo, val);
+    } else {
+      throw new CodecException("invalid enum type " + value.getClass());
+    }
   }
 
   private void encodeSet(CodecDataOutput cdo, Object value, List<String> elems) {


### PR DESCRIPTION
Fix #1622 

Also fixes similar problems in decimal/string/enum conversions.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to be included in the release note
