### PR TITLE
Fix array index out of bound when encoding

### DIFF
--- a/tikv-client/src/main/java/com/pingcap/tikv/codec/RowEncoderV2.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/codec/RowEncoderV2.java
@@ -176,8 +176,8 @@ public class RowEncoderV2 {
           this.row.colIDs32[j] = Byte.toUnsignedInt(this.row.colIDs[j]);
         }
         this.row.initOffsets32();
-        if (numCols >= 0) {
-          System.arraycopy(this.row.offsets, 0, this.row.offsets32, 0, numCols);
+        if (this.row.numNotNullCols >= 0) {
+          System.arraycopy(this.row.offsets, 0, this.row.offsets32, 0, this.row.numNotNullCols);
         }
         this.row.large = true;
       }


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
fix https://github.com/pingcap/tispark/issues/1959

Fix array IndexOutOfBound when decoding using RowEncoderV2.

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `tidb-ansible` repository
 - Need to be included in the release note
