### PR TITLE
support Async Commit: update resolve lock logic

### DIFF
--- a/tikv-client/scripts/proto.sh
+++ b/tikv-client/scripts/proto.sh
@@ -18,11 +18,11 @@ CURRENT_DIR=`pwd`
 TISPARK_HOME="$(cd "`dirname "$0"`"/../..; pwd)"
 cd $TISPARK_HOME/tikv-client
 
-kvproto_hash=2cf9a243b8d589f345de1dbaa9eeffec6afbdc06
+kvproto_hash=e6d6090277c921c3291c48c5bc8fb38907c852d0
 
 raft_rs_hash=b9891b673573fad77ebcf9bbe0969cf945841926
 
-tipb_hash=c4d518eb1d60c21f05b028b36729e64610346dac
+tipb_hash=45e60c77588fefe421d0f6f29426a36b5b15171d
 
 if [ -d "kvproto" ]; then
 	cd kvproto; git fetch -p; git checkout ${kvproto_hash}; cd ..

--- a/tikv-client/src/main/java/com/pingcap/tikv/TwoPhaseCommitter.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/TwoPhaseCommitter.java
@@ -32,7 +32,6 @@ import com.pingcap.tikv.util.ConcreteBackOffer;
 import com.pingcap.tikv.util.Pair;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
@@ -333,7 +332,7 @@ public class TwoPhaseCommitter {
     }
 
     // groups keys by region
-    GroupKeyResult groupResult = this.groupKeysByRegion(keys, size, backOffer);
+    GroupKeyResult groupResult = Utils.groupKeysByRegion(this.regionManager, keys, size, backOffer);
     List<BatchKeys> batchKeyList = new LinkedList<>();
     Map<Pair<TiRegion, Metapb.Store>, List<ByteString>> groupKeyMap = groupResult.getGroupsResult();
 
@@ -568,7 +567,7 @@ public class TwoPhaseCommitter {
     }
 
     // groups keys by region
-    GroupKeyResult groupResult = this.groupKeysByRegion(keys, size, backOffer);
+    GroupKeyResult groupResult = Utils.groupKeysByRegion(this.regionManager, keys, size, backOffer);
     List<BatchKeys> batchKeyList = new ArrayList<>();
     Map<Pair<TiRegion, Metapb.Store>, List<ByteString>> groupKeyMap = groupResult.getGroupsResult();
 
@@ -610,27 +609,6 @@ public class TwoPhaseCommitter {
         batchKeys.getKeys().size(),
         batchKeys.getSizeInKB(),
         batchKeys.getRegion().getId());
-  }
-
-  private GroupKeyResult groupKeysByRegion(ByteString[] keys, int size, BackOffer backOffer)
-      throws TiBatchWriteException {
-    Map<Pair<TiRegion, Metapb.Store>, List<ByteString>> groups = new HashMap<>();
-    int index = 0;
-    try {
-      for (; index < size; index++) {
-        ByteString key = keys[index];
-        Pair<TiRegion, Metapb.Store> pair =
-            this.regionManager.getRegionStorePairByKey(key, backOffer);
-        if (pair != null) {
-          groups.computeIfAbsent(pair, e -> new ArrayList<>()).add(key);
-        }
-      }
-    } catch (Exception e) {
-      throw new TiBatchWriteException("Txn groupKeysByRegion error", e);
-    }
-    GroupKeyResult result = new GroupKeyResult();
-    result.setGroupsResult(groups);
-    return result;
   }
 
   private long getTxnLockTTL(long startTime) {

--- a/tikv-client/src/main/java/com/pingcap/tikv/Utils.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/Utils.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pingcap.tikv;
+
+import com.google.protobuf.ByteString;
+import com.pingcap.tikv.exception.TiBatchWriteException;
+import com.pingcap.tikv.region.RegionManager;
+import com.pingcap.tikv.region.TiRegion;
+import com.pingcap.tikv.txn.type.GroupKeyResult;
+import com.pingcap.tikv.util.BackOffer;
+import com.pingcap.tikv.util.Pair;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.tikv.kvproto.Metapb;
+
+public class Utils {
+  public static GroupKeyResult groupKeysByRegion(
+      RegionManager regionManager, List<ByteString> keys, BackOffer backOffer) {
+    return groupKeysByRegion(
+        regionManager, keys.toArray(new ByteString[0]), keys.size(), backOffer);
+  }
+
+  public static GroupKeyResult groupKeysByRegion(
+      RegionManager regionManager, ByteString[] keys, int size, BackOffer backOffer)
+      throws TiBatchWriteException {
+    Map<Pair<TiRegion, Metapb.Store>, List<ByteString>> groups = new HashMap<>();
+    int index = 0;
+    try {
+      for (; index < size; index++) {
+        ByteString key = keys[index];
+        Pair<TiRegion, Metapb.Store> pair = regionManager.getRegionStorePairByKey(key, backOffer);
+        if (pair != null) {
+          groups.computeIfAbsent(pair, e -> new ArrayList<>()).add(key);
+        }
+      }
+    } catch (Exception e) {
+      throw new TiBatchWriteException("Txn groupKeysByRegion error", e);
+    }
+    GroupKeyResult result = new GroupKeyResult();
+    result.setGroupsResult(groups);
+    return result;
+  }
+}

--- a/tikv-client/src/main/java/com/pingcap/tikv/exception/ResolveLockException.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/exception/ResolveLockException.java
@@ -1,5 +1,4 @@
 /*
- *
  * Copyright 2020 PingCAP, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,21 +11,20 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
-package com.pingcap.tikv;
+package com.pingcap.tikv.exception;
 
-public class Version {
-  public static final String RESOLVE_LOCK_V2 = "2.0.0";
+public class ResolveLockException extends RuntimeException {
+  public ResolveLockException(Exception e) {
+    super(e);
+  }
 
-  public static final String RESOLVE_LOCK_V3 = "3.0.5";
+  public ResolveLockException(String msg) {
+    super(msg);
+  }
 
-  public static final String RESOLVE_LOCK_V4 = "4.0.0";
-
-  public static final String BATCH_WRITE = "3.0.14";
-
-  public static final String NEW_ROW_FORMAT = "4.0.0";
-
-  public static final String ASYNC_COMMIT = "4.1.0";
+  public ResolveLockException(String msg, Exception e) {
+    super(msg, e);
+  }
 }

--- a/tikv-client/src/main/java/com/pingcap/tikv/region/RegionStoreClient.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/region/RegionStoreClient.java
@@ -395,19 +395,6 @@ public class RegionStoreClient extends AbstractRegionStoreClient {
     this.prewrite(backOffer, primary, mutations, startTs, lockTTL, false, false, null);
   }
 
-  public void prewrite(
-      BackOffer backOffer,
-      ByteString primary,
-      Iterable<Mutation> mutations,
-      long startTs,
-      long lockTTL,
-      boolean useAsyncCommit,
-      Iterable<ByteString> secondaries)
-      throws TiClientInternalException, KeyException, RegionException {
-    this.prewrite(
-        backOffer, primary, mutations, startTs, lockTTL, false, useAsyncCommit, secondaries);
-  }
-
   /**
    * Prewrite batch keys
    *

--- a/tikv-client/src/main/java/com/pingcap/tikv/region/RegionStoreClient.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/region/RegionStoreClient.java
@@ -392,7 +392,20 @@ public class RegionStoreClient extends AbstractRegionStoreClient {
       long startTs,
       long lockTTL)
       throws TiClientInternalException, KeyException, RegionException {
-    this.prewrite(backOffer, primary, mutations, startTs, lockTTL, false);
+    this.prewrite(backOffer, primary, mutations, startTs, lockTTL, false, false, null);
+  }
+
+  public void prewrite(
+      BackOffer backOffer,
+      ByteString primary,
+      Iterable<Mutation> mutations,
+      long startTs,
+      long lockTTL,
+      boolean useAsyncCommit,
+      Iterable<ByteString> secondaries)
+      throws TiClientInternalException, KeyException, RegionException {
+    this.prewrite(
+        backOffer, primary, mutations, startTs, lockTTL, false, useAsyncCommit, secondaries);
   }
 
   /**
@@ -406,33 +419,37 @@ public class RegionStoreClient extends AbstractRegionStoreClient {
       Iterable<Mutation> mutations,
       long startTs,
       long ttl,
-      boolean skipConstraintCheck)
+      boolean skipConstraintCheck,
+      boolean useAsyncCommit,
+      Iterable<ByteString> secondaries)
       throws TiClientInternalException, KeyException, RegionException {
     boolean forWrite = true;
     while (true) {
       Supplier<PrewriteRequest> factory =
-          () ->
-              getIsV4()
-                  ? PrewriteRequest.newBuilder()
-                      .setContext(region.getContext())
-                      .setStartVersion(startTs)
-                      .setPrimaryLock(primaryLock)
-                      .addAllMutations(mutations)
-                      .setLockTtl(ttl)
-                      .setSkipConstraintCheck(skipConstraintCheck)
-                      .setMinCommitTs(startTs)
-                      .setTxnSize(16)
-                      .build()
-                  : PrewriteRequest.newBuilder()
-                      .setContext(region.getContext())
-                      .setStartVersion(startTs)
-                      .setPrimaryLock(primaryLock)
-                      .addAllMutations(mutations)
-                      .setLockTtl(ttl)
-                      .setSkipConstraintCheck(skipConstraintCheck)
-                      // v3 does not support setMinCommitTs(startTs)
-                      .setTxnSize(16)
-                      .build();
+          () -> {
+            PrewriteRequest.Builder builder =
+                PrewriteRequest.newBuilder()
+                    .setContext(region.getContext())
+                    .setStartVersion(startTs)
+                    .setPrimaryLock(primaryLock)
+                    .addAllMutations(mutations)
+                    .setLockTtl(ttl)
+                    .setSkipConstraintCheck(skipConstraintCheck)
+                    .setTxnSize(16);
+
+            if (getIsV4()) {
+              builder.setMinCommitTs(startTs);
+            }
+
+            if (useAsyncCommit) {
+              builder.setUseAsyncCommit(true);
+
+              if (secondaries != null) {
+                builder.addAllSecondaries(secondaries);
+              }
+            }
+            return builder.build();
+          };
       KVErrorHandler<PrewriteResponse> handler =
           new KVErrorHandler<>(
               regionManager,

--- a/tikv-client/src/main/java/com/pingcap/tikv/region/TiRegion.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/region/TiRegion.java
@@ -90,7 +90,7 @@ public class TiRegion implements Serializable {
   public List<Peer> getLearnerList() {
     List<Peer> peers = new ArrayList<>();
     for (Peer peer : getMeta().getPeersList()) {
-      if (peer.getIsLearner()) {
+      if (peer.getRole().equals(Metapb.PeerRole.Learner)) {
         peers.add(peer);
       }
     }

--- a/tikv-client/src/main/java/com/pingcap/tikv/txn/AsyncResolveData.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/txn/AsyncResolveData.java
@@ -1,0 +1,123 @@
+/*
+ *
+ * Copyright 2020 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.pingcap.tikv.txn;
+
+import com.google.protobuf.ByteString;
+import com.pingcap.tikv.exception.ResolveLockException;
+import java.util.ArrayList;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.tikv.kvproto.Kvrpcpb;
+
+public class AsyncResolveData {
+  private static final Logger LOG = LoggerFactory.getLogger(AsyncResolveData.class);
+
+  /**
+   * If any key has been committed (missingLock is true), then this is the commit ts. In that case,
+   * all locks should be committed with the same commit timestamp. If no locks have been committed
+   * (missingLock is false), then we will use max(all min commit ts) from all locks; i.e., it is the
+   * commit ts we should use. Note that a secondary lock's commit ts may or may not be the same as
+   * the primary lock's min commit ts.
+   */
+  private long commitTs;
+
+  private List<ByteString> keys;
+  private boolean missingLock;
+
+  public AsyncResolveData(long commitTs, List<ByteString> keys, boolean missingLock) {
+    this.commitTs = commitTs;
+    this.keys = keys;
+    this.missingLock = missingLock;
+  }
+
+  public long getCommitTs() {
+    return commitTs;
+  }
+
+  public List<ByteString> getKeys() {
+    return keys;
+  }
+
+  public synchronized void appendKey(ByteString key) {
+    ArrayList<ByteString> newKeys = new ArrayList<>(this.getKeys());
+    newKeys.add(key);
+    this.keys = newKeys;
+  }
+
+  /**
+   * addKeys adds the keys from locks to data, keeping other fields up to date. startTS and commitTS
+   * are for the transaction being resolved.
+   *
+   * <p>In the async commit protocol when checking locks, we send a list of keys to check and get
+   * back a list of locks. There will be a lock for every key which is locked. If there are fewer
+   * locks than keys, then a lock is missing because it has been committed, rolled back, or was
+   * never locked.
+   *
+   * <p>In this function, locks is the list of locks, and expected is the number of keys.
+   * asyncResolveData.missingLock will be set to true if the lengths don't match. If the lengths do
+   * match, then the locks are added to asyncResolveData.locks and will need to be resolved by the
+   * caller.
+   */
+  public synchronized void addKeys(
+      List<Kvrpcpb.LockInfo> locks, int expected, long startTs, long commitTs)
+      throws ResolveLockException {
+    if (locks.size() < expected) {
+      LOG.debug(
+          String.format(
+              "addKeys: lock has been committed or rolled back, startTs=%d, commitTs=%d",
+              startTs, commitTs));
+
+      if (!this.missingLock) {
+        // commitTS == 0 => lock has been rolled back.
+        if (commitTs != 0 && commitTs < this.commitTs) {
+          throw new ResolveLockException(
+              String.format(
+                  "commit TS must be greater or equal to min commit TS, commitTs=%d, minCommitTs=%d",
+                  commitTs, this.commitTs));
+        }
+        this.commitTs = commitTs;
+      }
+      this.missingLock = true;
+
+      if (this.commitTs != commitTs) {
+        throw new ResolveLockException(
+            String.format(
+                "commit TS mismatch in async commit recovery: %d and %d", this.commitTs, commitTs));
+      }
+      // We do not need to resolve the remaining locks because TiKV will have resolved them as
+      // appropriate.
+    } else {
+      LOG.debug(String.format("addKeys: all locks present, startTs=%d", startTs));
+
+      // Save all locks to be resolved.
+      for (Kvrpcpb.LockInfo lockInfo : locks) {
+        if (lockInfo.getLockVersion() != startTs) {
+          throw new ResolveLockException(
+              String.format(
+                  "unexpected timestamp, expected: %d, found: %d",
+                  startTs, lockInfo.getLockVersion()));
+        }
+        if (!this.missingLock && lockInfo.getMinCommitTs() > this.commitTs) {
+          this.commitTs = lockInfo.getMinCommitTs();
+        }
+        this.appendKey(lockInfo.getKey());
+      }
+    }
+  }
+}

--- a/tikv-client/src/main/java/com/pingcap/tikv/txn/Lock.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/txn/Lock.java
@@ -28,7 +28,9 @@ public class Lock {
   private final ByteString primary;
   private final long txnSize;
   private final Kvrpcpb.Op lockType;
+  private final boolean useAsyncCommit;
   private final long lockForUpdateTs;
+  private final long minCommitTS;
 
   public Lock(Kvrpcpb.LockInfo l) {
     txnID = l.getLockVersion();
@@ -37,7 +39,9 @@ public class Lock {
     ttl = l.getLockTtl() == 0 ? DEFAULT_LOCK_TTL : l.getLockTtl();
     txnSize = l.getTxnSize();
     lockType = l.getLockType();
+    useAsyncCommit = l.getUseAsyncCommit();
     lockForUpdateTs = l.getLockForUpdateTs();
+    minCommitTS = l.getMinCommitTs();
   }
 
   public long getTxnID() {
@@ -66,5 +70,13 @@ public class Lock {
 
   public long getLockForUpdateTs() {
     return lockForUpdateTs;
+  }
+
+  public boolean isUseAsyncCommit() {
+    return useAsyncCommit;
+  }
+
+  public long getMinCommitTS() {
+    return minCommitTS;
   }
 }

--- a/tikv-client/src/main/java/com/pingcap/tikv/txn/TxnStatus.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/txn/TxnStatus.java
@@ -30,29 +30,41 @@ public class TxnStatus {
   private long ttl;
   private long commitTS;
   private Kvrpcpb.Action action;
+  private Kvrpcpb.LockInfo primaryLock;
 
   public TxnStatus() {
     this.ttl = 0L;
     this.commitTS = 0L;
     this.action = Kvrpcpb.Action.UNRECOGNIZED;
+    this.primaryLock = null;
   }
 
   public TxnStatus(long ttl) {
     this.ttl = ttl;
     this.commitTS = 0L;
     this.action = Kvrpcpb.Action.UNRECOGNIZED;
+    this.primaryLock = null;
   }
 
   public TxnStatus(long ttl, long commitTS) {
     this.ttl = ttl;
     this.commitTS = commitTS;
     this.action = Kvrpcpb.Action.UNRECOGNIZED;
+    this.primaryLock = null;
   }
 
   public TxnStatus(long ttl, long commitTS, Kvrpcpb.Action action) {
     this.ttl = ttl;
     this.commitTS = commitTS;
     this.action = action;
+    this.primaryLock = null;
+  }
+
+  public TxnStatus(long ttl, long commitTS, Kvrpcpb.Action action, Kvrpcpb.LockInfo primaryLock) {
+    this.ttl = ttl;
+    this.commitTS = commitTS;
+    this.action = action;
+    this.primaryLock = primaryLock;
   }
 
   public long getTtl() {
@@ -81,5 +93,13 @@ public class TxnStatus {
 
   public void setAction(Kvrpcpb.Action action) {
     this.action = action;
+  }
+
+  public Kvrpcpb.LockInfo getPrimaryLock() {
+    return primaryLock;
+  }
+
+  public void setPrimaryLock(Kvrpcpb.LockInfo primaryLock) {
+    this.primaryLock = primaryLock;
   }
 }

--- a/tikv-client/src/test/java/com/pingcap/tikv/txn/LockResolverAsyncCommitTest.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/txn/LockResolverAsyncCommitTest.java
@@ -1,0 +1,381 @@
+/*
+ * Copyright 2020 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pingcap.tikv.txn;
+
+import static junit.framework.Assert.assertTrue;
+import static junit.framework.TestCase.assertEquals;
+
+import com.google.protobuf.ByteString;
+import com.pingcap.tikv.Version;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.Assert;
+import org.junit.Test;
+import org.tikv.kvproto.Kvrpcpb.IsolationLevel;
+
+public class LockResolverAsyncCommitTest extends LockResolverTest {
+
+  private final int ASYNC_COMMIT_TTL = 3000;
+
+  private final String oldValue = "o";
+  private final String primaryKeyValue = "v";
+  private final String[] secondaryKeyValueList = {"v0", "v1", "v2", "v3", "v4", "v5", "6", "v7"};
+  private final int secondarySize = secondaryKeyValueList.length;
+
+  public LockResolverAsyncCommitTest() {
+    super(IsolationLevel.SI);
+  }
+
+  @Test
+  public void prewriteCommitTest() {
+    if (!check()) {
+      return;
+    }
+
+    String primaryKey = genRandomKey(64);
+    List<String> secondaryKeyList = randomSecondaryKeyList();
+
+    // put
+    putAll(primaryKey, secondaryKeyList);
+
+    // prewrite keys
+    long startTs = session.getTimestamp().getVersion();
+    prewrite(startTs, primaryKey, secondaryKeyList);
+
+    // commitString primary key
+    long endTs = session.getTimestamp().getVersion();
+    assertTrue(commitString(Collections.singletonList(primaryKey), startTs, endTs));
+
+    // commitString secondary key
+    for (int i = 0; i < secondarySize; i++) {
+      assertTrue(commitString(Collections.singletonList(secondaryKeyList.get(i)), startTs, endTs));
+    }
+
+    // get check primary key & secondary key
+    assertEquals(pointGet(primaryKey), primaryKeyValue);
+    for (int i = 0; i < secondarySize; i++) {
+      assertEquals(pointGet(secondaryKeyList.get(i)), secondaryKeyValueList[i]);
+    }
+  }
+
+  @Test
+  public void prewriteWithoutCommitSecondaryTest() {
+    if (!check()) {
+      return;
+    }
+
+    String primaryKey = genRandomKey(64);
+    List<String> secondaryKeyList = randomSecondaryKeyList();
+
+    // put
+    putAll(primaryKey, secondaryKeyList);
+
+    // prewrite keys
+    long startTs = session.getTimestamp().getVersion();
+    prewrite(startTs, primaryKey, secondaryKeyList);
+
+    // commitString primary key
+    long endTs = session.getTimestamp().getVersion();
+    assertTrue(commitString(Collections.singletonList(primaryKey), startTs, endTs));
+
+    for (int i = 0; i < secondarySize; i++) {
+      if (i % 2 == 0) {
+        // skip commitString secondary key
+      } else {
+        // commitString secondary key
+        assertTrue(
+            commitString(Collections.singletonList(secondaryKeyList.get(i)), startTs, endTs));
+      }
+    }
+
+    // get check primary key & secondary key
+    for (int i = 0; i < secondarySize; i++) {
+      assertEquals(pointGet(secondaryKeyList.get(i)), secondaryKeyValueList[i]);
+    }
+    assertEquals(pointGet(primaryKey), primaryKeyValue);
+  }
+
+  @Test
+  public void prewriteWithoutCommitPrimaryTest() {
+    if (!check()) {
+      return;
+    }
+
+    String primaryKey = genRandomKey(64);
+    List<String> secondaryKeyList = randomSecondaryKeyList();
+
+    // put
+    putAll(primaryKey, secondaryKeyList);
+
+    // prewrite keys
+    long startTs = session.getTimestamp().getVersion();
+    prewrite(startTs, primaryKey, secondaryKeyList);
+
+    long endTs = session.getTimestamp().getVersion();
+
+    // skip commitString primary key
+
+    // commitString secondary key
+    for (int i = 0; i < secondarySize; i++) {
+      assertTrue(commitString(Collections.singletonList(secondaryKeyList.get(i)), startTs, endTs));
+    }
+
+    // get check primary key & secondary key
+    for (int i = 0; i < secondarySize; i++) {
+      assertEquals(pointGet(secondaryKeyList.get(i)), secondaryKeyValueList[i]);
+    }
+    assertEquals(pointGet(primaryKey), primaryKeyValue);
+  }
+
+  @Test
+  public void prewriteWithCommitSomeSecondaryTest() {
+    if (!check()) {
+      return;
+    }
+
+    String primaryKey = genRandomKey(64);
+    List<String> secondaryKeyList = randomSecondaryKeyList();
+
+    // put
+    putAll(primaryKey, secondaryKeyList);
+
+    // prewrite keys
+    long startTs = session.getTimestamp().getVersion();
+    prewrite(startTs, primaryKey, secondaryKeyList);
+
+    long endTs = session.getTimestamp().getVersion();
+
+    // skip commitString primary key
+
+    for (int i = 0; i < secondarySize; i++) {
+      if (i % 2 == 0) {
+        // commitString secondary key
+        assertTrue(
+            commitString(Collections.singletonList(secondaryKeyList.get(i)), startTs, endTs));
+      } else {
+        // skip commitString secondary key
+      }
+    }
+
+    // get check primary key & secondary key
+    for (int i = 0; i < secondarySize; i++) {
+      assertEquals(pointGet(secondaryKeyList.get(i)), secondaryKeyValueList[i]);
+    }
+    assertEquals(pointGet(primaryKey), primaryKeyValue);
+  }
+
+  @Test
+  public void prewriteWithoutCommitAllTest() {
+    if (!check()) {
+      return;
+    }
+
+    String primaryKey = genRandomKey(64);
+    List<String> secondaryKeyList = randomSecondaryKeyList();
+
+    // put
+    putAll(primaryKey, secondaryKeyList);
+
+    // prewrite keys
+    long startTs = session.getTimestamp().getVersion();
+    prewrite(startTs, primaryKey, secondaryKeyList);
+
+    // skip commitString primary key
+
+    // skip commitString secondary key
+
+    // get check primary key & secondary key
+    assertEquals(pointGet(primaryKey), primaryKeyValue);
+    for (int i = 0; i < secondarySize; i++) {
+      assertEquals(pointGet(secondaryKeyList.get(i)), secondaryKeyValueList[i]);
+    }
+  }
+
+  @Test
+  public void prewriteWtihoutSecondaryKeyTest() {
+    if (!check()) {
+      return;
+    }
+
+    String primaryKey = genRandomKey(64);
+    List<String> secondaryKeyList = randomSecondaryKeyList();
+
+    List<ByteString> secondaries =
+        secondaryKeyList.stream().map(ByteString::copyFromUtf8).collect(Collectors.toList());
+
+    // put
+    putAll(primaryKey, secondaryKeyList);
+
+    // prewriteString <primary key, value1, secondaries>
+    long startTs = session.getTimestamp().getVersion();
+    Assert.assertTrue(
+        prewriteStringUsingAsyncCommit(
+            primaryKey, primaryKeyValue, startTs, primaryKey, ASYNC_COMMIT_TTL, secondaries));
+
+    for (int i = 0; i < secondaryKeyList.size(); i++) {
+      if (i == secondarySize - 1) {
+        // skip prewriteString secondary key
+      } else {
+        // prewriteString secondary key
+        Assert.assertTrue(
+            prewriteStringUsingAsyncCommit(
+                secondaryKeyList.get(i),
+                secondaryKeyValueList[i],
+                startTs,
+                primaryKey,
+                ASYNC_COMMIT_TTL,
+                null));
+      }
+    }
+
+    // skip commitString primary key
+
+    // skip commitString secondary key
+
+    // get check primary key & secondary key
+    for (int i = 0; i < secondarySize; i++) {
+      assertEquals(pointGet(secondaryKeyList.get(i)), oldValue);
+    }
+    assertEquals(pointGet(primaryKey), oldValue);
+  }
+
+  @Test
+  public void prewriteWtihoutPrimaryKeyTest() {
+    if (!check()) {
+      return;
+    }
+
+    String primaryKey = genRandomKey(64);
+    List<String> secondaryKeyList = randomSecondaryKeyList();
+
+    // put
+    putAll(primaryKey, secondaryKeyList);
+
+    // skip prewriteString <primary key, value1, secondaries>
+
+    // prewriteString secondary key
+    long startTs = session.getTimestamp().getVersion();
+    for (int i = 0; i < secondaryKeyList.size(); i++) {
+      Assert.assertTrue(
+          prewriteStringUsingAsyncCommit(
+              secondaryKeyList.get(i),
+              secondaryKeyValueList[i],
+              startTs,
+              primaryKey,
+              ASYNC_COMMIT_TTL,
+              null));
+    }
+
+    // skip commitString primary key
+
+    // skip commitString secondary key
+
+    // get check primary key & secondary key
+    for (int i = 0; i < secondarySize; i++) {
+      assertEquals(pointGet(secondaryKeyList.get(i)), oldValue);
+    }
+    assertEquals(pointGet(primaryKey), oldValue);
+  }
+
+  @Test
+  public void ttlExpiredTest() throws InterruptedException {
+    if (!check()) {
+      return;
+    }
+
+    String primaryKey = genRandomKey(64);
+    List<String> secondaryKeyList = randomSecondaryKeyList();
+
+    // put
+    putAll(primaryKey, secondaryKeyList);
+
+    // prewrite keys
+    long startTs = session.getTimestamp().getVersion();
+    prewrite(startTs, primaryKey, secondaryKeyList);
+
+    // sleep
+    Thread.sleep(ASYNC_COMMIT_TTL);
+
+    // skip commitString primary key
+
+    // skip commitString secondary key
+
+    // get check primary key & secondary key
+    assertEquals(pointGet(primaryKey), primaryKeyValue);
+    for (int i = 0; i < secondarySize; i++) {
+      assertEquals(pointGet(secondaryKeyList.get(i)), secondaryKeyValueList[i]);
+    }
+  }
+
+  private boolean check() {
+    if (!init) {
+      skipTestInit();
+      return false;
+    }
+
+    if (!supportAsyncCommit()) {
+      logger.warn("Test skipped due to version of TiDB/TiKV should be " + Version.ASYNC_COMMIT);
+      return false;
+    }
+
+    return true;
+  }
+
+  private List<String> randomSecondaryKeyList() {
+    List<String> secondaryKeyList = new ArrayList<>();
+    for (int i = 0; i < secondarySize; i++) {
+      if (i % 3 == 0) {
+        secondaryKeyList.add("a-" + i + "-" + genRandomKey(64));
+      } else if (i % 3 == 1) {
+        secondaryKeyList.add("j-" + i + "-" + genRandomKey(64));
+      } else {
+        secondaryKeyList.add("z-" + i + "-" + genRandomKey(64));
+      }
+    }
+    return secondaryKeyList;
+  }
+
+  private void putAll(String primaryKey, List<String> secondaryKeyList) {
+    putKV(primaryKey, oldValue);
+    for (String secondaryKey : secondaryKeyList) {
+      putKV(secondaryKey, oldValue);
+    }
+  }
+
+  private void prewrite(long startTs, String primaryKey, List<String> secondaryKeyList) {
+    List<ByteString> secondaries =
+        secondaryKeyList.stream().map(ByteString::copyFromUtf8).collect(Collectors.toList());
+
+    // prewriteString <primary key, value1, secondaries>
+    Assert.assertTrue(
+        prewriteStringUsingAsyncCommit(
+            primaryKey, primaryKeyValue, startTs, primaryKey, ASYNC_COMMIT_TTL, secondaries));
+
+    // prewriteString secondaryKeys
+    for (int i = 0; i < secondaryKeyList.size(); i++) {
+      Assert.assertTrue(
+          prewriteStringUsingAsyncCommit(
+              secondaryKeyList.get(i),
+              secondaryKeyValueList[i],
+              startTs,
+              primaryKey,
+              ASYNC_COMMIT_TTL,
+              null));
+    }
+  }
+}

--- a/tikv-client/src/test/java/com/pingcap/tikv/txn/LockResolverTest.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/txn/LockResolverTest.java
@@ -170,6 +170,7 @@ abstract class LockResolverTest {
               Collections.singletonList(m),
               startTS,
               ttl,
+              false,
               useAsyncCommit,
               secondaries);
           break;


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
close https://github.com/pingcap/tispark/issues/1733

tidb-5.0 will support `Async Commit`, tispark should update the resolve lock logic.

### What is changed and how it works?

update tikv-java-client's resolve lock logic according to tidb's code (https://github.com/pingcap/tidb/pull/18467).

design documents:
https://github.com/tikv/sig-transaction/issues/60
https://github.com/tikv/sig-transaction/tree/master/design/async-commit


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `tidb-ansible` repository
 - Need to be included in the release note
