### PR TITLE
fix GregorianCalendar

### DIFF
--- a/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
@@ -21,6 +21,23 @@ import org.apache.spark.sql.functions.{col, sum}
 
 class IssueTestSuite extends BaseTiSparkTest {
 
+  test("test GregorianCalendar") {
+    tidbStmt.execute("drop table if exists t")
+    tidbStmt.execute("""
+                       |CREATE TABLE t (c1 date,c2 bigint(20) DEFAULT NULL);
+                       |insert into t values ('1582-10-04', 1);
+                       |insert into t values ('1582-10-15', 2);
+                       |insert into t values ('1582-10-05', 11);
+                       |insert into t values ('1582-10-06', 12);
+                       |insert into t values ('1582-10-14', 13);
+                       |""".stripMargin)
+
+    val query = "select * from t"
+    spark.sql(s"explain $query").show(false)
+    spark.sql(query).show(false)
+    runTest(query, skipJDBC = true)
+  }
+
   test("partition table with date partition column name") {
     tidbStmt.execute("drop table if exists t1")
     tidbStmt.execute("""

--- a/tikv-client/src/main/java/com/pingcap/tikv/columnar/TiBlockColumnVector.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/columnar/TiBlockColumnVector.java
@@ -197,7 +197,7 @@ public class TiBlockColumnVector extends TiColumnVector {
     int month = (int) (ym % 13);
     int day = (int) (ymd & ((1 << 5) - 1));
     LocalDate date = new LocalDate(year, month, day);
-    return ((DateType) type).getDays(date);
+    return ((DateType) type).getDaysUsingJulianGregorianCalendar(date);
   }
   /**
    * Returns the long type value for rowId. The return value is undefined and can be anything, if

--- a/tikv-client/src/main/java/com/pingcap/tikv/columnar/TiChunkColumnVector.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/columnar/TiChunkColumnVector.java
@@ -144,7 +144,7 @@ public class TiChunkColumnVector extends TiColumnVector {
     }
     if (this.type instanceof DateType) {
       LocalDate date = new LocalDate(year, month, day);
-      return ((DateType) this.type).getDays(date);
+      return ((DateType) this.type).getDaysUsingJulianGregorianCalendar(date);
     } else if (type instanceof DateTimeType || type instanceof TimestampType) {
       // only return microsecond from epoch.
       Timestamp ts =


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
In Spark 3.0, Proleptic Gregorian calendar is used in parsing, formatting, and converting dates
and timestamps as well as in extracting sub-components like years, days and so on. Spark 3.0
uses Java 8 API classes from the java.time packages that are based on ISO chronology. In Spark
 version 2.4 and below, those operations are performed using the hybrid calendar (Julian +
Gregorian. The changes impact on the results for dates before October 15, 1582 (Gregorian) and
 affect on the following Spark 3.0 API.

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `tidb-ansible` repository
 - Need to be included in the release note
