### PR TITLE
enable user provided auto increment value in update mode

### DIFF
--- a/core/src/test/scala/com/pingcap/tispark/datasource/AutoIncrementSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/AutoIncrementSuite.scala
@@ -345,4 +345,49 @@ class AutoIncrementSuite extends BaseBatchWriteTest("test_datasource_auto_increm
     assert(caught.getCause.isInstanceOf[ConvertOverflowException])
     assert(caught.getCause.getMessage.equals("value 256 > upperBound 255"))
   }
+
+  test("auto increment: user provide id, update") {
+    val row1 = Row(1L, 1L)
+    val row2 = Row(2L, 22L)
+    val row3 = Row(3L, 33L)
+    val row4 = Row(4L, 44L)
+
+    val schema = StructType(List(StructField("i", LongType), StructField("j", LongType)))
+
+    jdbcUpdate(
+      s"create table $dbtable(i int NOT NULL AUTO_INCREMENT, j int NOT NULL, primary key (i), key (j))")
+
+    jdbcUpdate(s"insert into $dbtable (j) values(1), (2), (3), (4)")
+
+    sql(s"select * from $dbtableWithPrefix").show()
+
+    tidbWrite(List(row2, row3, row4), schema, Some(Map("replace" -> "true")))
+
+    sql(s"select * from $dbtableWithPrefix").show()
+
+    testTiDBSelect(Seq(row1, row2, row3, row4))
+  }
+
+  test("auto increment: user provide id, update+insert") {
+    val row1 = Row(1L, 1L)
+    val row2 = Row(2L, 22L)
+    val row3 = Row(3L, 33L)
+    val row4 = Row(4L, 44L)
+
+    val schema = StructType(List(StructField("i", LongType), StructField("j", LongType)))
+
+    jdbcUpdate(
+      s"create table $dbtable(i int NOT NULL AUTO_INCREMENT, j int NOT NULL, primary key (i))")
+
+    jdbcUpdate(s"insert into $dbtable (j) values(1), (2), (3)")
+
+    sql(s"select * from $dbtableWithPrefix").show()
+
+    val caught = intercept[com.pingcap.tikv.exception.TiBatchWriteException] {
+      tidbWrite(List(row2, row3, row4), schema, Some(Map("replace" -> "true")))
+    }
+    assert(
+      caught.getMessage.equals(
+        "currently user provided auto increment value is only supported in update mode!"))
+  }
 }


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
currently user provided auto increment value is not supported in update mode

### What is changed and how it works?
enable user provided auto increment value in update mode

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `tidb-ansible` repository
 - Need to be included in the release note
