### PR TITLE
fix overflow when convert big MyDecimal to BigDecimal

### DIFF
--- a/tikv-client/src/main/java/com/pingcap/tikv/codec/MyDecimal.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/codec/MyDecimal.java
@@ -791,7 +791,7 @@ public class MyDecimal implements Serializable {
     return x;
   }
 
-  public long toLong() {
+  private long toLong() {
     long x = 0;
     int wordIdx = 0;
     for (int i = this.digitsInt; i > 0; i -= digitsPerWord) {
@@ -818,7 +818,9 @@ public class MyDecimal implements Serializable {
     // 19 is the length of digits of Long.MAX_VALUE
     // If a decimal can be expressed as a long value, we should use toLong method which has
     // better performance than toBigInteger.
-    if (digitsInt + digitsFrac < 19) {
+    if ((digitsInt + digitsPerWord - 1) / digitsPerWord
+            + (digitsFrac + digitsPerWord - 1) / digitsPerWord
+        < (19 + digitsPerWord - 1) / digitsPerWord) {
       return new BigDecimal(BigInteger.valueOf(toLong()), digitsFrac);
     }
     return new BigDecimal(toBigInteger(), digitsFrac);

--- a/tikv-client/src/test/java/com/pingcap/tikv/codec/MyDecimalTest.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/codec/MyDecimalTest.java
@@ -20,6 +20,7 @@ package com.pingcap.tikv.codec;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.Test;
@@ -104,6 +105,17 @@ public class MyDecimalTest {
           0x7E, 0xF2, 0x04, 0xC7, 0x2D, 0xFB, 0x2D,
         };
     assertArrayEquals(expected, data);
+  }
+
+  // https://github.com/pingcap/tispark/issues/1864
+  @Test
+  public void toBigDecimalOverflowTest() {
+    int[] wordBuf = new int[9];
+    wordBuf[0] = 24;
+    wordBuf[1] = 375218000;
+    MyDecimal dec = new MyDecimal(14, 2, false, wordBuf);
+    BigDecimal result = dec.toBigDecimal();
+    assertEquals("24375218000.00", result.toPlainString());
   }
 
   // MyDecimalTestStruct is only used for simplifying testing.


### PR DESCRIPTION
### What problem does this PR solve?

This fixes https://github.com/pingcap/tispark/issues/1864.

### What is changed and how it works?

Correctly judge whether it's safe to use the `toLong()` optimization.

### Check List

Tests

 - Unit test

Related changes

 - Need to cherry-pick to the release branch

Yes, need backport to 2.3.x and 2.4.x.
