### PR TITLE
Revert "disable date test in ClusteredIndexTest (#1941)"

### DIFF
--- a/core/src/test/scala/org/apache/spark/sql/clustered/ClusteredIndexTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/clustered/ClusteredIndexTest.scala
@@ -17,15 +17,14 @@ package org.apache.spark.sql.clustered
 
 import org.apache.spark.sql.BaseTiSparkTest
 import org.apache.spark.sql.insertion.BaseEnumerateDataTypesTestSpec
-import org.apache.spark.sql.test.generator.DataType.{BIT, BOOLEAN, DATE, ReflectedDataType}
+import org.apache.spark.sql.test.generator.DataType.{BIT, BOOLEAN, ReflectedDataType}
 import org.apache.spark.sql.test.generator.TestDataGenerator._
 import org.apache.spark.sql.test.generator._
 
 import scala.util.Random
 
 trait ClusteredIndexTest extends BaseTiSparkTest with BaseEnumerateDataTypesTestSpec {
-  // https://github.com/pingcap/tispark/issues/1939
-  protected val testDataTypes: List[ReflectedDataType] = baseDataTypes.filter(!_.equals(DATE))
+  protected val testDataTypes: List[ReflectedDataType] = baseDataTypes
 
   protected val tablePrefix: String = "clustered"
 


### PR DESCRIPTION
This reverts commit da92a61af2733fc4376e9295325e8289962a7d22.

### What problem does this PR solve? <!--add issue link with summary if exists-->


### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `tidb-ansible` repository
 - Need to be included in the release note
