### PR TITLE
disable year type index scan

### DIFF
--- a/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
@@ -21,6 +21,19 @@ import org.apache.spark.sql.functions.{col, sum}
 
 class IssueTestSuite extends BaseTiSparkTest {
 
+  test("year type index plan") {
+    tidbStmt.execute("drop table if exists t1")
+    tidbStmt.execute("create table t1(id varchar(10),a year, index idx_a (a))")
+    tidbStmt.execute(
+      "insert into t1 values('ab',1970), ('ab',2010), ('ab',2012), ('ab',2014), ('ab',2018)")
+
+    val query = "select * from t1 where a>2010 and a<2015"
+    spark.sql(s"explain $query").show(false)
+    spark.sql(query).show()
+
+    assert(spark.sql(query).collect().length == 2)
+  }
+
   test("Date type deals with timezone incorrectly") {
     tidbStmt.execute("drop table if exists t")
     tidbStmt.execute("""


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
close https://github.com/pingcap/tispark/issues/1692

### What is changed and how it works?
disable year type index scan

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `tidb-ansible` repository
 - Need to be included in the release note
