### PR TITLE
fix column name compare bug

### DIFF
--- a/core/src/main/scala/com/pingcap/tispark/write/TiBatchWriteTable.scala
+++ b/core/src/main/scala/com/pingcap/tispark/write/TiBatchWriteTable.scala
@@ -143,7 +143,7 @@ class TiBatchWriteTable(
             """.stripMargin)
         }
 
-        if (!df.columns.contains(autoIncrementColName)) {
+        if (!colsInDf.contains(autoIncrementColName)) {
           throw new TiBatchWriteException(
             "Column size is matched but cannot find auto increment column by name")
         }

--- a/core/src/test/scala/com/pingcap/tispark/datasource/AutoIncrementSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/AutoIncrementSuite.scala
@@ -409,4 +409,22 @@ class AutoIncrementSuite extends BaseBatchWriteTest("test_datasource_auto_increm
     sql(s"select * from $dbtableWithPrefix").show()
   }
 
+  test("auto increment column name compare") {
+    val row3 = Row(3L, 33L)
+    val row4 = Row(4L, 44L)
+
+    val schema = StructType(List(StructField("I", LongType), StructField("j", LongType)))
+
+    jdbcUpdate(
+      s"create table $dbtable(i int NOT NULL AUTO_INCREMENT, j int NOT NULL, unique key (i))")
+
+    jdbcUpdate(s"insert into $dbtable values (3, 0), (4, 0)")
+
+    sql(s"select * from $dbtableWithPrefix").show()
+
+    tidbWrite(List(row3, row4), schema, Some(Map("replace" -> "true")))
+
+    sql(s"select * from $dbtableWithPrefix").show()
+  }
+
 }


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
we should Ignore case when comparing column names

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `tidb-ansible` repository
 - Need to be included in the release note
