### PR TITLE
filter sequence table from catalog

### DIFF
--- a/core/src/test/scala/org/apache/spark/sql/SequenceTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/SequenceTestSuite.scala
@@ -35,6 +35,12 @@ class SequenceTestSuite extends BaseTiSparkTest {
     judge(s"select * from $table")
 
     spark.sql("show tables").show(false)
+
+    val tableInfo = ti.meta.getTable(s"${dbPrefix}tispark_test", table).get
+    assert(table.equals(tableInfo.getName))
+
+    val sequenceInfo = ti.meta.getTable(s"${dbPrefix}tispark_test", "sq_test")
+    assert(sequenceInfo.isEmpty)
   }
 
   override def afterAll(): Unit = {

--- a/tikv-client/src/main/java/com/pingcap/tikv/catalog/CatalogTransaction.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/catalog/CatalogTransaction.java
@@ -93,7 +93,14 @@ public class CatalogTransaction {
     ImmutableList.Builder<TiTableInfo> builder = ImmutableList.builder();
     for (Pair<ByteString, ByteString> pair : fields) {
       if (KeyUtils.hasPrefix(pair.first, ByteString.copyFromUtf8(MetaCodec.KEY_TABLE))) {
-        builder.add(parseFromJson(pair.second, TiTableInfo.class));
+        try {
+          TiTableInfo tableInfo = parseFromJson(pair.second, TiTableInfo.class);
+          if (!tableInfo.isSequence()) {
+            builder.add(tableInfo);
+          }
+        } catch (TiClientInternalException e) {
+          logger.warn("fail to parse table from json!", e);
+        }
       }
     }
     return builder.build();


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

 `sequenceTable.toString` throws the following exception

```
java.lang.NullPointerException
	at com.pingcap.tikv.meta.TiTableInfo.toProto(TiTableInfo.java:239)
	at com.pingcap.tikv.meta.TiTableInfo.toString(TiTableInfo.java:314)
	at com.pingcap.tikv.catalog.CatalogTransaction.getTables(CatalogTransaction.java:98)
	at com.pingcap.tikv.catalog.Catalog$CatalogCache.loadTables(Catalog.java:184)
	at com.pingcap.tikv.catalog.Catalog$CatalogCache.listTables(Catalog.java:162)
	at com.pingcap.tikv.catalog.Catalog.listTables(Catalog.java:80)
	at com.pingcap.tispark.MetaManager.getTables(MetaManager.scala:30)
	at org.apache.spark.sql.catalyst.catalog.TiDirectExternalCatalog.listTables(TiDirectExternalCatalog.scala:58)
	at org.apache.spark.sql.catalyst.catalog.TiDirectExternalCatalog.listTables(TiDirectExternalCatalog.scala:54)
	at org.apache.spark.sql.catalyst.catalog.SessionCatalog.listTables(SessionCatalog.scala:733)
```

### What is changed and how it works?

filter sequence table from catalog
