### PR TITLE
fix tidb_enable_clustered_index only support global variable (#1972)

### DIFF
--- a/core/src/main/scala/com/pingcap/tispark/write/TiBatchWriteTable.scala
+++ b/core/src/main/scala/com/pingcap/tispark/write/TiBatchWriteTable.scala
@@ -317,6 +317,11 @@ class TiBatchWriteTable(
   }
 
   def checkUnsupported(): Unit = {
+    if (tiTableInfo.isCommonHandle) {
+      throw new TiBatchWriteException(
+        "tispark currently does not support write data to table with clustered index!")
+    }
+
     // write to table with auto random column
     if (tiTableInfo.hasAutoRandomColumn) {
       throw new TiBatchWriteException(

--- a/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
@@ -95,8 +95,8 @@ class IssueTestSuite extends BaseTiSparkTest {
       cancel("currently tidb instance does not support clustered index")
     }
     spark.sqlContext.setConf(TiConfigConst.USE_INDEX_SCAN_FIRST, "true")
+    enableClusteredIndex()
     tidbStmt.execute("""
-        |SET tidb_enable_clustered_index = 1;
         |drop table if exists `tispark_test`.`clustered0`;
         |CREATE TABLE `tispark_test`.`clustered0` (
         |  `col_bit0` bit(1) not null,
@@ -113,6 +113,8 @@ class IssueTestSuite extends BaseTiSparkTest {
     spark.sql(s"$sql").show(200, false)
     runTest(sql, skipJDBC = true)
     spark.sqlContext.setConf(TiConfigConst.USE_INDEX_SCAN_FIRST, "false")
+
+    disableClusteredIndex()
   }
 
   test("partition table with date partition column name") {

--- a/core/src/test/scala/org/apache/spark/sql/clustered/ClusteredIndexTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/clustered/ClusteredIndexTest.scala
@@ -42,7 +42,7 @@ trait ClusteredIndexTest extends BaseTiSparkTest with BaseEnumerateDataTypesTest
 
   override def afterAll(): Unit = {
     if (supportClusteredIndex) {
-      executeTiDBSQL("SET tidb_enable_clustered_index = 0;")
+      disableClusteredIndex()
     }
     super.afterAll()
   }
@@ -88,7 +88,7 @@ trait ClusteredIndexTest extends BaseTiSparkTest with BaseEnumerateDataTypesTest
   }
 
   protected def test(schema: Schema): Unit = {
-    executeTiDBSQL("SET tidb_enable_clustered_index = 1;")
+    enableClusteredIndex()
     executeTiDBSQL(s"drop table if exists `$dbName`.`${schema.tableName}`;")
     executeTiDBSQL(schema.toString)
 

--- a/core/src/test/scala/org/apache/spark/sql/test/SharedSQLContext.scala
+++ b/core/src/test/scala/org/apache/spark/sql/test/SharedSQLContext.scala
@@ -174,6 +174,19 @@ trait SharedSQLContext
 
   protected def initializeStatement(): Unit = {
     _statement = _tidbConnection.createStatement()
+    disableClusteredIndex()
+  }
+
+  protected def enableClusteredIndex(): Unit = {
+    _statement.execute("SET GLOBAL tidb_enable_clustered_index = 1")
+    _statement.close()
+    _statement = _tidbConnection.createStatement()
+  }
+
+  protected def disableClusteredIndex(): Unit = {
+    _statement.execute("SET GLOBAL tidb_enable_clustered_index = 0")
+    _statement.close()
+    _statement = _tidbConnection.createStatement()
   }
 
   protected def timeZoneOffset: String = SharedSQLContext.timeZoneOffset


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

cherry pick https://github.com/pingcap/tispark/pull/1972
### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `tidb-ansible` repository
 - Need to be included in the release note
