### PR TITLE
fix maven-shade-plugin relocation cannot handle folder name with dot

### DIFF
--- a/assembly/src/main/assembly/assembly.xml
+++ b/assembly/src/main/assembly/assembly.xml
@@ -23,7 +23,7 @@
             <directory>
                 ${project.parent.basedir}/spark-wrapper/spark-2.3/target/classes/
             </directory>
-            <outputDirectory>resources/spark-wrapper-spark-2.3</outputDirectory>
+            <outputDirectory>resources/spark-wrapper-spark-2_3</outputDirectory>
             <includes>
                 <include>**/*</include>
             </includes>
@@ -32,7 +32,7 @@
             <directory>
                 ${project.parent.basedir}/spark-wrapper/spark-2.4/target/classes/
             </directory>
-            <outputDirectory>resources/spark-wrapper-spark-2.4</outputDirectory>
+            <outputDirectory>resources/spark-wrapper-spark-2_4</outputDirectory>
             <includes>
                 <include>**/*</include>
             </includes>

--- a/core/src/main/scala/com/pingcap/tispark/utils/ReflectionUtil.scala
+++ b/core/src/main/scala/com/pingcap/tispark/utils/ReflectionUtil.scala
@@ -64,7 +64,8 @@ object ReflectionUtil {
       classDir.toURI.toURL
     } else {
       new URL(
-        s"jar:$tisparkClassUrl!/resources/spark-wrapper-spark-${TiSparkInfo.SPARK_MAJOR_VERSION}/")
+        s"jar:$tisparkClassUrl!/resources/spark-wrapper-spark-${TiSparkInfo.SPARK_MAJOR_VERSION
+          .replace('.', '_')}/")
     }
     logger.info(s"spark wrapper class url: ${sparkWrapperClassURL.toString}")
 


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
`maven-shade-plugin`'s `relocation` cannot handle folder name with dot

```
<plugin>
                <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-shade-plugin</artifactId>
                <version>3.2.4</version>
                <executions>
                    <execution>
                        <phase>package</phase>
                        <goals>
                            <goal>shade</goal>
                        </goals>
                        <configuration>
                            <relocations>
                                <relocation>
                                    <pattern>com.pingcap.tispark</pattern>
                                    <shadedPattern>com.pingcap.tispark2</shadedPattern>
                                </relocation>
                            </relocations>
                        </configuration>
                    </execution>
                </executions>
            </plugin>
```

### What is changed and how it works?
replace `resources/spark-wrapper-spark-2.3` with `resources/spark-wrapper-spark-2_3`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `tidb-ansible` repository
 - Need to be included in the release note
