### PR TITLE
txn: fix the resolved txn status cache for pessimistic txn

### DIFF
--- a/tikv-client/src/main/java/com/pingcap/tikv/txn/LockResolverClientV4.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/txn/LockResolverClientV4.java
@@ -230,7 +230,13 @@ public class LockResolverClientV4 extends AbstractRegionStoreClient
     while (true) {
       try {
         return getTxnStatus(
-            bo, lock.getTxnID(), lock.getPrimary(), callerStartTS, currentTS, rollbackIfNotExist);
+            bo,
+            lock.getTxnID(),
+            lock.getPrimary(),
+            callerStartTS,
+            currentTS,
+            rollbackIfNotExist,
+            lock);
       } catch (TxnNotFoundException e) {
         // If the error is something other than txnNotFoundErr, throw the error (network
         // unavailable, tikv down, backoff timeout etc) to the caller.
@@ -270,7 +276,8 @@ public class LockResolverClientV4 extends AbstractRegionStoreClient
       ByteString primary,
       Long callerStartTS,
       Long currentTS,
-      boolean rollbackIfNotExist) {
+      boolean rollbackIfNotExist,
+      Lock lock) {
     TxnStatus status = getResolved(txnID);
     if (status != null) {
       return status;
@@ -346,9 +353,26 @@ public class LockResolverClientV4 extends AbstractRegionStoreClient
         status = new TxnStatus(resp.getLockTtl(), 0L, resp.getAction());
       } else {
         status = new TxnStatus(0L, resp.getCommitVersion(), resp.getAction());
-        saveResolved(txnID, status);
-      }
 
+        // If the transaction is still valid with ttl greater than zero, do nothing.
+        // If its status is certain:
+        //     If transaction is already committed, the result could be cached.
+        //     Otherwise:
+        //       If l.LockType is pessimistic lock type:
+        //           - if its primary lock is pessimistic too, the check txn status result should
+        // not be cached.
+        //           - if its primary lock is prewrite lock type, the check txn status could be
+        // cached, todo.
+        //       If l.lockType is prewrite lock type:
+        //           - always cache the check txn status result.
+        // For prewrite locks, their primary keys should ALWAYS be the correct one and will NOT
+        // change.
+        if (status.isCommitted()
+            || (lock != null
+                && lock.getLockType() != org.tikv.kvproto.Kvrpcpb.Op.PessimisticLock)) {
+          saveResolved(txnID, status);
+        }
+      }
       return status;
     }
   }


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
Solve the incorrect transaction status cache for resolve pessimistic primary key lock.

see https://github.com/pingcap/tidb/pull/21689

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `tidb-ansible` repository
 - Need to be included in the release note
