### PR TITLE
fix cluster index bug: primary key has more than one column

### DIFF
--- a/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
@@ -36,8 +36,8 @@ class IssueTestSuite extends BaseTiSparkTest {
         |  `col_int1` int(11) not null,
         |  UNIQUE KEY (`col_int0`),
         |  PRIMARY KEY (`col_bit1`,`col_bit0`)
-        |) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
-        |INSERT INTO `tispark_test`.`clustered0` VALUES (b'1',b'0',-1,-1);
+        |  );
+        |  INSERT INTO `tispark_test`.`clustered0` VALUES (b'1',b'0',-1,-1);
         |""".stripMargin)
     val sql = "select * from clustered0"
     spark.sql(s"explain $sql").show(200, false)

--- a/core/src/test/scala/org/apache/spark/sql/clustered/IndexScan1Suite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/clustered/IndexScan1Suite.scala
@@ -30,7 +30,7 @@ class IndexScan1Suite extends ClusteredIndexTest {
     super.afterAll()
   }
 
-  ignore("index scan 1: primary key has two columns") {
+  test("index scan 1: primary key has two columns") {
     for (dataType1 <- testDataTypes) {
       for (dataType2 <- testDataTypes) {
         val schemas = genSchema(List(dataType2, dataType1, INT, INT), tablePrefix)

--- a/core/src/test/scala/org/apache/spark/sql/clustered/TableScan1Suite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/clustered/TableScan1Suite.scala
@@ -18,7 +18,7 @@ package org.apache.spark.sql.clustered
 import org.apache.spark.sql.test.generator.DataType.INT
 
 class TableScan1Suite extends ClusteredIndexTest {
-  ignore("table scan 1: primary key has two columns") {
+  test("table scan 1: primary key has two columns") {
     for (dataType1 <- testDataTypes) {
       for (dataType2 <- testDataTypes) {
         val schemas = genSchema(List(dataType2, dataType1, INT, INT), tablePrefix)

--- a/tikv-client/src/main/java/com/pingcap/tikv/codec/CodecDataInput.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/codec/CodecDataInput.java
@@ -217,7 +217,7 @@ public class CodecDataInput implements DataInput {
         RealCodec.readDouble(this);
         break;
       case BYTES_FLAG:
-        readByte();
+        BytesCodec.readBytes(this);
         break;
       case COMPACT_BYTES_FLAG:
         BytesCodec.readCompactBytes(this);

--- a/tikv-client/src/main/java/com/pingcap/tikv/predicates/TiKVScanAnalyzer.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/predicates/TiKVScanAnalyzer.java
@@ -178,9 +178,6 @@ public class TiKVScanAnalyzer {
           if (table.isCommonHandle() && table.getPrimaryKey().equals(index)) {
             continue;
           }
-          if (table.isCommonHandle() && table.getPrimaryKey().getIndexColumns().size() >= 2) {
-            continue;
-          }
 
           if (supportIndexScan(index, table)) {
             TiKVScanPlan plan =


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

fix cluster index bug: primary key has more than one column

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `tidb-ansible` repository
 - Need to be included in the release note
