### PR TITLE
Fix typo in DateTime calculation

### DIFF
--- a/tikv-client/src/main/java/com/pingcap/tikv/types/AbstractDateTimeType.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/AbstractDateTimeType.java
@@ -60,10 +60,7 @@ public abstract class AbstractDateTimeType extends DataType {
     // nearest
     // value which is 0001-01-01.
     if (extendedDateTime == null) {
-      Timestamp ts =
-          DateTimeCodec.createExtendedDateTime(getTimezone(), 1, 1, 1, 0, 0, 0, 0).toTimeStamp();
-      // by dividing 1000 on milliseconds, we have eliminated fraction part of ts
-      return ts.getTime() / 1000 * 100000 + ts.getNanos() / 1000;
+      extendedDateTime = DateTimeCodec.createExtendedDateTime(getTimezone(), 1, 1, 1, 0, 0, 0, 0);
     }
     Timestamp ts = extendedDateTime.toTimeStamp();
     return ts.getTime() / 1000 * 1000000 + ts.getNanos() / 1000;


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
fix typo in datetime calculation, which may cause the result be incorrect when using datetime like `0000-00-00 00:00:00`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

Related changes

 - Need to cherry-pick to the release branch
