### PR TITLE
fix tidb_enable_clustered_index test with tidb-4.0

### DIFF
--- a/core/src/test/scala/org/apache/spark/sql/BaseTiSparkTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/BaseTiSparkTest.scala
@@ -138,12 +138,6 @@ class BaseTiSparkTest extends QueryTest with SharedSQLContext {
     tiDBJDBCClient.isEnableTableLock
   }
 
-  protected def supportClusteredIndex: Boolean = {
-    val conn = TiDBUtils.createConnectionFactory(jdbcUrl)()
-    val tiDBJDBCClient = new TiDBJDBCClient(conn)
-    tiDBJDBCClient.supportClusteredIndex
-  }
-
   protected def supportTTLUpdate: Boolean = {
     StoreVersion.minTiKVVersion(Version.RESOLVE_LOCK_V3, this.ti.tiSession.getPDClient)
   }

--- a/core/src/test/scala/org/apache/spark/sql/test/SharedSQLContext.scala
+++ b/core/src/test/scala/org/apache/spark/sql/test/SharedSQLContext.scala
@@ -20,8 +20,7 @@ package org.apache.spark.sql.test
 import java.io.File
 import java.sql.{Connection, Date, Statement}
 import java.util.{Locale, Properties, TimeZone}
-
-import com.pingcap.tikv.{StoreVersion, Version}
+import com.pingcap.tikv.{StoreVersion, TiDBJDBCClient, Version}
 import com.pingcap.tispark.TiDBUtils
 import com.pingcap.tispark.statistics.StatisticsManager
 import org.apache.spark.internal.Logging
@@ -175,7 +174,15 @@ trait SharedSQLContext
 
   protected def initializeStatement(): Unit = {
     _statement = _tidbConnection.createStatement()
-    disableClusteredIndex()
+    if (supportClusteredIndex) {
+      disableClusteredIndex()
+    }
+  }
+
+  protected def supportClusteredIndex: Boolean = {
+    val conn = TiDBUtils.createConnectionFactory(jdbcUrl)()
+    val tiDBJDBCClient = new TiDBJDBCClient(conn)
+    tiDBJDBCClient.supportClusteredIndex
   }
 
   protected def enableClusteredIndex(): Unit = {


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

fix tidb_enable_clustered_index test with tidb-4.0

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `tidb-ansible` repository
 - Need to be included in the release note
