### PR TITLE
add test for integer conversion

### DIFF
--- a/core/src/test/scala/com/pingcap/tispark/BatchWriteIssueSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/BatchWriteIssueSuite.scala
@@ -27,6 +27,28 @@ import org.apache.spark.sql.types.{
 
 class BatchWriteIssueSuite extends BaseBatchWriteTest("test_batchwrite_issue") {
 
+  test("integer conversion test") {
+    jdbcUpdate(s"drop table if exists t")
+    jdbcUpdate(s"create table t(a int)")
+
+    spark.sql(s"""
+                      |CREATE TABLE default.st1
+                      |USING tidb
+                      |OPTIONS (
+                      |  database '$database',
+                      |  table 't',
+                      |  tidb.addr '$tidbAddr',
+                      |  tidb.password '$tidbPassword',
+                      |  tidb.port '$tidbPort',
+                      |  tidb.user '$tidbUser',
+                      |  spark.tispark.pd.addresses '$pdAddresses'
+                      |)
+       """.stripMargin)
+
+    // spark-2.x do not check data conversion error
+    spark.sql(s"""insert into default.st1 select "g"""")
+  }
+
   test("Combine unique index with null value test") {
     doTestNullValues(s"create table $dbtable(a int, b varchar(64), CONSTRAINT ab UNIQUE (a, b))")
   }


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
close https://github.com/pingcap/tispark/issues/1684

### What is changed and how it works?
spark do not do type conversion check in v2.x
(spark do type conversion check from v3.0)


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `tidb-ansible` repository
 - Need to be included in the release note
