### PR TITLE
BatchWrite: fix auto increment column not primary key

### DIFF
--- a/core/src/test/scala/com/pingcap/tispark/datasource/AutoIncrementSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/AutoIncrementSuite.scala
@@ -390,4 +390,23 @@ class AutoIncrementSuite extends BaseBatchWriteTest("test_datasource_auto_increm
       caught.getMessage.equals(
         "currently user provided auto increment value is only supported in update mode!"))
   }
+
+  test("auto increment but not primary key") {
+    val row3 = Row(3L, 33L)
+    val row4 = Row(4L, 44L)
+
+    val schema = StructType(List(StructField("j", LongType)))
+
+    jdbcUpdate(
+      s"create table $dbtable(i int NOT NULL AUTO_INCREMENT, j int NOT NULL, unique key (i))")
+
+    jdbcUpdate(s"insert into $dbtable (j) values(1), (2)")
+
+    sql(s"select * from $dbtableWithPrefix").show()
+
+    tidbWrite(List(row3, row4), schema)
+
+    sql(s"select * from $dbtableWithPrefix").show()
+  }
+
 }

--- a/tikv-client/src/main/java/com/pingcap/tikv/meta/TiTableInfo.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/meta/TiTableInfo.java
@@ -135,18 +135,20 @@ public class TiTableInfo implements Serializable {
     return this.sequenceInfo != null;
   }
 
-  // auto increment column must be a primary key column
   public boolean hasAutoIncrementColumn() {
-    if (primaryKeyColumn != null) {
-      return primaryKeyColumn.isAutoIncrement();
+    for (TiColumnInfo tiColumnInfo : getColumns()) {
+      if (tiColumnInfo.isAutoIncrement()) {
+        return true;
+      }
     }
     return false;
   }
 
-  // auto increment column must be a primary key column
   public TiColumnInfo getAutoIncrementColInfo() {
-    if (hasAutoIncrementColumn()) {
-      return primaryKeyColumn;
+    for (TiColumnInfo tiColumnInfo : getColumns()) {
+      if (tiColumnInfo.isAutoIncrement()) {
+        return tiColumnInfo;
+      }
     }
     return null;
   }


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
auto-increment column may not primary key

### What is changed and how it works?
scan all the columns to get auto-increment column

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `tidb-ansible` repository
 - Need to be included in the release note
