### PR TITLE
fix unit test: NPE when decoding datetime,date,timestamp

### DIFF
--- a/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
@@ -455,20 +455,6 @@ class IssueTestSuite extends BaseTiSparkTest {
     project_df.show
   }
 
-  // https://github.com/pingcap/tispark/issues/262
-  // https://github.com/pingcap/tispark/issues/1794
-  ignore("NPE when decoding datetime,date,timestamp") {
-    if (enableTiFlashTest) {
-      cancel("ignored in tiflash test")
-    }
-    tidbStmt.execute("DROP TABLE IF EXISTS `tmp_debug`")
-    tidbStmt.execute(
-      "CREATE TABLE `tmp_debug` (\n  `tp_datetime` datetime DEFAULT NULL, `tp_date` date DEFAULT NULL, `tp_timestamp` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP\n) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin")
-    tidbStmt.execute(
-      "INSERT INTO `tmp_debug` VALUES ('0000-00-00 00:00:00','0000-00-00','0000-00-00 00:00:00')")
-    spark.sql("select * from tmp_debug").collect().foreach(println)
-  }
-
   // https://github.com/pingcap/tispark/issues/255
   test("Group by with first") {
     setCurrentDatabase(tpchDBName)


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
cherry pick https://github.com/pingcap/tispark/pull/1956/files
close https://github.com/pingcap/tispark/issues/1794

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `tidb-ansible` repository
 - Need to be included in the release note
