### PR TITLE
support invisible index

### DIFF
--- a/core/src/test/scala/org/apache/spark/sql/InvisibleIndexSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/InvisibleIndexSuite.scala
@@ -1,0 +1,45 @@
+package org.apache.spark.sql
+
+class InvisibleIndexSuite extends BaseTiSparkTest {
+
+  test("invisible index") {
+    if (!supportInvisibleIndex) {
+      cancel("current version of TiDB does not support invisible index!")
+    }
+
+    tidbStmt.execute("drop table if exists t_invisible_index")
+    tidbStmt.execute("create table t_invisible_index(a int, index idx_a(a))")
+    val tiTableInfo1 =
+      ti.tiSession.getCatalog.getTable(dbPrefix + "tispark_test", "t_invisible_index")
+    assert(!tiTableInfo1.getIndices.get(0).isInvisible)
+
+    tidbStmt.execute("alter table t_invisible_index alter index idx_a invisible")
+    val tiTableInfo2 =
+      ti.tiSession.getCatalog.getTable(dbPrefix + "tispark_test", "t_invisible_index")
+    assert(tiTableInfo2.getIndices.get(0).isInvisible)
+  }
+
+  private lazy val supportInvisibleIndex: Boolean = {
+    var result = true
+    tidbStmt.execute("drop table if exists t_invisible_index")
+    tidbStmt.execute("create table t_invisible_index(a int, index idx_a(a))")
+    try {
+      tidbStmt.execute("alter table t_invisible_index alter index idx_a invisible")
+
+      val tiTableInfo =
+        ti.tiSession.getCatalog.getTable(dbPrefix + "tispark_test", "t_invisible_index")
+      result = tiTableInfo.getIndices.get(0).isInvisible
+    } catch {
+      case e: Throwable => result = false
+    }
+    result
+  }
+
+  override def afterAll(): Unit = {
+    try {
+      tidbStmt.execute("drop table if exists t_invisible_index")
+    } finally {
+      super.afterAll()
+    }
+  }
+}

--- a/core/src/test/scala/org/apache/spark/sql/InvisibleIndexSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/InvisibleIndexSuite.scala
@@ -1,8 +1,11 @@
 package org.apache.spark.sql
 
-class InvisibleIndexSuite extends BaseTiSparkTest {
+import org.apache.spark.sql.catalyst.plans.BasePlanTest
+import org.scalatest.exceptions.TestFailedException
 
-  test("invisible index") {
+class InvisibleIndexSuite extends BasePlanTest {
+
+  test("test invisible index in catalog") {
     if (!supportInvisibleIndex) {
       cancel("current version of TiDB does not support invisible index!")
     }
@@ -11,12 +14,46 @@ class InvisibleIndexSuite extends BaseTiSparkTest {
     tidbStmt.execute("create table t_invisible_index(a int, index idx_a(a))")
     val tiTableInfo1 =
       ti.tiSession.getCatalog.getTable(dbPrefix + "tispark_test", "t_invisible_index")
-    assert(!tiTableInfo1.getIndices.get(0).isInvisible)
+    assert(!tiTableInfo1.getIndices(true).get(0).isInvisible)
 
     tidbStmt.execute("alter table t_invisible_index alter index idx_a invisible")
     val tiTableInfo2 =
       ti.tiSession.getCatalog.getTable(dbPrefix + "tispark_test", "t_invisible_index")
-    assert(tiTableInfo2.getIndices.get(0).isInvisible)
+    assert(tiTableInfo2.getIndices(true).get(0).isInvisible)
+  }
+
+  test("test invisible index in planner") {
+    if (!supportInvisibleIndex) {
+      cancel("current version of TiDB does not support invisible index!")
+    }
+
+    {
+      tidbStmt.execute("drop table if exists t_invisible_index")
+      tidbStmt.execute("create table t_invisible_index(a int, b int, index idx_a(a))")
+
+      tidbStmt.execute(
+        "insert into t_invisible_index values(1, 1),(2, 2),(3, 3),(4, 4),(5, 5),(6, 6)")
+      tidbStmt.execute("analyze table t_invisible_index")
+      val df = spark.sql("select * from t_invisible_index where a = 1")
+      checkIsIndexScan(df, "t_invisible_index")
+      checkIndex(df, "idx_a")
+    }
+
+    {
+      tidbStmt.execute("drop table if exists t_invisible_index")
+      tidbStmt.execute("create table t_invisible_index(a int, b int, index idx_a(a))")
+      tidbStmt.execute("alter table t_invisible_index alter index idx_a invisible")
+
+      tidbStmt.execute(
+        "insert into t_invisible_index values(1, 1),(2, 2),(3, 3),(4, 4),(5, 5),(6, 6)")
+      tidbStmt.execute("analyze table t_invisible_index")
+      val df = spark.sql("select * from t_invisible_index where a = 1")
+      intercept[TestFailedException] {
+        checkIsIndexScan(df, "t_invisible_index")
+        checkIndex(df, "idx_a")
+      }
+
+    }
   }
 
   private lazy val supportInvisibleIndex: Boolean = {
@@ -28,7 +65,7 @@ class InvisibleIndexSuite extends BaseTiSparkTest {
 
       val tiTableInfo =
         ti.tiSession.getCatalog.getTable(dbPrefix + "tispark_test", "t_invisible_index")
-      result = tiTableInfo.getIndices.get(0).isInvisible
+      result = tiTableInfo.getIndices(true).get(0).isInvisible
     } catch {
       case e: Throwable => result = false
     }

--- a/tikv-client/src/main/java/com/pingcap/tikv/meta/TiIndexInfo.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/meta/TiIndexInfo.java
@@ -42,6 +42,7 @@ public class TiIndexInfo implements Serializable {
   private final String comment;
   private final IndexType indexType;
   private final boolean isFakePrimaryKey;
+  private final boolean isInvisible;
 
   // default index column size (TypeFlag + Int64)
   private long indexColumnSize = 9;
@@ -60,7 +61,8 @@ public class TiIndexInfo implements Serializable {
       @JsonProperty("index_type") int indexType,
       // This is a fake property and added JsonProperty only to
       // to bypass Jackson frameworks's check
-      @JsonProperty("___isFakePrimaryKey") boolean isFakePrimaryKey) {
+      @JsonProperty("___isFakePrimaryKey") boolean isFakePrimaryKey,
+      @JsonProperty("is_invisible") boolean isInvisible) {
     this.id = id;
     this.name = requireNonNull(name, "index name is null").getL();
     this.tableName = requireNonNull(tableName, "table name is null").getL();
@@ -71,6 +73,7 @@ public class TiIndexInfo implements Serializable {
     this.comment = comment;
     this.indexType = IndexType.fromValue(indexType);
     this.isFakePrimaryKey = isFakePrimaryKey;
+    this.isInvisible = isInvisible;
   }
 
   public static TiIndexInfo generateFakePrimaryKeyIndex(TiTableInfo table) {
@@ -86,7 +89,8 @@ public class TiIndexInfo implements Serializable {
           SchemaState.StatePublic.getStateCode(),
           "Fake Column",
           IndexType.IndexTypeHash.getTypeCode(),
-          true);
+          true,
+          false);
     }
     return null;
   }
@@ -181,6 +185,10 @@ public class TiIndexInfo implements Serializable {
 
   public boolean isFakePrimaryKey() {
     return isFakePrimaryKey;
+  }
+
+  public boolean isInvisible() {
+    return isInvisible;
   }
 
   @Override

--- a/tikv-client/src/main/java/com/pingcap/tikv/meta/TiTableInfo.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/meta/TiTableInfo.java
@@ -201,7 +201,15 @@ public class TiTableInfo implements Serializable {
   }
 
   public List<TiIndexInfo> getIndices() {
-    return indices;
+    return getIndices(false);
+  }
+
+  public List<TiIndexInfo> getIndices(boolean includingInvisible) {
+    if (includingInvisible) {
+      return indices;
+    } else {
+      return indices.stream().filter(idx -> !idx.isInvisible()).collect(Collectors.toList());
+    }
   }
 
   public String getComment() {

--- a/tikv-client/src/test/java/com/pingcap/tikv/meta/MetaUtils.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/meta/MetaUtils.java
@@ -118,6 +118,7 @@ public class MetaUtils {
               SchemaState.StatePublic.getStateCode(),
               "",
               IndexType.IndexTypeBtree.getTypeCode(),
+              false,
               false);
       indices.add(index);
       return this;

--- a/tikv-client/src/test/java/com/pingcap/tikv/predicates/TiKVScanAnalyzerTest.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/predicates/TiKVScanAnalyzerTest.java
@@ -399,6 +399,7 @@ public class TiKVScanAnalyzerTest {
               SchemaState.StatePublic.getStateCode(),
               "Test Index",
               IndexType.IndexTypeBtree.getTypeCode(),
+              false,
               false);
       boolean isCovering = scanBuilder.isCoveringIndex(columns, indexInfo, pkIsHandle);
       assertEquals(t.isCovering, isCovering);


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
tidb-5.0 supports support invisible index
see https://github.com/pingcap/tidb/pull/16914

close https://github.com/pingcap/tispark/issues/1650

### What is changed and how it works?
tispark should also support invisible index
- decode `invisible index` from json schema
- ignore `invisible index` in planner

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

