### PR TITLE
BatchWrite: add parameter maxRegionSplitNum

### DIFF
--- a/core/src/main/scala/com/pingcap/tispark/write/TiBatchWrite.scala
+++ b/core/src/main/scala/com/pingcap/tispark/write/TiBatchWrite.scala
@@ -435,9 +435,11 @@ class TiBatchWrite(
     val regionSplitPointNum = if (options.regionSplitNum > 0) {
       options.regionSplitNum
     } else {
-      Math.max(
-        options.minRegionSplitNum,
-        Math.ceil(count.toDouble / options.regionSplitKeys).toInt)
+      Math.min(
+        Math.max(
+          options.minRegionSplitNum,
+          Math.ceil(count.toDouble / options.regionSplitKeys).toInt),
+        options.maxRegionSplitNum)
     }
     logger.info(s"regionSplitPointNum=$regionSplitPointNum")
 
@@ -462,11 +464,9 @@ class TiBatchWrite(
     }
     logger.info(s"splitPointNumUsingSize=$splitPointNumUsingSize")
 
-    val finalRegionSplitPointNum = if (splitPointNumUsingSize < options.minRegionSplitNum) {
-      options.minRegionSplitNum
-    } else {
-      splitPointNumUsingSize
-    }
+    val finalRegionSplitPointNum = Math.min(
+      Math.max(options.minRegionSplitNum, splitPointNumUsingSize),
+      options.maxRegionSplitNum)
     logger.info(s"finalRegionSplitPointNum=$finalRegionSplitPointNum")
 
     val sortedSampleData = sampleData

--- a/core/src/main/scala/com/pingcap/tispark/write/TiDBOptions.scala
+++ b/core/src/main/scala/com/pingcap/tispark/write/TiDBOptions.scala
@@ -94,6 +94,7 @@ class TiDBOptions(@transient val parameters: CaseInsensitiveMap[String]) extends
   val scatterWaitMS: Int = getOrDefault(TIDB_SCATTER_WAIT_MS, "300000").toInt
   val regionSplitKeys: Int = getOrDefault(TIDB_REGION_SPLIT_KEYS, "960000").toInt
   val minRegionSplitNum: Int = getOrDefault(TIDB_MIN_REGION_SPLIT_NUM, "8").toInt
+  val maxRegionSplitNum: Int = getOrDefault(TIDB_MAX_REGION_SPLIT_NUM, "4096").toInt
   val regionSplitThreshold: Int = getOrDefault(TIDB_REGION_SPLIT_THRESHOLD, "100000").toInt
   val splitRegionBackoffMS: Int = getOrDefault(TIDB_SPLIT_REGION_BACKOFFER_MS, "120000").toInt
   val scatterRegionBackoffMS: Int = getOrDefault(TIDB_SCATTER_REGION_BACKOFFER_MS, "30000").toInt
@@ -210,6 +211,7 @@ object TiDBOptions {
   val TIDB_SCATTER_WAIT_MS: String = newOption("scatterWaitMS")
   val TIDB_REGION_SPLIT_KEYS: String = newOption("regionSplitKeys")
   val TIDB_MIN_REGION_SPLIT_NUM: String = newOption("minRegionSplitNum")
+  val TIDB_MAX_REGION_SPLIT_NUM: String = newOption("maxRegionSplitNum")
   val TIDB_REGION_SPLIT_THRESHOLD: String = newOption("regionSplitThreshold")
   val TIDB_SPLIT_REGION_BACKOFFER_MS: String = newOption("splitRegionBackoffMS")
   val TIDB_SCATTER_REGION_BACKOFFER_MS: String = newOption("scatterRegionBackoffMS")


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
too many regions will be split if inserting more than one Billion rows

### What is changed and how it works?
add parameter `maxRegionSplitNum`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `tidb-ansible` repository
 - Need to be included in the release note
