### PR TITLE
Fix covering index error when alter-primary-key is enabled

### DIFF
--- a/tikv-client/src/main/java/com/pingcap/tikv/meta/TiDAGRequest.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/meta/TiDAGRequest.java
@@ -323,9 +323,8 @@ public class TiDAGRequest implements Serializable {
             }
           }
           // if a column of field is not contained in index selected,
-          // logically it must be the pk column and
-          // the pkIsHandle must be true. Extra check here.
-          else if (tableInfo.getColumn(col.getName()).isPrimaryKey() && tableInfo.isPkHandle()) {
+          // logically it must be the pk column. Extra check here.
+          else if (tableInfo.getColumn(col.getName()).isPrimaryKey()) {
             pkIsNeeded = true;
             // offset should be processed for each primary key encountered
             outputOffsets.add(colCount);


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix a possible covering index error when alter-primary-key feature is enabled in TiDB.

When this feature is enabled, the primary key could be both of integer type and not a handle, which violets the check in covering index.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test
Modify the plan to use covering index and turn on alter-primary-key.

Related changes

 - Need to cherry-pick to the release branch
 - Need to be included in the release note
