### PR TITLE
BatchWrite: fix initial ttl expired

### DIFF
--- a/core/src/main/scala/com/pingcap/tispark/write/TiDBOptions.scala
+++ b/core/src/main/scala/com/pingcap/tispark/write/TiDBOptions.scala
@@ -64,6 +64,8 @@ class TiDBOptions(@transient val parameters: CaseInsensitiveMap[String]) extends
   //20k
   val snapshotBatchGetSize: Int = getOrDefault(TIDB_SNAPSHOT_BATCH_GET_SIZE, "20480").toInt
   val batchGetBackOfferMS: Int = getOrDefault(TIDB_BATCH_GET_BACKOFFER_MS, "60000").toInt
+  val sleepBeforePrewritePrimaryKey: Long =
+    getOrDefault(TIDB_SLEEP_BEFORE_PREWRITE_PRIMARY_KEY, "0").toLong
   val sleepAfterPrewritePrimaryKey: Long =
     getOrDefault(TIDB_SLEEP_AFTER_PREWRITE_PRIMARY_KEY, "0").toLong
   val sleepAfterPrewriteSecondaryKey: Long =
@@ -217,6 +219,7 @@ object TiDBOptions {
   // ------------------------------------------------------------
   val TIDB_IS_TEST: String = newOption("isTest")
   val TIDB_LOCK_TTL_SECONDS: String = newOption("lockTTLSeconds")
+  val TIDB_SLEEP_BEFORE_PREWRITE_PRIMARY_KEY: String = newOption("sleepBeforePrewritePrimaryKey")
   val TIDB_SLEEP_AFTER_PREWRITE_PRIMARY_KEY: String = newOption("sleepAfterPrewritePrimaryKey")
   val TIDB_SLEEP_AFTER_PREWRITE_SECONDARY_KEY: String = newOption(
     "sleepAfterPrewriteSecondaryKey")

--- a/core/src/test/scala/com/pingcap/tispark/ttl/InitialTTLExpiredSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/ttl/InitialTTLExpiredSuite.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2020 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pingcap.tispark.ttl
+
+import com.pingcap.tispark.datasource.BaseBatchWriteWithoutDropTableTest
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
+
+class InitialTTLExpiredSuite
+    extends BaseBatchWriteWithoutDropTableTest("test_initial_ttl_expired") {
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    jdbcUpdate(s"create table $dbtable(i int, s varchar(128))")
+  }
+
+  test("Test Initial TTL Expired") {
+    if (!supportTTLUpdate || !supportBatchWrite) {
+      cancel
+    }
+
+    new Thread(new Runnable {
+      override def run(): Unit = {
+        while (true) {
+          try {
+            tidbStmt.execute(s"select * from $dbtable")
+            Thread.sleep(1000)
+          } catch {
+            case _: Throwable =>
+          }
+        }
+      }
+    }).start()
+
+    val row1 = Row(1, "Value1")
+    val row2 = Row(2, "Value2")
+
+    val schema: StructType =
+      StructType(List(StructField("i", IntegerType), StructField("s", StringType)))
+
+    val sleepBeforePrewritePrimaryKey = 30000
+    val sleepAfterPrewritePrimaryKey = 5000
+    val data: RDD[Row] = sc.makeRDD(List(row1, row2))
+    val df = sqlContext.createDataFrame(data, schema)
+    df.write
+      .format("tidb")
+      .options(tidbOptions)
+      .option("database", database)
+      .option("table", table)
+      .option("sleepBeforePrewritePrimaryKey", sleepBeforePrewritePrimaryKey)
+      .option("sleepAfterPrewritePrimaryKey", sleepAfterPrewritePrimaryKey)
+      .mode("append")
+      .save()
+  }
+}

--- a/tikv-client/src/main/java/com/pingcap/tikv/TTLManager.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/TTLManager.java
@@ -89,9 +89,13 @@ public class TTLManager {
     }
   }
 
+  public static long calculateUptime(TxnKVClient kvClient, long startTS) {
+    return kvClient.getTimestamp().getPhysical() - TiTimestamp.extractPhysical(startTS);
+  }
+
   private void doKeepAlive() {
     BackOffer bo = ConcreteBackOffer.newCustomBackOff(MANAGED_LOCK_TTL);
-    long uptime = kvClient.getTimestamp().getPhysical() - TiTimestamp.extractPhysical(startTS);
+    long uptime = calculateUptime(kvClient, startTS);
     long ttl = uptime + MANAGED_LOCK_TTL;
 
     LOG.info("doKeepAlive key={} uptime={} ttl={}", KeyUtils.formatBytes(primaryLock), uptime, ttl);


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
BatchWrite: initial ttl may expired
```
com.pingcap.tikv.exception.KeyException: tikv restart txn Txn(Mvcc(TxnLockNotFound { start_ts: TimeStamp(420321374141153282), commit_ts: TimeStamp(0), key: [116, 128, 0, 0, 0, 0, 0, 5, 121, 95, 114, 128, 0, 0, 0, 0, 13, 234, 195] }))
        at com.pingcap.tikv.txn.AbstractLockResolverClient.extractLockFromKeyErr(AbstractLockResolverClient.java:57)
        at com.pingcap.tikv.operation.KVErrorHandler.handleResponseError(KVErrorHandler.java:286)
        at com.pingcap.tikv.policy.RetryPolicy.callWithRetry(RetryPolicy.java:65)
        at com.pingcap.tikv.AbstractGRPCClient.callWithRetry(AbstractGRPCClient.java:77)
        at com.pingcap.tikv.region.RegionStoreClient.txnHeartBeat(RegionStoreClient.java:525)
        at com.pingcap.tikv.txn.TxnKVClient.txnHeartBeat(TxnKVClient.java:124)
        at com.pingcap.tikv.TTLManager.sendTxnHeartBeat(TTLManager.java:112)
        at com.pingcap.tikv.TTLManager.doKeepAlive(TTLManager.java:100)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308)
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180)
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
```

### What is changed and how it works?
add `uptime` to `initial ttl`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `tidb-ansible` repository
 - Need to be included in the release note
