### PR TITLE
Fix DateTime shift before year 1582

### DIFF
--- a/tikv-client/src/main/java/com/pingcap/tikv/codec/RowEncoderV2.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/codec/RowEncoderV2.java
@@ -308,14 +308,14 @@ public class RowEncoderV2 {
   private void encodeTimestamp(CodecDataOutput cdo, Object value, DateTimeZone tz) {
     if (value instanceof Timestamp) {
       Timestamp timestamp = (Timestamp) value;
-      DateTime dateTime = new DateTime(timestamp.getTime());
+      DateTime dateTime = DateTime.parse(timestamp.toLocalDateTime().toString());
       int nanos = timestamp.getNanos();
       ExtendedDateTime extendedDateTime = new ExtendedDateTime(dateTime, (nanos / 1000) % 1000);
       long t = DateTimeCodec.toPackedLong(extendedDateTime, tz);
       encodeInt(cdo, t);
     } else if (value instanceof Date) {
       ExtendedDateTime extendedDateTime =
-          new ExtendedDateTime(new DateTime(((Date) value).getTime()));
+          new ExtendedDateTime(DateTime.parse(((Date) value).toLocalDate().toString()));
       long t = DateTimeCodec.toPackedLong(extendedDateTime, tz);
       encodeInt(cdo, t);
     } else {


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix #1701 

### What is changed, and how it works?
Fix the DateTime shift before the year 1582 due to incorrect usage of DateTime / Timestamp conversion.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Side effects

 - Possible performance regression

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to be included in the release note
