### PR TITLE
Fix enum insert with trailing spaces

### DIFF
--- a/core/src/main/scala/com/pingcap/tispark/TiDBUtils.scala
+++ b/core/src/main/scala/com/pingcap/tispark/TiDBUtils.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.execution.datasources.jdbc.{DriverRegistry, DriverWr
 import scala.util.Try
 
 object TiDBUtils {
-  private val TIDB_DRIVER_CLASS = "com.mysql.jdbc.Driver"
+  val TIDB_DRIVER_CLASS = "com.mysql.jdbc.Driver"
 
   /**
    * Returns true if the table already exists in the TiDB.

--- a/core/src/test/scala/com/pingcap/tispark/convert/ToBitSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/convert/ToBitSuite.scala
@@ -78,7 +78,7 @@ class ToBitSuite extends BaseBatchWriteTest("test_data_type_convert_to_bit") {
         // insert rows
         writeFunc(List(row1, row2, row3, row4, row5), schema, None)
         compareTiDBSelectWithJDBC(
-          Seq(readRow1, readRow2, readRow3, readRow4, readRow5),
+          List(readRow1, readRow2, readRow3, readRow4, readRow5),
           readSchema)
     }
   }
@@ -113,7 +113,7 @@ class ToBitSuite extends BaseBatchWriteTest("test_data_type_convert_to_bit") {
 
         // insert rows
         writeFunc(List(row1, row2, row3, row4, row5), schema, None)
-        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5), schema)
+        compareTiDBSelectWithJDBC(List(row1, row2, row3, row4, row5), schema)
     }
   }
 
@@ -147,7 +147,7 @@ class ToBitSuite extends BaseBatchWriteTest("test_data_type_convert_to_bit") {
 
         // insert rows
         writeFunc(List(row1, row2, row3, row4, row5), schema, None)
-        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5), schema)
+        compareTiDBSelectWithJDBC(List(row1, row2, row3, row4, row5), schema)
     }
   }
 
@@ -181,7 +181,7 @@ class ToBitSuite extends BaseBatchWriteTest("test_data_type_convert_to_bit") {
 
         // insert rows
         writeFunc(List(row1, row2, row3, row4, row5), schema, None)
-        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5), schema)
+        compareTiDBSelectWithJDBC(List(row1, row2, row3, row4, row5), schema)
     }
   }
 
@@ -215,7 +215,7 @@ class ToBitSuite extends BaseBatchWriteTest("test_data_type_convert_to_bit") {
 
         // insert rows
         writeFunc(List(row1, row2, row3, row4, row5), schema, None)
-        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5), schema)
+        compareTiDBSelectWithJDBC(List(row1, row2, row3, row4, row5), schema)
     }
   }
 
@@ -250,7 +250,7 @@ class ToBitSuite extends BaseBatchWriteTest("test_data_type_convert_to_bit") {
         // insert rows
         writeFunc(List(row1, row2, row3, row4, row5), schema, None)
         compareTiDBSelectWithJDBC(
-          Seq(readRow1, readRow2, readRow3, readRow4, readRow5),
+          List(readRow1, readRow2, readRow3, readRow4, readRow5),
           readSchema)
     }
   }
@@ -306,7 +306,7 @@ class ToBitSuite extends BaseBatchWriteTest("test_data_type_convert_to_bit") {
         // insert rows
         writeFunc(List(row1, row2, row3, row4, row5), schema, None)
         compareTiDBSelectWithJDBC(
-          Seq(readRow1, readRow2, readRow3, readRow4, readRow5),
+          List(readRow1, readRow2, readRow3, readRow4, readRow5),
           readSchema)
     }
   }

--- a/core/src/test/scala/com/pingcap/tispark/convert/ToBytesSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/convert/ToBytesSuite.scala
@@ -83,7 +83,7 @@ class ToBytesSuite extends BaseBatchWriteTest("test_data_type_convert_to_bytes")
         // TODO: skipTiDBAndExpectedAnswerCheck because spark returns WrappedArray Type
         writeFunc(List(row1, row2, row3, row4, row5), schema, None)
         compareTiDBSelectWithJDBC(
-          Seq(readRow1, readRow2, readRow3, readRow4, readRow5),
+          List(readRow1, readRow2, readRow3, readRow4, readRow5),
           readSchema,
           skipTiDBAndExpectedAnswerCheck = true)
     }
@@ -142,7 +142,7 @@ class ToBytesSuite extends BaseBatchWriteTest("test_data_type_convert_to_bytes")
         // TODO: skipTiDBAndExpectedAnswerCheck because spark returns WrappedArray Type
         writeFunc(List(row1, row2, row3, row4, row5), schema, None)
         compareTiDBSelectWithJDBC(
-          Seq(readRow1, readRow2, readRow3, readRow4, readRow5),
+          List(readRow1, readRow2, readRow3, readRow4, readRow5),
           readSchema,
           skipTiDBAndExpectedAnswerCheck = true)
     }
@@ -201,7 +201,7 @@ class ToBytesSuite extends BaseBatchWriteTest("test_data_type_convert_to_bytes")
         // TODO: skipTiDBAndExpectedAnswerCheck because spark returns WrappedArray Type
         writeFunc(List(row1, row2, row3, row4, row5), schema, None)
         compareTiDBSelectWithJDBC(
-          Seq(readRow1, readRow2, readRow3, readRow4, readRow5),
+          List(readRow1, readRow2, readRow3, readRow4, readRow5),
           readSchema,
           skipTiDBAndExpectedAnswerCheck = true)
     }
@@ -260,7 +260,7 @@ class ToBytesSuite extends BaseBatchWriteTest("test_data_type_convert_to_bytes")
         // TODO: skipTiDBAndExpectedAnswerCheck because spark returns WrappedArray Type
         writeFunc(List(row1, row2, row3, row4, row5), schema, None)
         compareTiDBSelectWithJDBC(
-          Seq(readRow1, readRow2, readRow3, readRow4, readRow5),
+          List(readRow1, readRow2, readRow3, readRow4, readRow5),
           readSchema,
           skipTiDBAndExpectedAnswerCheck = true)
     }
@@ -319,7 +319,7 @@ class ToBytesSuite extends BaseBatchWriteTest("test_data_type_convert_to_bytes")
         // TODO: skipTiDBAndExpectedAnswerCheck because spark returns WrappedArray Type
         writeFunc(List(row1, row2, row3, row4, row5), schema, None)
         compareTiDBSelectWithJDBC(
-          Seq(readRow1, readRow2, readRow3, readRow4, readRow5),
+          List(readRow1, readRow2, readRow3, readRow4, readRow5),
           readSchema,
           skipTiDBAndExpectedAnswerCheck = true)
     }
@@ -378,7 +378,7 @@ class ToBytesSuite extends BaseBatchWriteTest("test_data_type_convert_to_bytes")
         // TODO: skipTiDBAndExpectedAnswerCheck because spark returns WrappedArray Type
         writeFunc(List(row1, row2, row3, row4, row5), schema, None)
         compareTiDBSelectWithJDBC(
-          Seq(readRow1, readRow2, readRow3, readRow4, readRow5),
+          List(readRow1, readRow2, readRow3, readRow4, readRow5),
           readSchema,
           skipTiDBAndExpectedAnswerCheck = true)
     }

--- a/core/src/test/scala/com/pingcap/tispark/convert/ToDateSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/convert/ToDateSuite.scala
@@ -66,7 +66,7 @@ class ToDateSuite extends BaseBatchWriteTest("test_data_type_convert_to_date") {
 
         // insert rows
         writeFunc(List(row1, row2), schema, None)
-        compareTiDBSelectWithJDBC(Seq(readRow1, readRow2), readSchema)
+        compareTiDBSelectWithJDBC(List(readRow1, readRow2), readSchema)
       case (writeFunc, "jdbcWrite") =>
       //ignored, because of this error
       //java.sql.BatchUpdateException: Data truncation: invalid time format: '34'
@@ -95,7 +95,7 @@ class ToDateSuite extends BaseBatchWriteTest("test_data_type_convert_to_date") {
 
         // insert rows
         writeFunc(List(row1, row2), schema, None)
-        compareTiDBSelectWithJDBC(Seq(readRow1, readRow2), readSchema)
+        compareTiDBSelectWithJDBC(List(readRow1, readRow2), readSchema)
     }
   }
 
@@ -121,7 +121,7 @@ class ToDateSuite extends BaseBatchWriteTest("test_data_type_convert_to_date") {
 
         // insert rows
         writeFunc(List(row1, row2), schema, None)
-        compareTiDBSelectWithJDBC(Seq(row1, row2), schema)
+        compareTiDBSelectWithJDBC(List(row1, row2), schema)
     }
   }
 
@@ -147,7 +147,7 @@ class ToDateSuite extends BaseBatchWriteTest("test_data_type_convert_to_date") {
 
         // insert rows
         writeFunc(List(row1, row2), schema, None)
-        compareTiDBSelectWithJDBC(Seq(readRow1, readRow2), readSchema)
+        compareTiDBSelectWithJDBC(List(readRow1, readRow2), readSchema)
     }
   }
 

--- a/core/src/test/scala/com/pingcap/tispark/convert/ToDateTimeSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/convert/ToDateTimeSuite.scala
@@ -66,7 +66,7 @@ class ToDateTimeSuite extends BaseBatchWriteTest("test_data_type_convert_to_date
 
         // insert rows
         writeFunc(List(row1, row2), schema, None)
-        compareTiDBSelectWithJDBC(Seq(readRow1, readRow2), readSchema)
+        compareTiDBSelectWithJDBC(List(readRow1, readRow2), readSchema)
     }
   }
 
@@ -94,7 +94,7 @@ class ToDateTimeSuite extends BaseBatchWriteTest("test_data_type_convert_to_date
 
         // insert rows
         writeFunc(List(row1, row2), schema, None)
-        compareTiDBSelectWithJDBC(Seq(row1, row2), schema)
+        compareTiDBSelectWithJDBC(List(row1, row2), schema)
     }
   }
 
@@ -122,7 +122,7 @@ class ToDateTimeSuite extends BaseBatchWriteTest("test_data_type_convert_to_date
 
         // insert rows
         writeFunc(List(row1, row2), schema, None)
-        compareTiDBSelectWithJDBC(Seq(row1, row2), schema)
+        compareTiDBSelectWithJDBC(List(row1, row2), schema)
     }
   }
 

--- a/core/src/test/scala/com/pingcap/tispark/convert/ToDecimalSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/convert/ToDecimalSuite.scala
@@ -84,7 +84,7 @@ class ToDecimalSuite extends BaseBatchWriteTest("test_data_type_convert_to_decim
         // insert rows
         writeFunc(List(row1, row2, row3, row4, row5), schema, None)
         compareTiDBSelectWithJDBC(
-          Seq(readRow1, readRow2, readRow3, readRow4, readRow5),
+          List(readRow1, readRow2, readRow3, readRow4, readRow5),
           readSchema)
     }
   }
@@ -120,7 +120,7 @@ class ToDecimalSuite extends BaseBatchWriteTest("test_data_type_convert_to_decim
 
         // insert rows
         writeFunc(List(row1, row2, row3, row4, row5), schema, None)
-        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5), schema)
+        compareTiDBSelectWithJDBC(List(row1, row2, row3, row4, row5), schema)
     }
   }
 
@@ -155,7 +155,7 @@ class ToDecimalSuite extends BaseBatchWriteTest("test_data_type_convert_to_decim
 
         // insert rows
         writeFunc(List(row1, row2, row3, row4, row5), schema, None)
-        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5), schema)
+        compareTiDBSelectWithJDBC(List(row1, row2, row3, row4, row5), schema)
     }
   }
 
@@ -190,7 +190,7 @@ class ToDecimalSuite extends BaseBatchWriteTest("test_data_type_convert_to_decim
 
         // insert rows
         writeFunc(List(row1, row2, row3, row4, row5), schema, None)
-        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5), schema)
+        compareTiDBSelectWithJDBC(List(row1, row2, row3, row4, row5), schema)
     }
   }
 
@@ -225,7 +225,7 @@ class ToDecimalSuite extends BaseBatchWriteTest("test_data_type_convert_to_decim
 
         // insert rows
         writeFunc(List(row1, row2, row3, row4, row5), schema, None)
-        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5), schema)
+        compareTiDBSelectWithJDBC(List(row1, row2, row3, row4, row5), schema)
     }
   }
 
@@ -269,7 +269,7 @@ class ToDecimalSuite extends BaseBatchWriteTest("test_data_type_convert_to_decim
 
         // insert rows
         writeFunc(List(row1, row2), schema, None)
-        compareTiDBSelectWithJDBC(Seq(readRow1, readRow2), readSchema)
+        compareTiDBSelectWithJDBC(List(readRow1, readRow2), readSchema)
     }
   }
 
@@ -312,7 +312,7 @@ class ToDecimalSuite extends BaseBatchWriteTest("test_data_type_convert_to_decim
 
         // insert rows
         writeFunc(List(row1, row2), schema, None)
-        compareTiDBSelectWithJDBC(Seq(readRow1, readRow2), readSchema)
+        compareTiDBSelectWithJDBC(List(readRow1, readRow2), readSchema)
     }
   }
 
@@ -352,7 +352,7 @@ class ToDecimalSuite extends BaseBatchWriteTest("test_data_type_convert_to_decim
 
         // insert rows
         writeFunc(List(row1, row2), schema, None)
-        compareTiDBSelectWithJDBC(Seq(readRow1, readRow2), readSchema)
+        compareTiDBSelectWithJDBC(List(readRow1, readRow2), readSchema)
     }
   }
 
@@ -387,7 +387,7 @@ class ToDecimalSuite extends BaseBatchWriteTest("test_data_type_convert_to_decim
 
         // insert rows
         writeFunc(List(row1, row2, row3, row4, row5), schema, None)
-        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5), schema)
+        compareTiDBSelectWithJDBC(List(row1, row2, row3, row4, row5), schema)
     }
   }
 

--- a/core/src/test/scala/com/pingcap/tispark/convert/ToEnumSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/convert/ToEnumSuite.scala
@@ -81,7 +81,7 @@ class ToEnumSuite extends BaseBatchWriteTest("test_data_type_convert_to_enum") {
         // insert rows
         writeFunc(List(row1, row2, row3, row4, row5), schema, None)
         compareTiDBSelectWithJDBC(
-          Seq(readRow1, readRow2, readRow3, readRow4, readRow5),
+          List(readRow1, readRow2, readRow3, readRow4, readRow5),
           readSchema)
     }
   }
@@ -120,7 +120,7 @@ class ToEnumSuite extends BaseBatchWriteTest("test_data_type_convert_to_enum") {
         // insert rows
         writeFunc(List(row1, row2, row3, row4, row5), schema, None)
         compareTiDBSelectWithJDBC(
-          Seq(readRow1, readRow2, readRow3, readRow4, readRow5),
+          List(readRow1, readRow2, readRow3, readRow4, readRow5),
           readSchema)
     }
   }
@@ -159,7 +159,7 @@ class ToEnumSuite extends BaseBatchWriteTest("test_data_type_convert_to_enum") {
         // insert rows
         writeFunc(List(row1, row2, row3, row4, row5), schema, None)
         compareTiDBSelectWithJDBC(
-          Seq(readRow1, readRow2, readRow3, readRow4, readRow5),
+          List(readRow1, readRow2, readRow3, readRow4, readRow5),
           readSchema)
     }
   }
@@ -198,7 +198,7 @@ class ToEnumSuite extends BaseBatchWriteTest("test_data_type_convert_to_enum") {
         // insert rows
         writeFunc(List(row1, row2, row3, row4, row5), schema, None)
         compareTiDBSelectWithJDBC(
-          Seq(readRow1, readRow2, readRow3, readRow4, readRow5),
+          List(readRow1, readRow2, readRow3, readRow4, readRow5),
           readSchema)
     }
   }
@@ -237,7 +237,7 @@ class ToEnumSuite extends BaseBatchWriteTest("test_data_type_convert_to_enum") {
         // insert rows
         writeFunc(List(row1, row2, row3, row4, row5), schema, None)
         compareTiDBSelectWithJDBC(
-          Seq(readRow1, readRow2, readRow3, readRow4, readRow5),
+          List(readRow1, readRow2, readRow3, readRow4, readRow5),
           readSchema)
     }
   }
@@ -276,7 +276,7 @@ class ToEnumSuite extends BaseBatchWriteTest("test_data_type_convert_to_enum") {
         // insert rows
         writeFunc(List(row1, row2, row3, row4, row5), schema, None)
         compareTiDBSelectWithJDBC(
-          Seq(readRow1, readRow2, readRow3, readRow4, readRow5),
+          List(readRow1, readRow2, readRow3, readRow4, readRow5),
           readSchema)
     }
   }
@@ -315,7 +315,7 @@ class ToEnumSuite extends BaseBatchWriteTest("test_data_type_convert_to_enum") {
         // insert rows
         writeFunc(List(row1, row2, row3, row4, row5), schema, None)
         compareTiDBSelectWithJDBC(
-          Seq(readRow1, readRow2, readRow3, readRow4, readRow5),
+          List(readRow1, readRow2, readRow3, readRow4, readRow5),
           readSchema)
     }
   }
@@ -354,7 +354,7 @@ class ToEnumSuite extends BaseBatchWriteTest("test_data_type_convert_to_enum") {
         // insert rows
         writeFunc(List(row1, row2, row3, row4, row5), schema, None)
         compareTiDBSelectWithJDBC(
-          Seq(readRow1, readRow2, readRow3, readRow4, readRow5),
+          List(readRow1, readRow2, readRow3, readRow4, readRow5),
           readSchema)
     }
   }

--- a/core/src/test/scala/com/pingcap/tispark/convert/ToRealSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/convert/ToRealSuite.scala
@@ -66,7 +66,7 @@ class ToRealSuite extends BaseBatchWriteTest("test_data_type_convert_to_real") {
 
         // insert rows
         writeFunc(List(row1, row2, row3, row4), schema, None)
-        compareTiDBSelectWithJDBC(Seq(readRow1, readRow2, readRow3, readRow4), readSchema)
+        compareTiDBSelectWithJDBC(List(readRow1, readRow2, readRow3, readRow4), readSchema)
     }
   }
 
@@ -95,7 +95,7 @@ class ToRealSuite extends BaseBatchWriteTest("test_data_type_convert_to_real") {
 
         // insert rows
         writeFunc(List(row1, row2, row3, row4), schema, None)
-        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4), schema)
+        compareTiDBSelectWithJDBC(List(row1, row2, row3, row4), schema)
     }
   }
 
@@ -124,7 +124,7 @@ class ToRealSuite extends BaseBatchWriteTest("test_data_type_convert_to_real") {
 
         // insert rows
         writeFunc(List(row1, row2, row3, row4), schema, None)
-        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4), schema)
+        compareTiDBSelectWithJDBC(List(row1, row2, row3, row4), schema)
     }
   }
 
@@ -156,7 +156,7 @@ class ToRealSuite extends BaseBatchWriteTest("test_data_type_convert_to_real") {
 
         // insert rows
         writeFunc(List(row1, row2, row3, row4), schema, None)
-        compareTiDBSelectWithJDBC(Seq(readRow1, readRow2, readRow3, readRow4), readSchema)
+        compareTiDBSelectWithJDBC(List(readRow1, readRow2, readRow3, readRow4), readSchema)
     }
   }
 
@@ -182,7 +182,7 @@ class ToRealSuite extends BaseBatchWriteTest("test_data_type_convert_to_real") {
 
         // insert rows
         writeFunc(List(row1, row2, row3, row4), schema, None)
-        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4), schema)
+        compareTiDBSelectWithJDBC(List(row1, row2, row3, row4), schema)
     }
   }
 
@@ -221,7 +221,7 @@ class ToRealSuite extends BaseBatchWriteTest("test_data_type_convert_to_real") {
         // TODO: TiSpark transforms FLOAT to Double, which will cause precision problem,
         //  so we just set skipTiDBAndExpectedAnswerCheck = true
         compareTiDBSelectWithJDBC(
-          Seq(readRow1, readRow2, readRow3, readRow4, readRow5, readRow6),
+          List(readRow1, readRow2, readRow3, readRow4, readRow5, readRow6),
           readSchema,
           skipTiDBAndExpectedAnswerCheck = true)
     }
@@ -260,7 +260,7 @@ class ToRealSuite extends BaseBatchWriteTest("test_data_type_convert_to_real") {
         // insert rows
         writeFunc(List(row1, row2, row3, row4, row5, row6), schema, None)
         compareTiDBSelectWithJDBC(
-          Seq(readRow1, readRow2, readRow3, readRow4, readRow5, readRow6),
+          List(readRow1, readRow2, readRow3, readRow4, readRow5, readRow6),
           readSchema)
     }
   }
@@ -297,7 +297,7 @@ class ToRealSuite extends BaseBatchWriteTest("test_data_type_convert_to_real") {
         // insert rows
         writeFunc(List(row1, row2, row3, row4, row5, row6), schema, None)
         compareTiDBSelectWithJDBC(
-          Seq(readRow1, readRow2, readRow3, readRow4, readRow5, readRow6),
+          List(readRow1, readRow2, readRow3, readRow4, readRow5, readRow6),
           readSchema)
     }
   }

--- a/core/src/test/scala/com/pingcap/tispark/convert/ToSignedSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/convert/ToSignedSuite.scala
@@ -75,7 +75,7 @@ class ToSignedSuite extends BaseBatchWriteTest("test_data_type_convert_to_signed
         // insert rows
         writeFunc(List(row1, row2, row3, row4, row5, row6), schema, None)
         compareTiDBSelectWithJDBC(
-          Seq(readRow1, readRow2, readRow3, readRow4, readRow5, readRow6),
+          List(readRow1, readRow2, readRow3, readRow4, readRow5, readRow6),
           readSchema)
     }
   }
@@ -114,7 +114,7 @@ class ToSignedSuite extends BaseBatchWriteTest("test_data_type_convert_to_signed
 
         // insert rows
         writeFunc(List(row1, row2, row3, row4, row5, row6), schema, None)
-        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
+        compareTiDBSelectWithJDBC(List(row1, row2, row3, row4, row5, row6), schema)
     }
   }
 
@@ -155,7 +155,7 @@ class ToSignedSuite extends BaseBatchWriteTest("test_data_type_convert_to_signed
 
         // insert rows
         writeFunc(List(row1, row2, row3, row4, row5, row6), schema, None)
-        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
+        compareTiDBSelectWithJDBC(List(row1, row2, row3, row4, row5, row6), schema)
     }
   }
 
@@ -198,7 +198,7 @@ class ToSignedSuite extends BaseBatchWriteTest("test_data_type_convert_to_signed
 
         // insert rows
         writeFunc(List(row1, row2, row3, row4, row5, row6), schema, None)
-        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
+        compareTiDBSelectWithJDBC(List(row1, row2, row3, row4, row5, row6), schema)
     }
   }
 
@@ -243,7 +243,7 @@ class ToSignedSuite extends BaseBatchWriteTest("test_data_type_convert_to_signed
 
         // insert rows
         writeFunc(List(row1, row2, row3, row4, row5, row6), schema, None)
-        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
+        compareTiDBSelectWithJDBC(List(row1, row2, row3, row4, row5, row6), schema)
     }
   }
 
@@ -289,7 +289,7 @@ class ToSignedSuite extends BaseBatchWriteTest("test_data_type_convert_to_signed
 
         // insert rows
         writeFunc(List(row1, row2, row3, row4, row5, row6), schema, None)
-        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
+        compareTiDBSelectWithJDBC(List(row1, row2, row3, row4, row5, row6), schema)
     }
   }
 
@@ -332,7 +332,7 @@ class ToSignedSuite extends BaseBatchWriteTest("test_data_type_convert_to_signed
 
         // insert rows
         writeFunc(List(row1, row2, row3, row4, row5, row6), schema, None)
-        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
+        compareTiDBSelectWithJDBC(List(row1, row2, row3, row4, row5, row6), schema)
     }
   }
 
@@ -393,7 +393,7 @@ class ToSignedSuite extends BaseBatchWriteTest("test_data_type_convert_to_signed
         // insert rows
         writeFunc(List(row1, row2, row3, row4, row5, row6), schema, None)
         compareTiDBSelectWithJDBC(
-          Seq(readRow1, readRow2, readRow3, readRow4, readRow5, readRow6),
+          List(readRow1, readRow2, readRow3, readRow4, readRow5, readRow6),
           readSchema)
     }
   }

--- a/core/src/test/scala/com/pingcap/tispark/convert/ToStringSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/convert/ToStringSuite.scala
@@ -79,7 +79,7 @@ class ToStringSuite extends BaseBatchWriteTest("test_data_type_convert_to_string
         // insert rows
         writeFunc(List(row1, row2, row3, row4, row5), schema, None)
         compareTiDBSelectWithJDBC(
-          Seq(readRow1, readRow2, readRow3, readRow4, readRow5),
+          List(readRow1, readRow2, readRow3, readRow4, readRow5),
           readSchema)
     }
   }
@@ -127,7 +127,7 @@ class ToStringSuite extends BaseBatchWriteTest("test_data_type_convert_to_string
         // insert rows
         writeFunc(List(row1, row2, row3, row4, row5), schema, None)
         compareTiDBSelectWithJDBC(
-          Seq(readRow1, readRow2, readRow3, readRow4, readRow5),
+          List(readRow1, readRow2, readRow3, readRow4, readRow5),
           readSchema)
     }
   }
@@ -175,7 +175,7 @@ class ToStringSuite extends BaseBatchWriteTest("test_data_type_convert_to_string
         // insert rows
         writeFunc(List(row1, row2, row3, row4, row5), schema, None)
         compareTiDBSelectWithJDBC(
-          Seq(readRow1, readRow2, readRow3, readRow4, readRow5),
+          List(readRow1, readRow2, readRow3, readRow4, readRow5),
           readSchema)
     }
   }
@@ -223,7 +223,7 @@ class ToStringSuite extends BaseBatchWriteTest("test_data_type_convert_to_string
         // insert rows
         writeFunc(List(row1, row2, row3, row4, row5), schema, None)
         compareTiDBSelectWithJDBC(
-          Seq(readRow1, readRow2, readRow3, readRow4, readRow5),
+          List(readRow1, readRow2, readRow3, readRow4, readRow5),
           readSchema)
     }
   }
@@ -271,7 +271,7 @@ class ToStringSuite extends BaseBatchWriteTest("test_data_type_convert_to_string
         // insert rows
         writeFunc(List(row1, row2, row3, row4, row5), schema, None)
         compareTiDBSelectWithJDBC(
-          Seq(readRow1, readRow2, readRow3, readRow4, readRow5),
+          List(readRow1, readRow2, readRow3, readRow4, readRow5),
           readSchema)
     }
   }
@@ -323,7 +323,7 @@ class ToStringSuite extends BaseBatchWriteTest("test_data_type_convert_to_string
         //  so we just set skipTiDBAndExpectedAnswerCheck = true
         writeFunc(List(row1, row2, row3, row4, row5), schema, None)
         compareTiDBSelectWithJDBC(
-          Seq(readRow1, readRow2, readRow3, readRow4, readRow5),
+          List(readRow1, readRow2, readRow3, readRow4, readRow5),
           readSchema,
           skipTiDBAndExpectedAnswerCheck = true)
     }
@@ -361,7 +361,7 @@ class ToStringSuite extends BaseBatchWriteTest("test_data_type_convert_to_string
 
         // insert rows
         writeFunc(List(row1, row2, row3, row4, row5), schema, None)
-        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5), schema)
+        compareTiDBSelectWithJDBC(List(row1, row2, row3, row4, row5), schema)
     }
   }
 
@@ -396,7 +396,7 @@ class ToStringSuite extends BaseBatchWriteTest("test_data_type_convert_to_string
 
         // insert rows
         writeFunc(List(row1, row2, row3, row4, row5), schema, None)
-        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5), schema)
+        compareTiDBSelectWithJDBC(List(row1, row2, row3, row4, row5), schema)
     }
   }
 
@@ -443,7 +443,7 @@ class ToStringSuite extends BaseBatchWriteTest("test_data_type_convert_to_string
         // insert rows
         writeFunc(List(row1, row2, row3, row4, row5), schema, None)
         compareTiDBSelectWithJDBC(
-          Seq(readRow1, readRow2, readRow3, readRow4, readRow5),
+          List(readRow1, readRow2, readRow3, readRow4, readRow5),
           readSchema)
     }
   }
@@ -491,7 +491,7 @@ class ToStringSuite extends BaseBatchWriteTest("test_data_type_convert_to_string
         // insert rows
         writeFunc(List(row1, row2, row3, row4, row5), schema, None)
         compareTiDBSelectWithJDBC(
-          Seq(readRow1, readRow2, readRow3, readRow4, readRow5),
+          List(readRow1, readRow2, readRow3, readRow4, readRow5),
           readSchema)
     }
   }
@@ -539,7 +539,7 @@ class ToStringSuite extends BaseBatchWriteTest("test_data_type_convert_to_string
         // insert rows
         writeFunc(List(row1, row2, row3, row4, row5), schema, None)
         compareTiDBSelectWithJDBC(
-          Seq(readRow1, readRow2, readRow3, readRow4, readRow5),
+          List(readRow1, readRow2, readRow3, readRow4, readRow5),
           readSchema)
     }
   }

--- a/core/src/test/scala/com/pingcap/tispark/convert/ToTimestampSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/convert/ToTimestampSuite.scala
@@ -59,7 +59,7 @@ class ToTimestampSuite extends BaseBatchWriteTest("test_data_type_convert_to_tim
 
         // insert rows
         writeFunc(List(row1, row2), schema, None)
-        compareTiDBSelectWithJDBC(Seq(readRow1, readRow2), readSchema)
+        compareTiDBSelectWithJDBC(List(readRow1, readRow2), readSchema)
       case (writeFunc, "jdbcWrite") =>
       // TODO: ignored, because of this error
       //java.sql.BatchUpdateException: Data truncation: invalid time format: '34'
@@ -91,7 +91,7 @@ class ToTimestampSuite extends BaseBatchWriteTest("test_data_type_convert_to_tim
 
         // insert rows
         writeFunc(List(row1, row2), schema, None)
-        compareTiDBSelectWithJDBC(Seq(readRow1, readRow2), readSchema)
+        compareTiDBSelectWithJDBC(List(readRow1, readRow2), readSchema)
       case (writeFunc, "jdbcWrite") =>
       // ignored because spark jdbc write does not use local time zone
     }
@@ -125,7 +125,7 @@ class ToTimestampSuite extends BaseBatchWriteTest("test_data_type_convert_to_tim
 
         // insert rows
         writeFunc(List(row1, row2), schema, None)
-        compareTiDBSelectWithJDBC(Seq(readRow1, readRow2), readSchema)
+        compareTiDBSelectWithJDBC(List(readRow1, readRow2), readSchema)
 
       case (writeFunc, "jdbcWrite") =>
       // ignored because spark jdbc write does not use local time zone
@@ -154,7 +154,7 @@ class ToTimestampSuite extends BaseBatchWriteTest("test_data_type_convert_to_tim
 
         // insert rows
         writeFunc(List(row1, row2), schema, None)
-        compareTiDBSelectWithJDBC(Seq(row1, row2), readSchema)
+        compareTiDBSelectWithJDBC(List(row1, row2), readSchema)
 
       case (writeFunc, "jdbcWrite") =>
       // ignored because spark jdbc write does not use local time zone

--- a/core/src/test/scala/com/pingcap/tispark/convert/ToUnsignedSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/convert/ToUnsignedSuite.scala
@@ -71,7 +71,7 @@ class ToUnsignedSuite extends BaseBatchWriteTest("test_data_type_convert_to_unsi
         // insert rows
         writeFunc(List(row1, row2, row3, row4, row5, row6), schema, None)
         compareTiDBSelectWithJDBC(
-          Seq(readRow1, readRow2, readRow3, readRow4, readRow5, readRow6),
+          List(readRow1, readRow2, readRow3, readRow4, readRow5, readRow6),
           readSchema)
     }
   }
@@ -107,7 +107,7 @@ class ToUnsignedSuite extends BaseBatchWriteTest("test_data_type_convert_to_unsi
 
         // insert rows
         writeFunc(List(row1, row2, row3, row4, row5, row6), schema, None)
-        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
+        compareTiDBSelectWithJDBC(List(row1, row2, row3, row4, row5, row6), schema)
     }
   }
 
@@ -144,7 +144,7 @@ class ToUnsignedSuite extends BaseBatchWriteTest("test_data_type_convert_to_unsi
 
         // insert rows
         writeFunc(List(row1, row2, row3, row4, row5, row6), schema, None)
-        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
+        compareTiDBSelectWithJDBC(List(row1, row2, row3, row4, row5, row6), schema)
     }
   }
 
@@ -182,7 +182,7 @@ class ToUnsignedSuite extends BaseBatchWriteTest("test_data_type_convert_to_unsi
 
         // insert rows
         writeFunc(List(row1, row2, row3, row4, row5, row6), schema, None)
-        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
+        compareTiDBSelectWithJDBC(List(row1, row2, row3, row4, row5, row6), schema)
     }
   }
 
@@ -221,7 +221,7 @@ class ToUnsignedSuite extends BaseBatchWriteTest("test_data_type_convert_to_unsi
 
         // insert rows
         writeFunc(List(row1, row2, row3, row4, row5, row6), schema, None)
-        compareTiDBSelectWithJDBC(Seq(row1, row2, row3, row4, row5, row6), schema)
+        compareTiDBSelectWithJDBC(List(row1, row2, row3, row4, row5, row6), schema)
     }
   }
 
@@ -276,7 +276,7 @@ class ToUnsignedSuite extends BaseBatchWriteTest("test_data_type_convert_to_unsi
         // insert rows
         writeFunc(List(row1, row2, row3, row4, row5, row6), schema, None)
         compareTiDBSelectWithJDBC(
-          Seq(readRow1, readRow2, readRow3, readRow4, readRow5, readRow6),
+          List(readRow1, readRow2, readRow3, readRow4, readRow5, readRow6),
           readSchema)
     }
   }
@@ -331,7 +331,7 @@ class ToUnsignedSuite extends BaseBatchWriteTest("test_data_type_convert_to_unsi
         // insert rows
         writeFunc(List(row1, row2, row3, row4, row5, row6), schema, None)
         compareTiDBSelectWithJDBC(
-          Seq(readRow1, readRow2, readRow3, readRow4, readRow5, readRow6),
+          List(readRow1, readRow2, readRow3, readRow4, readRow5, readRow6),
           readSchema)
     }
   }
@@ -386,7 +386,7 @@ class ToUnsignedSuite extends BaseBatchWriteTest("test_data_type_convert_to_unsi
         // insert rows
         writeFunc(List(row1, row2, row3, row4, row5, row6), schema, None)
         compareTiDBSelectWithJDBC(
-          Seq(readRow1, readRow2, readRow3, readRow4, readRow5, readRow6),
+          List(readRow1, readRow2, readRow3, readRow4, readRow5, readRow6),
           readSchema)
     }
   }

--- a/core/src/test/scala/com/pingcap/tispark/datasource/BaseBatchWriteWithoutDropTableTest.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/BaseBatchWriteWithoutDropTableTest.scala
@@ -25,7 +25,6 @@ class BaseBatchWriteWithoutDropTableTest(
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    setCurrentDatabase(database)
   }
 
   override def beforeEach(): Unit = {

--- a/core/src/test/scala/com/pingcap/tispark/datasource/BaseBatchWriteWithoutDropTableTest.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/BaseBatchWriteWithoutDropTableTest.scala
@@ -23,6 +23,11 @@ class BaseBatchWriteWithoutDropTableTest(
     override val database: String = "tispark_test")
     extends BaseDataSourceTest(table, database) {
 
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    setCurrentDatabase(database)
+  }
+
   override def beforeEach(): Unit = {
     super.beforeEach()
     if (!supportBatchWrite) {

--- a/core/src/test/scala/com/pingcap/tispark/datasource/BaseDataSourceTest.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/BaseDataSourceTest.scala
@@ -19,10 +19,11 @@ import java.util.Objects
 
 import com.pingcap.tikv.allocator.RowIDAllocator
 import com.pingcap.tikv.meta.TiColumnInfo
-import com.pingcap.tispark.TiConfigConst
+import com.pingcap.tispark.{TiConfigConst, TiDBUtils}
 import org.apache.spark.SparkException
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException
+import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{BaseTiSparkTest, DataFrame, Row}
 
@@ -149,9 +150,10 @@ class BaseDataSourceTest(val table: String, val database: String = "tispark_test
     val df = sqlContext.createDataFrame(data, schema)
     df.write
       .format("jdbc")
-      .option("url", jdbcUrl)
-      .option("dbtable", dbtable)
-      .option("isolationLevel", "REPEATABLE_READ")
+      .option(JDBCOptions.JDBC_URL, jdbcUrl)
+      .option(JDBCOptions.JDBC_DRIVER_CLASS, TiDBUtils.TIDB_DRIVER_CLASS)
+      .option(JDBCOptions.JDBC_TABLE_NAME, dbtable)
+      .option(JDBCOptions.JDBC_TXN_ISOLATION_LEVEL, "REPEATABLE_READ")
       .mode("append")
       .save()
   }
@@ -163,7 +165,7 @@ class BaseDataSourceTest(val table: String, val database: String = "tispark_test
   }
 
   protected def compareTiDBSelectWithJDBC(
-      expectedAnswer: Seq[Row],
+      expectedAnswer: List[Row],
       schema: StructType,
       sortCol: String = "i",
       skipTiDBAndExpectedAnswerCheck: Boolean = false,

--- a/core/src/test/scala/com/pingcap/tispark/datatype/BatchWriteDataTypeSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datatype/BatchWriteDataTypeSuite.scala
@@ -547,4 +547,12 @@ class BatchWriteDataTypeSuite extends BaseBatchWriteTest("test_data_type", "test
       tidbWrite(data, schema)
     }
   }
+
+  test("Test enum with trailing spaces") {
+    jdbcUpdate(s"create table $dbtable(a enum('a','b '))")
+
+    val schema = StructType(List(StructField("a", StringType)))
+    tidbWrite(List(Row("b")), schema, None)
+    compareTiDBSelectWithJDBC(List(Row("b ")), schema, sortCol = "a")
+  }
 }

--- a/core/src/test/scala/com/pingcap/tispark/overflow/DecimalOverflowSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/overflow/DecimalOverflowSuite.scala
@@ -66,7 +66,7 @@ class DecimalOverflowSuite extends BaseBatchWriteTest("test_data_type_decimal_ov
               StructField("c1", DecimalType(testData.length, testData.precision))))
 
           writeFunc(List(row1), schema, None)
-          compareTiDBSelectWithJDBC(Seq(readRow1), readSchema)
+          compareTiDBSelectWithJDBC(List(readRow1), readSchema)
       }
     }
   }

--- a/core/src/test/scala/com/pingcap/tispark/overflow/StringOverflowSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/overflow/StringOverflowSuite.scala
@@ -40,7 +40,7 @@ class StringOverflowSuite extends BaseBatchWriteTest("test_data_type_string_over
         val schema =
           StructType(List(StructField("i", IntegerType), StructField("c1", StringType)))
         writeFunc(List(row), schema, None)
-        compareTiDBSelectWithJDBC(Seq(row), schema)
+        compareTiDBSelectWithJDBC(List(row), schema)
     }
   }
 

--- a/core/src/test/scala/org/apache/spark/sql/BaseTiSparkTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/BaseTiSparkTest.scala
@@ -57,7 +57,7 @@ class BaseTiSparkTest extends QueryTest with SharedSQLContext {
           .format("jdbc")
           .option(JDBCOptions.JDBC_URL, jdbcUrl)
           .option(JDBCOptions.JDBC_TABLE_NAME, "information_schema.tables")
-          .option(JDBCOptions.JDBC_DRIVER_CLASS, "com.mysql.jdbc.Driver")
+          .option(JDBCOptions.JDBC_DRIVER_CLASS, TiDBUtils.TIDB_DRIVER_CLASS)
           .load()
           .filter(s"table_schema = '$dbName'")
           .select("TABLE_NAME")
@@ -80,7 +80,7 @@ class BaseTiSparkTest extends QueryTest with SharedSQLContext {
       .format("jdbc")
       .option(JDBCOptions.JDBC_URL, jdbcUrl)
       .option(JDBCOptions.JDBC_TABLE_NAME, s"`$dbName`.`$viewName`")
-      .option(JDBCOptions.JDBC_DRIVER_CLASS, "com.mysql.jdbc.Driver")
+      .option(JDBCOptions.JDBC_DRIVER_CLASS, TiDBUtils.TIDB_DRIVER_CLASS)
       .load()
       .createOrReplaceTempView(s"`$viewName$postfix`")
 

--- a/core/src/test/scala/org/apache/spark/sql/insertion/BatchWritePkSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/insertion/BatchWritePkSuite.scala
@@ -28,7 +28,7 @@ class BatchWritePkSuite
   override def dataTypes: List[ReflectedDataType] =
     integers ::: decimals ::: doubles ::: charCharset
   override def unsignedDataTypes: List[ReflectedDataType] = integers ::: decimals ::: doubles
-  override val dbName = "batch_write_test_pk"
+  override val dbName: String = database
   override val testDesc = "Test for single PK column in batch-write insertion"
 
   override def beforeAll(): Unit = {

--- a/core/src/test/scala/org/apache/spark/sql/insertion/BatchWriteUniqueIndexSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/insertion/BatchWriteUniqueIndexSuite.scala
@@ -28,7 +28,7 @@ class BatchWriteUniqueIndexSuite
   override def dataTypes: List[ReflectedDataType] =
     integers ::: decimals ::: doubles ::: charCharset
   override def unsignedDataTypes: List[ReflectedDataType] = integers ::: decimals ::: doubles
-  override val dbName = "batch_write_test_index"
+  override val dbName: String = database
   override val testDesc =
     "Test for single and multiple unique index type in batch-write insertion"
 

--- a/tikv-client/src/main/java/com/pingcap/tikv/codec/Codec.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/codec/Codec.java
@@ -689,11 +689,15 @@ public class Codec {
 
   public static class EnumCodec {
 
+    public static boolean equals(String a, String b) {
+      return a.trim().equalsIgnoreCase(b.trim());
+    }
+
     public static Integer parseEnumName(String name, List<String> elems)
         throws ConvertOverflowException {
       int i = 0;
       while (i < elems.size()) {
-        if (elems.get(i).equals(name)) {
+        if (equals(elems.get(i), name)) {
           return i + 1;
         }
         i = i + 1;


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix #1743 

### What is changed and how it works?
After analyzing the behavior of TiDB/MySQL, the trailing spaces should be ignored in **_STRING COMPARISON_** when the collation is PAD SPACE.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to be included in the release note
