### PR TITLE
fix spark-3.0 catalog throw NullPointerException

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,10 +184,11 @@ The configurations in the table below can be put together with `spark-defaults.c
 | `spark.tispark.isolation_read_engines` | `tikv,tiflash` | List of readable engines of TiSpark, comma separated, storage engines not listed will not be read |
 
 ## Spark-3.0 Catalog
-Please use the following configuration to enable `Catalog` provided by `spark-3.0`.
+Please use the following configurations to enable `Catalog` provided by `spark-3.0`.
 
 ```
 spark.sql.catalog.tidb_catalog org.apache.spark.sql.catalyst.catalog.TiCatalog
+spark.sql.catalog.tidb_catalog.pd.addresses 127.0.0.1:2379
 ```
 
 ## `Log4j` Configuration

--- a/core/src/main/scala/org/apache/spark/sql/catalyst/catalog/TiCatalog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/catalyst/catalog/TiCatalog.scala
@@ -123,7 +123,10 @@ class TiCatalog extends TableCatalog with SupportsNamespaces {
 
   override def initialize(name: String, options: CaseInsensitiveStringMap): Unit = {
     _name = Some(name)
-    val pdAddress = options.getOrDefault("pd.address", "127.0.0.1:2379")
+    if (!options.containsKey("pd.addresses") && !options.containsKey("pd.address")) {
+      throw new Exception("missing configuration spark.sql.catalog.tidb_catalog.pd.addresses")
+    }
+    val pdAddress = options.getOrDefault("pd.addresses", options.get("pd.address"))
     logger.info(s"Initialize TiCatalog with name: $name, pd address: $pdAddress")
     val conf = TiConfiguration.createDefault(pdAddress)
     val session = TiSession.getInstance(conf)

--- a/core/src/test/scala/org/apache/spark/sql/test/SharedSQLContext.scala
+++ b/core/src/test/scala/org/apache/spark/sql/test/SharedSQLContext.scala
@@ -421,7 +421,7 @@ trait SharedSQLContext
       conf.set(DB_PREFIX, dbPrefix)
       if (catalogPluginMode) {
         conf.set("spark.sql.catalog.tidb_catalog", TiCatalog.className)
-        conf.set("spark.sql.catalog.tidb_catalog.pd.address", pdAddresses)
+        conf.set("spark.sql.catalog.tidb_catalog.pd.addresses", pdAddresses)
       }
     }
 


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
close https://github.com/pingcap/tispark/issues/1769

### What is changed and how it works?
add missing configuration to document to enable `Catalog` provided by `spark-3.0`.

```
spark.sql.catalog.tidb_catalog.pd.addresses 127.0.0.1:2379
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `tidb-ansible` repository
 - Need to be included in the release note
