### PR TITLE
Fix string insert overflow check

### DIFF
--- a/tikv-client/src/main/java/com/pingcap/tikv/types/StringType.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/StringType.java
@@ -96,7 +96,7 @@ public class StringType extends BytesType {
     }
 
     // check utf-8 length of result string
-    if (result.codePointCount(0, result.length() - 1) > this.getLength()) {
+    if (result.codePointCount(0, result.length()) > this.getLength()) {
       throw ConvertOverflowException.newMaxLengthException(result, this.getLength());
     }
 

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/StringType.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/StringType.java
@@ -95,7 +95,8 @@ public class StringType extends BytesType {
       throw new ConvertNotSupportException(value.getClass().getName(), this.getClass().getName());
     }
 
-    if (result.length() > this.getLength()) {
+    // check utf-8 length of result string
+    if (result.codePointCount(0, result.length() - 1) > this.getLength()) {
       throw ConvertOverflowException.newMaxLengthException(result, this.getLength());
     }
 


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
Close #1722 

### What is changed, and how it works?
Use `codePointCount()` instead of string length to check string length overflow.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to be included in the release note
