### PR TITLE
fix wrong conversion from LocalDate to days since UNIX epoch

### DIFF
--- a/tikv-client/src/main/java/com/pingcap/tikv/columnar/TiBlockColumnVector.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/columnar/TiBlockColumnVector.java
@@ -197,7 +197,7 @@ public class TiBlockColumnVector extends TiColumnVector {
     int month = (int) (ym % 13);
     int day = (int) (ymd & ((1 << 5) - 1));
     LocalDate date = new LocalDate(year, month, day);
-    return Math.floorDiv(date.toDate().getTime(), AbstractDateTimeType.MILLS_PER_DAY);
+    return DateType.getDays(date);
   }
   /**
    * Returns the long type value for rowId. The return value is undefined and can be anything, if

--- a/tikv-client/src/main/java/com/pingcap/tikv/columnar/TiChunkColumnVector.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/columnar/TiChunkColumnVector.java
@@ -144,7 +144,7 @@ public class TiChunkColumnVector extends TiColumnVector {
     }
     if (this.type instanceof DateType) {
       LocalDate date = new LocalDate(year, month, day);
-      return Math.floorDiv(date.toDate().getTime(), AbstractDateTimeType.MILLS_PER_DAY);
+      return DateType.getDays(date);
     } else if (type instanceof DateTimeType || type instanceof TimestampType) {
       // only return microsecond from epoch.
       Timestamp ts =

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/AbstractDateTimeType.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/AbstractDateTimeType.java
@@ -30,7 +30,6 @@ import org.joda.time.DateTimeZone;
 import org.joda.time.LocalDate;
 
 public abstract class AbstractDateTimeType extends DataType {
-  public static long MILLS_PER_DAY = 3600L * 24 * 1000;
 
   AbstractDateTimeType(InternalTypeHolder holder) {
     super(holder);

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/DateType.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/DateType.java
@@ -25,9 +25,11 @@ import com.pingcap.tikv.exception.ConvertOverflowException;
 import com.pingcap.tikv.meta.TiColumnInfo;
 import java.sql.Date;
 import org.joda.time.DateTimeZone;
+import org.joda.time.Days;
 import org.joda.time.LocalDate;
 
 public class DateType extends AbstractDateTimeType {
+  private static final LocalDate EPOCH = new LocalDate(0);
   public static final DateType DATE = new DateType(MySQLType.TypeDate);
   public static final MySQLType[] subTypes = new MySQLType[] {MySQLType.TypeDate};
 
@@ -90,6 +92,10 @@ public class DateType extends AbstractDateTimeType {
     return "DATE";
   }
 
+  public static int getDays(LocalDate d) {
+    return Days.daysBetween(EPOCH, d).getDays();
+  }
+
   /** {@inheritDoc} */
   @Override
   protected Long decodeNotNull(int flag, CodecDataInput cdi) {
@@ -98,8 +104,8 @@ public class DateType extends AbstractDateTimeType {
     if (date == null) {
       return null;
     }
-    // return how many days from EPOCH
-    return Math.floorDiv(date.toDate().getTime(), AbstractDateTimeType.MILLS_PER_DAY);
+
+    return new Long(getDays(date));
   }
 
   @Override


### PR DESCRIPTION
### What problem does this PR solve?

For timezone UTC+8, `2020-10-25 +8` is `2020-10-24 16:00:00 UTC`,
the original wrong code truncates it to days between `2020-10-24 UTC`
and `1970-01-01 UTC`.

```
$ jshell --class-path ~/.m2//repository/joda-time/joda-time/2.9.9/joda-time-2.9.9.jar
jshell> import org.joda.time.*;

jshell> var d = LocalDate.parse("2020-10-25");
d ==> 2020-10-25

jshell> d.toDate()
$3 ==> Sun Oct 25 00:00:00 CST 2020

jshell> d.toDate().getTime()
$4 ==> 1603555200000

jshell> Math.floorDiv(d.toDate().getTime(), 3600L * 1000 * 24)
$5 ==> 18559

jshell> Days.daysBetween(new LocalDate(0), d).getDays()
$6 ==> 18560
```

### What is changed and how it works?

Use joda-time class `Days` to correctly convert LocalDate to days.

### Check List

Tests

 - Manual test (add detailed scripts or steps below)

Create table in TiDB 4.0, local timezone is UTC+08:00.

```sql
create table test.t (id int, d date);
insert into test.t values (1, '2020-10-25');
```

Check with spark-shell:
```sh
$ spark-2.4.7-bin-hadoop2.7/bin/spark-shell --jars ~/.m2/repository/com/pingcap/tispark/tispark-assembly/2.3.6/tispark-assembly-2.3.6.jar
scala> spark.sql("select * from test.t").show
+---+----------+                                                                
| id|         d|
+---+----------+
|  1|2020-10-24|
+---+----------+

# I actually test again branch release-2.4, I can't use branch master because
# it need scala 2.12 but spark-2.4.7 uses scala 2.11.
$ spark-2.4.7-bin-hadoop2.7/bin/spark-shell --jars ~/.m2/repository/com/pingcap/tispark/tispark-assembly/2.4.0-SNAPSHOT/tispark-assembly-2.4.0-SNAPSHOT.jar
scala> spark.sql("select * from test.t").show
+---+----------+
| id|         d|
+---+----------+
|  1|2020-10-25|
+---+----------+

```

Code changes

 - Has exported function/method change: NO
 - Has exported variable/fields change: NO
 - Has interface methods change: NO
 - Has persistent data change: NO

Side effects

 - Possible performance regression: NO
 - Increased code complexity: NO
 - Breaking backward compatibility: NO (**Actually this is a serve bug,  tispark <= 2.3.6 will output wrong date for timezone earlier than UTC, aka. timezone > +00:00**)

Related changes

 - Need to cherry-pick to the release branch:  **YES, please backport to release-2.4 and release-2.3**.
 - Need to update the documentation: NO
 - Need to update the `tidb-ansible` repository: NO
 - Need to be included in the release note: YES
