### PR TITLE
fix negative column id when there are more than 128 columns

### DIFF
--- a/tikv-client/src/main/java/com/pingcap/tikv/codec/RowEncoderV2.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/codec/RowEncoderV2.java
@@ -125,7 +125,7 @@ public class RowEncoderV2 {
       for (int i = 0; i < len; i++) {
         idx[i] = i;
       }
-      Arrays.sort(idx, Comparator.comparingInt(o -> this.row.colIDs[o]));
+      Arrays.sort(idx, Comparator.comparingInt(o -> Byte.toUnsignedInt(this.row.colIDs[o])));
       for (int i = 0; i < len; i++) {
         this.row.colIDs[i] = temp[idx[i]];
         this.values[i] = valueList.get(idx[i]);
@@ -138,7 +138,8 @@ public class RowEncoderV2 {
         for (int i = 0; i < len; i++) {
           idx[i] = i;
         }
-        Arrays.sort(idx, Comparator.comparingInt(o -> this.row.colIDs[start + o]));
+        Arrays.sort(
+            idx, Comparator.comparingInt(o -> Byte.toUnsignedInt(this.row.colIDs[start + o])));
         for (int i = 0; i < len; i++) {
           // values should all be null
           this.row.colIDs[start + i] = temp[idx[i]];
@@ -163,13 +164,16 @@ public class RowEncoderV2 {
       if (this.row.large) {
         encodeValue(cdo, o, getColumnInfoByID(columnInfos, this.row.colIDs32[i]).getType());
       } else {
-        encodeValue(cdo, o, getColumnInfoByID(columnInfos, this.row.colIDs[i]).getType());
+        encodeValue(
+            cdo,
+            o,
+            getColumnInfoByID(columnInfos, Byte.toUnsignedInt(this.row.colIDs[i])).getType());
       }
       if (cdo.size() > 0xffff && !this.row.large) {
         // only initialize once
         this.row.initColIDs32();
         for (int j = 0; j < numCols; j++) {
-          this.row.colIDs32[j] = this.row.colIDs[j];
+          this.row.colIDs32[j] = Byte.toUnsignedInt(this.row.colIDs[j]);
         }
         this.row.initOffsets32();
         if (numCols >= 0) {

--- a/tikv-client/src/main/java/com/pingcap/tikv/codec/RowV2.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/codec/RowV2.java
@@ -145,7 +145,7 @@ public class RowV2 {
       if (this.large) {
         v = this.colIDs32[h];
       } else {
-        v = this.colIDs[h];
+        v = Byte.toUnsignedLong(this.colIDs[h]);
       }
       if (v < colID) {
         i = h + 1;


### PR DESCRIPTION
### What problem does this PR solve?

When a table has more than 128 columns,  TiBatchWriteTable.scala throws exception, the cause is obvious:

```
2020-10-26 00:21:30.055 level=INFO thread=dag-scheduler-event-loop class=DAGScheduler msg=ShuffleMapStage 51 (map at TiBatchWriteTable.scala:220) failed in 19.155 s due to Job aborted due to stage failure: Task 0 in stage 51.0 failed 4 times, most recent failure: Lost task 0.3 in stage 51.0 (TID 467, 172.18.7.30, executor 7): com.pingcap.tikv.exception.CodecException: column id -108 not found in ColumnInfo
        at com.pingcap.tikv.codec.RowEncoderV2.getColumnInfoByID(RowEncoderV2.java:156)
        at com.pingcap.tikv.codec.RowEncoderV2.encodeRowCols(RowEncoderV2.java:166)
        at com.pingcap.tikv.codec.RowEncoderV2.encode(RowEncoderV2.java:61)
        at com.pingcap.tikv.codec.TableCodecV2.encodeRow(TableCodecV2.java:49)
        at com.pingcap.tikv.codec.TableCodec.encodeRow(TableCodec.java:38)
        at com.pingcap.tispark.write.TiBatchWriteTable.encodeTiRow(TiBatchWriteTable.scala:591)
        at com.pingcap.tispark.write.TiBatchWriteTable.com$pingcap$tispark$write$TiBatchWriteTable$$generateRowKey(TiBatchWriteTable.scala:677)
        at com.pingcap.tispark.write.TiBatchWriteTable$$anonfun$generateRecordKV$1.apply(TiBatchWriteTable.scala:685)
        at com.pingcap.tispark.write.TiBatchWriteTable$$anonfun$generateRecordKV$1.apply(TiBatchWriteTable.scala:683)
        at scala.collection.Iterator$$anon$11.next(Iterator.scala:410)
        at scala.collection.Iterator$$anon$11.next(Iterator.scala:410)
        at org.apache.spark.util.collection.ExternalSorter.insertAll(ExternalSorter.scala:193)
        at org.apache.spark.shuffle.sort.SortShuffleWriter.write(SortShuffleWriter.scala:62)
        at org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:99)
        at org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:55)
        at org.apache.spark.scheduler.Task.run(Task.scala:123)
        at org.apache.spark.executor.Executor$TaskRunner$$anonfun$10.apply(Executor.scala:408)
        at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:1360)
        at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:414)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
```


### What is changed and how it works?

When obtain column id from `colIDs`, it must be converted to unsigned int or long.

### Check List

 - Manual test

Manual test passed for a table with 252 columns.

Code changes

 - Has exported function/method change: NO
 - Has exported variable/fields change: NO
 - Has interface methods change: NO
 - Has persistent data change: NO

Side effects

 - Possible performance regression: NO
 - Increased code complexity: NO
 - Breaking backward compatibility: NO

Related changes

 - Need to cherry-pick to the release branch:  **YES, please backport to branch release-2.4 and release-2.3**
 - Need to update the documentation: NO
 - Need to update the `tidb-ansible` repository: NO
 - Need to be included in the release note: YES
