### PR TITLE
support read from table with expression index

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ Do not use `spark.sql.session.timeZone`.
 
 For how TiSpark can benefit from TiDB's statistic information, see [here](./docs/userguide.md).
 
-## Compatibility with TiDB 3.0
+## Compatibility with TiDB
 
 ### View
 
@@ -234,6 +234,12 @@ TiSpark currently **does not support** `view`. Users are not be able to observe 
 TiSpark currently supports `Range Partition` and `Hash Partition`. Users can select data from the `Range Partition` table and the `Hash Partition` table through TiSpark.
 
 In most cases, TiSpark use a full table scan on partition tables. Only in certain cases, TiSpark applies partition pruning. For more details, see [here](./docs/userguide.md).
+
+### Expression Index
+
+`tidb-5.0` supports `Expression Index`.
+
+TiSpark currently supports retrieving data from table with `Expression Index`, but the `Expression Index` will not be used by the planner of TiSpark.
 
 ## Upgrade from TiDB-2.x to TiDB-3.x
 When upgrading from TiDB-2.x to TiDB-3.x,

--- a/core/src/test/scala/org/apache/spark/sql/BaseTiSparkTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/BaseTiSparkTest.scala
@@ -558,4 +558,17 @@ class BaseTiSparkTest extends QueryTest with SharedSQLContext {
 
   protected case class TestTables(dbName: String, tables: String*)
 
+  protected lazy val supportExpressionIndex: Boolean = {
+    var result = true
+    tidbStmt.execute("drop table if exists t")
+    tidbStmt.execute("create table t (name varchar(64));")
+    try {
+      tidbStmt.execute("CREATE INDEX idx ON t ((lower(name)));")
+    } catch {
+      case e: Throwable => result = false
+    } finally {
+      tidbStmt.execute("drop table if exists t")
+    }
+    result
+  }
 }

--- a/core/src/test/scala/org/apache/spark/sql/ExpressionIndexSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/ExpressionIndexSuite.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql
+
+class ExpressionIndexSuite extends BaseTiSparkTest {
+
+  test("expression index") {
+    if (!supportExpressionIndex) {
+      cancel("current version of TiDB does not support expression index!")
+    }
+
+    tidbStmt.execute("drop table if exists t")
+    tidbStmt.execute("create table t (name varchar(64));")
+    tidbStmt.execute("CREATE INDEX idx ON t ((lower(name)));")
+    tidbStmt.execute("insert into t values ('a'), ('b'), ('PingCAP');")
+
+    val query = "select * from t  where lower(name) = 'pingcap';"
+    spark.sql(s"explain $query").show(false)
+    spark.sql(query).show()
+    val queryResult = spark.sql(query).collect()
+    assert("PingCAP".equals(queryResult.head.getString(0)))
+    assert(1 == queryResult.head.size)
+
+    val tiTableInfo = ti.meta.getTable(dbPrefix + "tispark_test", "t").get
+    assert(tiTableInfo.getColumns.size() == 1)
+    assert(tiTableInfo.getColumns(true).size() == 2)
+    assert(tiTableInfo.getIndices.size() == 0)
+    assert(tiTableInfo.getIndices(true).size() == 1)
+  }
+
+  override def afterAll(): Unit =
+    try {
+      tidbStmt.execute("drop table if exists t")
+    } finally {
+      super.afterAll()
+    }
+}

--- a/tikv-client/src/main/java/com/pingcap/tikv/meta/TiColumnInfo.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/meta/TiColumnInfo.java
@@ -51,6 +51,7 @@ public class TiColumnInfo implements Serializable {
   // if version is 1 then timestamp's default value will be read and decoded as utc.
   private final long version;
   private final String generatedExprString;
+  private final boolean hidden;
 
   @JsonCreator
   public TiColumnInfo(
@@ -64,7 +65,8 @@ public class TiColumnInfo implements Serializable {
       @JsonProperty("default_bit") String defaultValueBit,
       @JsonProperty("comment") String comment,
       @JsonProperty("version") long version,
-      @JsonProperty("generated_expr_string") String generatedExprString) {
+      @JsonProperty("generated_expr_string") String generatedExprString,
+      @JsonProperty("hidden") boolean hidden) {
     this.id = id;
     this.name = requireNonNull(name, "column name is null").getL();
     this.offset = offset;
@@ -79,6 +81,7 @@ public class TiColumnInfo implements Serializable {
     this.isPrimaryKey = (type.getFlag() & PK_MASK) > 0;
     this.version = version;
     this.generatedExprString = generatedExprString;
+    this.hidden = hidden;
   }
 
   public TiColumnInfo(
@@ -92,7 +95,8 @@ public class TiColumnInfo implements Serializable {
       String defaultValueBit,
       String comment,
       long version,
-      String generatedExprString) {
+      String generatedExprString,
+      boolean hidden) {
     this.id = id;
     this.name = requireNonNull(name, "column name is null").toLowerCase();
     this.offset = offset;
@@ -105,6 +109,7 @@ public class TiColumnInfo implements Serializable {
     this.isPrimaryKey = (type.getFlag() & PK_MASK) > 0;
     this.version = version;
     this.generatedExprString = generatedExprString;
+    this.hidden = hidden;
   }
 
   @VisibleForTesting
@@ -121,6 +126,7 @@ public class TiColumnInfo implements Serializable {
     this.defaultValueBit = null;
     this.version = DataType.COLUMN_VERSION_FLAG;
     this.generatedExprString = "";
+    this.hidden = false;
   }
 
   static TiColumnInfo getRowIdColumn(int offset) {
@@ -142,7 +148,8 @@ public class TiColumnInfo implements Serializable {
         this.defaultValueBit,
         this.comment,
         this.version,
-        this.generatedExprString);
+        this.generatedExprString,
+        this.hidden);
   }
 
   public long getId() {
@@ -277,6 +284,10 @@ public class TiColumnInfo implements Serializable {
 
   public boolean isGeneratedColumn() {
     return generatedExprString != null && !generatedExprString.isEmpty();
+  }
+
+  public boolean isHidden() {
+    return hidden;
   }
 
   @JsonIgnoreProperties(ignoreUnknown = true)


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
close https://github.com/pingcap/tispark/issues/1734

tidb currently supports `expression index` (https://docs.pingcap.com/tidb/dev/sql-statement-create-index#expression-index), tispark should also support it.

### What is changed and how it works?
read: tispark will ignore `expression index`, but can read data successfully from table with `expression index`
write: tispark does not support writing to table with `expression index` using BatchWrite

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `tidb-ansible` repository
 - Need to be included in the release note
