### PR TITLE
fix jackson-databind

### DIFF
--- a/tikv-client/pom.xml
+++ b/tikv-client/pom.xml
@@ -22,7 +22,8 @@
         <slf4j.version>1.7.16</slf4j.version>
         <grpc.version>1.29.0</grpc.version>
         <powermock.version>1.6.6</powermock.version>
-        <jackson.version>2.10.0</jackson.version>
+        <jackson.annotations.version>2.9.10</jackson.annotations.version>
+        <jackson.databind.version>2.9.10.4</jackson.databind.version>
         <trove4j.version>3.0.1</trove4j.version>
         <jetcd.version>0.4.1</jetcd.version>
         <joda-time.version>2.9.9</joda-time.version>
@@ -90,13 +91,13 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>${jackson.version}</version>
+            <version>${jackson.annotations.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
+            <version>${jackson.databind.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
A flaw was discovered in jackson-databind in versions before 2.9.10, 2.8.11.5 and 2.6.7.3, where it would permit polymorphic deserialization of a malicious object using commons-configuration 1 and 2 JNDI classes. An attacker could use this flaw to execute arbitrary code.

PATCHED VERSIONS ： 2.9.10.4
