### PR TITLE
BatchWrite: fix commit ts expired

### DIFF
--- a/core/src/main/scala/com/pingcap/tispark/write/TiBatchWrite.scala
+++ b/core/src/main/scala/com/pingcap/tispark/write/TiBatchWrite.scala
@@ -16,8 +16,8 @@
 package com.pingcap.tispark.write
 
 import com.pingcap.tikv.exception.TiBatchWriteException
-import com.pingcap.tikv.util.ConcreteBackOffer
-import com.pingcap.tikv.{TTLManager, TiDBJDBCClient, _}
+import com.pingcap.tikv.util.{BackOffFunction, BackOffer, ConcreteBackOffer}
+import com.pingcap.tikv.{TTLManager, TiDBJDBCClient, TwoPhaseCommitter, _}
 import com.pingcap.tispark.TiDBUtils
 import com.pingcap.tispark.utils.TiUtil
 import org.apache.spark.SparkConf
@@ -306,43 +306,7 @@ class TiBatchWrite(
     logger.info("prewriteSecondaryKeys success")
 
     // driver primary commit
-    val commitTs = tiSession.getTimestamp.getVersion
-    // check commitTS
-    if (commitTs <= startTs) {
-      throw new TiBatchWriteException(
-        s"invalid transaction tso with startTs=$startTs, commitTs=$commitTs")
-    }
-
-    // for test
-    if (options.sleepAfterPrewriteSecondaryKey > 0) {
-      logger.info(s"sleep ${options.sleepAfterPrewriteSecondaryKey} ms for test")
-      Thread.sleep(options.sleepAfterPrewriteSecondaryKey)
-    }
-
-    // check schema change
-    if (!useTableLock) {
-      tiBatchWriteTables.foreach(_.checkSchemaChange())
-    }
-
-    // for test
-    if (options.sleepAfterGetCommitTS > 0) {
-      logger.info(s"sleep ${options.sleepAfterGetCommitTS} ms for test")
-      Thread.sleep(options.sleepAfterGetCommitTS)
-    }
-
-    val commitPrimaryBackoff = ConcreteBackOffer.newCustomBackOff(PRIMARY_KEY_COMMIT_BACKOFF)
-
-    // check connection lost if using lock table
-    checkConnectionLost()
-
-    logger.info("start to commitPrimaryKey")
-    ti2PCClient.commitPrimaryKey(commitPrimaryBackoff, primaryKey.bytes, commitTs)
-    try {
-      ti2PCClient.close()
-    } catch {
-      case _: Throwable =>
-    }
-    logger.info("commitPrimaryKey success")
+    val commitTs = commitPrimaryKeyWithRetry(startTs, primaryKey, ti2PCClient)
 
     // stop primary key ttl update
     if (isTTLUpdate) {
@@ -392,6 +356,70 @@ class TiBatchWrite(
 
     val endMS = System.currentTimeMillis()
     logger.info(s"batch write cost ${(endMS - startMS) / 1000} seconds")
+  }
+
+  private def commitPrimaryKeyWithRetry(
+      startTs: Long,
+      primaryKey: SerializableKey,
+      ti2PCClient: TwoPhaseCommitter): Long = {
+    val backoff = ConcreteBackOffer.newCustomBackOff(options.commitPrimaryKeyBackOfferMS)
+    while (true) {
+      try {
+        return commitPrimaryKey(startTs, primaryKey, ti2PCClient)
+      } catch {
+        case e: TiBatchWriteException =>
+          throw e
+        case e: Throwable =>
+          backoff.doBackOff(
+            BackOffFunction.BackOffFuncType.BoRegionMiss,
+            new TiBatchWriteException("commit primary key error", e))
+      }
+    }
+    0L
+  }
+
+  private def commitPrimaryKey(
+      startTs: Long,
+      primaryKey: SerializableKey,
+      ti2PCClient: TwoPhaseCommitter): Long = {
+    val commitTsAttempt = tiSession.getTimestamp.getVersion
+    // check commitTS
+    if (commitTsAttempt <= startTs) {
+      throw new TiBatchWriteException(
+        s"invalid transaction tso with startTs=$startTs, commitTsAttempt=$commitTsAttempt")
+    }
+
+    // for test
+    if (options.sleepAfterPrewriteSecondaryKey > 0) {
+      logger.info(s"sleep ${options.sleepAfterPrewriteSecondaryKey} ms for test")
+      Thread.sleep(options.sleepAfterPrewriteSecondaryKey)
+    }
+
+    // check schema change
+    if (!useTableLock) {
+      tiBatchWriteTables.foreach(_.checkSchemaChange())
+    }
+
+    // for test
+    if (options.sleepAfterGetCommitTS > 0) {
+      logger.info(s"sleep ${options.sleepAfterGetCommitTS} ms for test")
+      Thread.sleep(options.sleepAfterGetCommitTS)
+    }
+
+    val commitPrimaryBackoff = ConcreteBackOffer.newCustomBackOff(PRIMARY_KEY_COMMIT_BACKOFF)
+
+    // check connection lost if using lock table
+    checkConnectionLost()
+
+    logger.info(s"start to commitPrimaryKey, commitTsAttempt=$commitTsAttempt")
+    ti2PCClient.commitPrimaryKey(commitPrimaryBackoff, primaryKey.bytes, commitTsAttempt)
+    try {
+      ti2PCClient.close()
+    } catch {
+      case _: Throwable =>
+    }
+    logger.info("commitPrimaryKey success")
+    commitTsAttempt
   }
 
   private def getRegionSplitPoints(

--- a/core/src/main/scala/com/pingcap/tispark/write/TiDBOptions.scala
+++ b/core/src/main/scala/com/pingcap/tispark/write/TiDBOptions.scala
@@ -84,6 +84,8 @@ class TiDBOptions(@transient val parameters: CaseInsensitiveMap[String]) extends
   val retryCommitSecondaryKey: Boolean =
     getOrDefault(TIDB_RETRY_COMMIT_SECONDARY_KEY, "true").toBoolean
   val prewriteMaxRetryTimes: Int = getOrDefault(TIDB_PREWRITE_MAX_RETRY_TIMES, "64").toInt
+  val commitPrimaryKeyBackOfferMS: Int =
+    getOrDefault(TIDB_COMMIT_PRIMARY_KEY_BACKOFFER_MS, "120000").toInt
 
   // region split
   val enableRegionSplit: Boolean = getOrDefault(TIDB_ENABLE_REGION_SPLIT, "true").toBoolean
@@ -199,6 +201,7 @@ object TiDBOptions {
   val TIDB_WRITE_THREAD_PER_TASK: String = newOption("writeThreadPerTask")
   val TIDB_RETRY_COMMIT_SECONDARY_KEY: String = newOption("retryCommitSecondaryKey")
   val TIDB_PREWRITE_MAX_RETRY_TIMES: String = newOption("prewriteMaxRetryTimes")
+  val TIDB_COMMIT_PRIMARY_KEY_BACKOFFER_MS: String = newOption("commitPrimaryKeyBackOfferMS")
 
   // region split
   val TIDB_ENABLE_REGION_SPLIT: String = newOption("enableRegionSplit")


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
```
Error: java.util.concurrent.ExecutionException: java.lang.RuntimeException: com.pingcap.tikv.exception.GrpcException: retry is exhausted.
com.pingcap.tikv.exception.GrpcException: Txn commit primary key failed, regionId=5572059
com.pingcap.tikv.exception.KeyException: Key exception occurred and the reason is commit_ts_expired {
  start_ts: 420399258342522881
  attempted_commit_ts: 420399307022663682
  key: "t\200\000\000\000\000\000\002f_r\200\000\000\000\000\236\024\f"
  min_commit_ts: 420399315490177026
} (state=,code=0)
```

### What is changed and how it works?
tispark should refetch a new `commit ts` when receving `commit_ts_expired` error

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `tidb-ansible` repository
 - Need to be included in the release note
