### PR TITLE
let test success because of a tiflash bug

### DIFF
--- a/.ci/tidb_config-for-tiflash-test.properties
+++ b/.ci/tidb_config-for-tiflash-test.properties
@@ -1,1 +1,2 @@
 test.tiflash.enable=true
+spark.tispark.coprocess.codec_format=chunk

--- a/core/src/test/scala/org/apache/spark/sql/test/SharedSQLContext.scala
+++ b/core/src/test/scala/org/apache/spark/sql/test/SharedSQLContext.scala
@@ -391,6 +391,15 @@ trait SharedSQLContext
 
         conf = new SparkConf(false)
 
+        val propertyNames = _tidbConf.propertyNames()
+        while (propertyNames.hasMoreElements) {
+          val key: String = propertyNames.nextElement().asInstanceOf[String]
+          if (key.startsWith("spark.")) {
+            val value = _tidbConf.getProperty(key)
+            conf.set(key, value)
+          }
+        }
+
         conf.set("spark.tispark.write.allow_spark_sql", "true")
         conf.set("spark.tispark.write.without_lock_table", "true")
         conf.set("spark.tispark.tikv.region_split_size_in_mb", "1")


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
let test success because of a tiflash bug
https://github.com/pingcap/tics/issues/1572
insert 1969-12-31 return 1970-01-01 when disable chunk rpc and set timezone

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `tidb-ansible` repository
 - Need to be included in the release note
