### PR TITLE
optimize region split number in small data size

### DIFF
--- a/core/src/main/scala/com/pingcap/tispark/write/TiBatchWrite.scala
+++ b/core/src/main/scala/com/pingcap/tispark/write/TiBatchWrite.scala
@@ -445,7 +445,7 @@ class TiBatchWrite(
     val sampleData = rdd.sample(false, sampleSize.toDouble / count).collect()
     logger.info(s"sampleData size=${sampleData.length}")
 
-    val finalRegionSplitPointNum = if (options.regionSplitUsingSize) {
+    val splitPointNumUsingSize = if (options.regionSplitUsingSize) {
       val avgSize = getAverageSizeInBytes(sampleData)
       logger.info(s"avgSize=$avgSize Bytes")
       if (avgSize <= options.bytesPerRegion / options.regionSplitKeys) {
@@ -457,6 +457,13 @@ class TiBatchWrite(
       }
     } else {
       regionSplitPointNum
+    }
+    logger.info(s"splitPointNumUsingSize=$splitPointNumUsingSize")
+
+    val finalRegionSplitPointNum = if (splitPointNumUsingSize < options.minRegionSplitNum) {
+      options.minRegionSplitNum
+    } else {
+      splitPointNumUsingSize
     }
     logger.info(s"finalRegionSplitPointNum=$finalRegionSplitPointNum")
 

--- a/core/src/main/scala/com/pingcap/tispark/write/TiDBOptions.scala
+++ b/core/src/main/scala/com/pingcap/tispark/write/TiDBOptions.scala
@@ -93,7 +93,7 @@ class TiDBOptions(@transient val parameters: CaseInsensitiveMap[String]) extends
   val sampleSplitFrac: Int = getOrDefault(TIDB_SAMPLE_SPLIT_FRAC, "1000").toInt
   val scatterWaitMS: Int = getOrDefault(TIDB_SCATTER_WAIT_MS, "300000").toInt
   val regionSplitKeys: Int = getOrDefault(TIDB_REGION_SPLIT_KEYS, "960000").toInt
-  val minRegionSplitNum: Int = getOrDefault(TIDB_MIN_REGION_SPLIT_NUM, "4").toInt
+  val minRegionSplitNum: Int = getOrDefault(TIDB_MIN_REGION_SPLIT_NUM, "8").toInt
   val regionSplitThreshold: Int = getOrDefault(TIDB_REGION_SPLIT_THRESHOLD, "100000").toInt
   val splitRegionBackoffMS: Int = getOrDefault(TIDB_SPLIT_REGION_BACKOFFER_MS, "120000").toInt
   val scatterRegionBackoffMS: Int = getOrDefault(TIDB_SCATTER_REGION_BACKOFFER_MS, "30000").toInt


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
region split number is too small for small data size (e.g. 15w)

### What is changed and how it works?
optimize region split number in small data size

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `tidb-ansible` repository
 - Need to be included in the release note
