### PR TITLE
fix select count where values contains null

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/catalyst/expressions/TiExprUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/catalyst/expressions/TiExprUtils.scala
@@ -174,8 +174,7 @@ object TiExprUtils {
       tiDBRelation: TiDBRelation,
       blocklist: ExpressionBlocklist): Boolean =
     aggExpr.aggregateFunction match {
-      case Average(_) | Sum(_) | SumNotNullable(_) | PromotedSum(_) | Count(_) | Min(_) | Max(
-            _) =>
+      case Average(_) | Sum(_) | SumNotNullable(_) | PromotedSum(_) | Min(_) | Max(_) =>
         !aggExpr.isDistinct &&
           aggExpr.aggregateFunction.children
             .forall(isSupportedBasicExpression(_, tiDBRelation, blocklist))

--- a/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
@@ -25,7 +25,18 @@ class IssueTestSuite extends BaseTiSparkTest {
     tidbStmt.execute("drop table if exists t1")
     tidbStmt.execute("create table t1(a int)")
     tidbStmt.execute("insert into t1 values (1), (null)")
-    spark.sql("select count(*) from t1").show()
+
+    spark.sql("explain select count(*) from t1").show(false)
+    spark.sql("select count(*) from t1").show(false)
+    assert(2 == spark.sql("select count(*) from t1").collect().head.get(0))
+
+    spark.sql("explain select count(*) from t1 where isnull(a)").show(false)
+    spark.sql("select count(*) from t1 where isnull(a)").show(false)
+    assert(1 == spark.sql("select count(*) from t1 where isnull(a)").collect().head.get(0))
+
+    spark.sql("explain select count(*) from t1 where !isnull(a)").show(false)
+    spark.sql("select count(*) from t1 where !isnull(a)").show(false)
+    assert(1 == spark.sql("select count(*) from t1 where !isnull(a)").collect().head.get(0))
   }
 
   test("year type index plan") {

--- a/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
@@ -21,6 +21,13 @@ import org.apache.spark.sql.functions.{col, sum}
 
 class IssueTestSuite extends BaseTiSparkTest {
 
+  test("count(*) with null values") {
+    tidbStmt.execute("drop table if exists t1")
+    tidbStmt.execute("create table t1(a int)")
+    tidbStmt.execute("insert into t1 values (1), (null)")
+    spark.sql("select count(*) from t1").show()
+  }
+
   test("year type index plan") {
     tidbStmt.execute("drop table if exists t1")
     tidbStmt.execute("create table t1(id varchar(10),a year, index idx_a (a))")


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
close https://github.com/pingcap/tispark/issues/1753

current `count aggregration pushdown` implementation is incorrect.

### What is changed and how it works?

simply disable  `count aggregration pushdown` and will do it in https://github.com/pingcap/tispark/issues/1142

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `tidb-ansible` repository
 - Need to be included in the release note
