### PR TITLE
fix Too many keys specified; max 64 keys allowed

### DIFF
--- a/config/tidb-4.0.toml
+++ b/config/tidb-4.0.toml
@@ -14,3 +14,6 @@ enable-table-lock = true
 # If it is true, we can add the primary key by "alter table", but we may not be able to drop the primary key.
 # In order to support "drop primary key" operation , this flag must be true and the table does not have the pkIsHandle flag.
 alter-primary-key = true
+
+# index-limit is used to deal with compatibility issues. It can only be in [64, 64*8].
+index-limit = 512

--- a/core/src/test/scala/com/pingcap/tispark/concurrency/WriteWriteConflictSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/concurrency/WriteWriteConflictSuite.scala
@@ -19,22 +19,6 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.Row
 
 class WriteWriteConflictSuite extends ConcurrencyTest {
-
-  test("Concurrent Insert") {
-      if(blockingRead) {
-        cancel
-      }
-
-    jdbcUpdate(s"create table $dbtable(i int primary key)")
-    (1 to 100).foreach(i => jdbcUpdate(s"insert into $dbtable values ($i)"))
-
-    spark.sql(s"select count(*) from $dbtableWithPrefix").show(false)
-
-
-  }
-
-  private def runTiSparkInsert()
-
   test("write write conflict using TableLock & jdbc") {
     if (!isEnableTableLock) {
       cancel

--- a/core/src/test/scala/com/pingcap/tispark/concurrency/WriteWriteConflictSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/concurrency/WriteWriteConflictSuite.scala
@@ -19,6 +19,22 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.Row
 
 class WriteWriteConflictSuite extends ConcurrencyTest {
+
+  test("Concurrent Insert") {
+      if(blockingRead) {
+        cancel
+      }
+
+    jdbcUpdate(s"create table $dbtable(i int primary key)")
+    (1 to 100).foreach(i => jdbcUpdate(s"insert into $dbtable values ($i)"))
+
+    spark.sql(s"select count(*) from $dbtableWithPrefix").show(false)
+
+
+  }
+
+  private def runTiSparkInsert()
+
   test("write write conflict using TableLock & jdbc") {
     if (!isEnableTableLock) {
       cancel

--- a/core/src/test/scala/com/pingcap/tispark/datatype/DecimalTypeSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datatype/DecimalTypeSuite.scala
@@ -18,7 +18,7 @@ package com.pingcap.tispark.datatype
 import org.apache.spark.sql.BaseTiSparkTest
 
 class DecimalTypeSuite extends BaseTiSparkTest {
-  ignore("test decimal reading logic") {
+  test("test decimal reading logic") {
     judge("select tp_decimal from full_data_type_table_idx")
     judge("select tp_decimal from full_data_type_table")
   }

--- a/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
@@ -268,7 +268,7 @@ class IssueTestSuite extends BaseTiSparkTest {
     }
   }
 
-  ignore("cannot resolve column name when specifying table.column") {
+  test("cannot resolve column name when specifying table.column") {
     spark.sql("select full_data_type_table.id_dt from full_data_type_table").explain(true)
     judge("select full_data_type_table.id_dt from full_data_type_table")
     spark
@@ -279,7 +279,7 @@ class IssueTestSuite extends BaseTiSparkTest {
       "select full_data_type_table.id_dt from full_data_type_table join full_data_type_table_idx on full_data_type_table.id_dt = full_data_type_table_idx.id_dt")
   }
 
-  ignore("test date") {
+  test("test date") {
     judge("select tp_date from full_data_type_table where tp_date >= date '2065-04-19'")
     judge(
       "select tp_date, tp_datetime, id_dt from full_data_type_table where tp_date <= date '2065-04-19' order by id_dt limit 10")
@@ -334,7 +334,7 @@ class IssueTestSuite extends BaseTiSparkTest {
       prevRegionIndexScanDowngradeThreshold)
   }
 
-  ignore("Test index task batch size") {
+  test("Test index task batch size") {
     val tiConf = ti.tiConf
     val prevIndexScanBatchSize = tiConf.getIndexScanBatchSize
     tiConf.setIndexScanBatchSize(5)
@@ -485,7 +485,7 @@ class IssueTestSuite extends BaseTiSparkTest {
     judge("select cast(count(1) as char(20)) from `tmp_empty_tbl`")
   }
 
-  ignore("test push down filters when using index double read") {
+  test("test push down filters when using index double read") {
     if (enableTiFlashTest) {
       cancel("ignored in tiflash test")
     }

--- a/core/src/test/scala/org/apache/spark/sql/catalyst/plans/statistics/StatisticsTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/catalyst/plans/statistics/StatisticsTestSuite.scala
@@ -47,7 +47,7 @@ class StatisticsTestSuite extends BasePlanTest {
   protected var fDataTbl: TiTableInfo = _
   protected var fDataIdxTbl: TiTableInfo = _
 
-  ignore("Test fixed table size estimation") {
+  test("Test fixed table size estimation") {
     tidbStmt.execute("DROP TABLE IF EXISTS `tb_fixed_float`")
     tidbStmt.execute("DROP TABLE IF EXISTS `tb_fixed_int`")
     tidbStmt.execute("DROP TABLE IF EXISTS `tb_fixed_time`")
@@ -158,7 +158,7 @@ class StatisticsTestSuite extends BasePlanTest {
   tableScanCases.foreach { query =>
     {
       val tableName = "full_data_type_table_idx"
-      ignore(query) {
+      test(query) {
         if (isEnableAlterPrimaryKey) {
           cancel()
         }
@@ -171,7 +171,7 @@ class StatisticsTestSuite extends BasePlanTest {
   indexScanCases.foreach {
     case (query, idxName) =>
       val tableName = "full_data_type_table_idx"
-      ignore(query) {
+      test(query) {
         val df = spark.sql(query)
         checkIsIndexScan(df, tableName)
         checkIndex(df, idxName)
@@ -181,7 +181,7 @@ class StatisticsTestSuite extends BasePlanTest {
   coveringIndexScanCases.foreach {
     case (query, idxName) =>
       val tableName = "full_data_type_table_idx"
-      ignore(query) {
+      test(query) {
         if (isEnableAlterPrimaryKey) {
           cancel()
         }

--- a/core/src/test/scala/org/apache/spark/sql/catalyst/plans/statistics/StatisticsTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/catalyst/plans/statistics/StatisticsTestSuite.scala
@@ -93,8 +93,7 @@ class StatisticsTestSuite extends BasePlanTest {
     assert(timeBytes >= 19 * 2)
   }
 
-  ignore(
-    "select count(1) from full_data_type_table_idx where tp_int = 2006469139 or tp_int < 0") {
+  test("select count(1) from full_data_type_table_idx where tp_int = 2006469139 or tp_int < 0") {
     val indexes = fDataIdxTbl.getIndices.asScala
     val idx = indexes.filter(_.getIndexColumns.asScala.exists(_.matchName("tp_int"))).head
 
@@ -108,7 +107,7 @@ class StatisticsTestSuite extends BasePlanTest {
     testSelectRowCount(expressions, idx, 46)
   }
 
-  ignore(
+  test(
     "select tp_int from full_data_type_table_idx where tp_int < 5390653 and tp_int > -46759812") {
     val indexes = fDataIdxTbl.getIndices.asScala
     val idx = indexes.filter(_.getIndexColumns.asScala.exists(_.matchName("tp_int"))).head

--- a/core/src/test/scala/org/apache/spark/sql/expression/LikeTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/LikeTestSuite.scala
@@ -36,7 +36,7 @@ class LikeTestSuite extends BaseInitialOnceTest {
     "select * from full_data_type_table_idx where tp_varchar LIKE 'a%f'",
     "select * from full_data_type_table_idx where tp_varchar LIKE 'ÿ%'")
 
-  ignore("Test - Like") {
+  test("Test - Like") {
     tableScanCases.foreach { query =>
       explainAndRunTest(query)
     }

--- a/core/src/test/scala/org/apache/spark/sql/expression/index/Between0Suite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/index/Between0Suite.scala
@@ -31,7 +31,7 @@ class Between0Suite extends BaseInitialOnceTest {
     "select tp_real from full_data_type_table_idx  where tp_real between 4.44 and 0.5194052764001038 order by id_dt",
     "select tp_real from full_data_type_table_idx  where tp_real between 0.5194052764001038 and 4.44 order by id_dt ")
 
-  ignore("Test index Between") {
+  test("Test index Between") {
     allCases.foreach { query =>
       runTest(query)
     }

--- a/core/src/test/scala/org/apache/spark/sql/expression/index/ComprehensiveSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/index/ComprehensiveSuite.scala
@@ -50,7 +50,7 @@ class ComprehensiveSuite extends BaseInitialOnceTest {
     """select id_dt from full_data_type_table_idx
       | where (tp_int is null or tp_int = 4355836469450447576) and tp_tinyint < 100 order by 1""".stripMargin)
 
-  ignore("Test index - Comprehensive") {
+  test("Test index - Comprehensive") {
     allCases.foreach { query =>
       runTest(query)
     }

--- a/core/src/test/scala/org/apache/spark/sql/expression/index/CoveringIndex0Suite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/index/CoveringIndex0Suite.scala
@@ -491,7 +491,7 @@ class CoveringIndex0Suite extends BaseInitialOnceTest {
     "select id_dt from full_data_type_table_idx where tp_int is null and tp_tinyint < 100 order by id_dt",
     "select id_dt from full_data_type_table_idx where tp_int = 4355836469450447576 is null and tp_tinyint < 100 order by id_dt")
 
-  ignore("Test index - Covering Index") {
+  test("Test index - Covering Index") {
     allCases.foreach { query =>
       runTest(query)
     }

--- a/core/src/test/scala/org/apache/spark/sql/expression/index/InTest0Suite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/index/InTest0Suite.scala
@@ -32,7 +32,7 @@ class InTest0Suite extends BaseInitialOnceTest {
     "select tp_timestamp from full_data_type_table_idx  where tp_timestamp in ('2017-11-02 16:48:01') order by id_dt ",
     "select tp_real from full_data_type_table_idx  where tp_real in (4.44,0.5194052764001038) order by id_dt ")
 
-  ignore("Test index In") {
+  test("Test index In") {
     allCases.foreach { query =>
       runTest(query)
     }

--- a/core/src/test/scala/org/apache/spark/sql/expression/index/Join0Suite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/index/Join0Suite.scala
@@ -35,7 +35,7 @@ class Join0Suite extends BaseInitialOnceTest {
     "select a.id_dt from full_data_type_table_idx a join full_data_type_table_idx b on a.tp_date = b.tp_date",
     "select a.id_dt from full_data_type_table_idx a join full_data_type_table_idx b on a.tp_timestamp = b.tp_timestamp")
 
-  ignore("Test index - Join") {
+  test("Test index - Join") {
     allCases.foreach { query =>
       runTest(query)
     }

--- a/core/src/test/scala/org/apache/spark/sql/expression/index/Special0Suite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/expression/index/Special0Suite.scala
@@ -78,7 +78,7 @@ class Special0Suite extends BaseInitialOnceTest {
     "select * from full_data_type_table_idx where tp_timestamp <> timestamp(timestamp '2017-11-02 08:47:43')",
     "select * from full_data_type_table_idx where tp_timestamp <> timestamp(timestamp '2017-09-07 11:11:11')")
 
-  ignore("Test index - Date/Timestamp") {
+  test("Test index - Date/Timestamp") {
     allCases.foreach { query =>
       runTest(query)
     }

--- a/core/src/test/scala/org/apache/spark/sql/test/SharedSQLContext.scala
+++ b/core/src/test/scala/org/apache/spark/sql/test/SharedSQLContext.scala
@@ -304,7 +304,7 @@ trait SharedSQLContext
       if (shouldLoadData(loadData) && !forceNotLoad) {
         logger.info("Loading TiSparkTestData")
         // Load index test data
-        // loadSQLFile("tispark-test", "IndexTest")
+        loadSQLFile("tispark-test", "IndexTest")
         // Load expression test data
         loadSQLFile("tispark-test", "TiSparkTest")
         // Load TPC-H test data
@@ -332,8 +332,8 @@ trait SharedSQLContext
   private def initStatistics(): Unit = {
     _tidbConnection.setCatalog("tispark_test")
     initializeStatement()
-    //logger.info("Analyzing table tispark_test.full_data_type_table_idx...")
-    //_statement.execute("analyze table tispark_test.full_data_type_table_idx")
+    logger.info("Analyzing table tispark_test.full_data_type_table_idx...")
+    _statement.execute("analyze table tispark_test.full_data_type_table_idx")
     logger.info("Analyzing table tispark_test.full_data_type_table...")
     _statement.execute("analyze table tispark_test.full_data_type_table")
     logger.info("Analyzing table finished.")


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
close https://github.com/pingcap/tispark/issues/1730

tidb limit the max index column number to 64

### What is changed and how it works?
set `index-limit = 512` in tidb config


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `tidb-ansible` repository
 - Need to be included in the release note
