### PR TITLE
fix unit test: convert real

### DIFF
--- a/core/src/test/scala/com/pingcap/tispark/convert/ToRealSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/convert/ToRealSuite.scala
@@ -166,10 +166,14 @@ class ToRealSuite extends BaseBatchWriteTest("test_data_type_convert_to_real") {
     // java.lang.Long -> DOUBLE
     compareTiDBWriteWithJDBC {
       case (writeFunc, _) =>
+        val factor = 0.00000000001
+        val max = (factor * java.lang.Long.MAX_VALUE).toLong
+        val min = (factor * java.lang.Long.MIN_VALUE).toLong
+
         val row1 = Row(1, null, null)
         val row2 = Row(2, 22L, 33L)
-        val row3 = Row(3, java.lang.Long.MAX_VALUE, java.lang.Long.MIN_VALUE)
-        val row4 = Row(4, java.lang.Long.MIN_VALUE, java.lang.Long.MAX_VALUE)
+        val row3 = Row(3, max, min)
+        val row4 = Row(4, min, max)
 
         val schema = StructType(
           List(


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
```
[2021-03-15T06:50:51.604Z] - Test Convert from java.lang.Long to REAL *** FAILED ***

[2021-03-15T06:50:51.604Z]   BaseDataSourceTest.this.compSqlResult(sql, jdbcResult, answer, false) was false (BaseDataSourceTest.scala:195)
```

### What is changed and how it works?
fix comparison between `long` and `float`, because of Precision problem

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `tidb-ansible` repository
 - Need to be included in the release note
