### PR TITLE
add retry in RangeSplitter

### DIFF
--- a/tikv-client/src/test/java/com/pingcap/tikv/util/RangeSplitterTest.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/util/RangeSplitterTest.java
@@ -298,7 +298,7 @@ public class RangeSplitterTest {
 
     @Override
     public Pair<TiRegion, Metapb.Store> getRegionStorePairByKey(
-        ByteString key, TiStoreType storeType) {
+        ByteString key, TiStoreType storeType, BackOffer backOffer) {
       for (Map.Entry<KeyRange, TiRegion> entry : mockRegionMap.entrySet()) {
         KeyRange range = entry.getKey();
         if (KeyRangeUtils.makeRange(range.getStart(), range.getEnd()).contains(Key.toRawKey(key))) {


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
`RangeSplitter` miss retry during `getPartitions`

```
Caused by: com.pingcap.tikv.exception.TiClientInternalException: Cannot find valid store on TiFlash(engine=tiflash) for region

{Region[253] ConfVer[17] Version[37] Store[6] KeyRange[t\200\000\000\000\000\000\000A_r\200\000\000\000\000\026\352\"]:[t\200\000\000\000\000\000\000A_r\200\000\000\000\000\033L\265]}

at com.pingcap.tikv.region.RegionManager.getRegionStorePairByKey(RegionManager.java:132)
at com.pingcap.tikv.region.RegionManager.getRegionStorePairByKey(RegionManager.java:95)
at com.pingcap.tikv.util.RangeSplitter.splitRangeByRegion(RangeSplitter.java:175)
at org.apache.spark.sql.tispark.TiRDD.getPartitions(TiRDD.scala:56)
at org.apache.spark.rdd.RDD$$anonfun$partitions$2.apply(RDD.scala:253)
at org.apache.spark.rdd.RDD$$anonfun$partitions$2.apply(RDD.scala:251)
at scala.Option.getOrElse(Option.scala:121)
at org.apache.spark.rdd.RDD.partitions(RDD.scala:251)
at org.apache.spark.SparkContext$$anonfun$union$1$$anonfun$31.apply(SparkContext.scala:1314)
at org.apache.spark.SparkContext$$anonfun$union$1$$anonfun$31.apply(SparkContext.scala:1314)
at scala.collection.TraversableLike$$anonfun$filterImpl$1.apply(TraversableLike.scala:248)
at scala.collection.immutable.List.foreach(List.scala:392)
at scala.collection.TraversableLike$class.filterImpl(TraversableLike.scala:247)
at scala.collection.TraversableLike$class.filter(TraversableLike.scala:259)
at scala.collection.AbstractTraversable.filter(Traversable.scala:104)
at org.apache.spark.SparkContext$$anonfun$union$1.apply(SparkContext.scala:1314)
at org.apache.spark.SparkContext$$anonfun$union$1.apply(SparkContext.scala:1313)
at org.apache.spark.rdd.RDDOperationScope$.withScope(RDDOperationScope.scala:151)
at org.apache.spark.rdd.RDDOperationScope$.withScope(RDDOperationScope.scala:112)
at org.apache.spark.SparkContext.withScope(SparkContext.scala:699)
at org.apache.spark.SparkContext.union(SparkContext.scala:1313)
at org.apache.spark.sql.execution.ColumnarCoprocessorRDD.inputRDDs(CoprocessorRDD.scala:86)
at org.apache.spark.sql.execution.FilterExec.inputRDDs(basicPhysicalOperators.scala:121)
at org.apache.spark.sql.execution.ProjectExec.inputRDDs(basicPhysicalOperators.scala:41)
at org.apache.spark.sql.execution.aggregate.HashAggregateExec.inputRDDs(HashAggregateExec.scala:151)
at org.apache.spark.sql.execution.WholeStageCodegenExec.doExecute(WholeStageCodegenExec.scala:627)
at org.apache.spark.sql.execution.SparkPlan$$anonfun$execute$1.apply(SparkPlan.scala:131)
at org.apache.spark.sql.execution.SparkPlan$$anonfun$execute$1.apply(SparkPlan.scala:127)
at org.apache.spark.sql.execution.SparkPlan$$anonfun$executeQuery$1.apply(SparkPlan.scala:155)
at org.apache.spark.rdd.RDDOperationScope$.withScope(RDDOperationScope.scala:151)
at org.apache.spark.sql.execution.SparkPlan.executeQuery(SparkPlan.scala:152)
at org.apache.spark.sql.execution.SparkPlan.execute(SparkPlan.scala:127)
at org.apache.spark.sql.execution.exchange.ShuffleExchangeExec.prepareShuffleDependency(ShuffleExchangeExec.scala:92)
at org.apache.spark.sql.execution.exchange.ShuffleExchangeExec$$anonfun$doExecute$1.apply(ShuffleExchangeExec.scala:128)
at org.apache.spark.sql.execution.exchange.ShuffleExchangeExec$$anonfun$doExecute$1.apply(ShuffleExchangeExec.scala:119)
at org.apache.spark.sql.catalyst.errors.package$.attachTree(package.scala:52)
```

### What is changed and how it works?
add retry in `RangeSplitter`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `tidb-ansible` repository
 - Need to be included in the release note
