### PR TITLE
fix regresstion test: AutoIncrementSuite

### DIFF
--- a/core/src/test/scala/com/pingcap/tispark/datasource/ColumnMappingSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/ColumnMappingSuite.scala
@@ -69,7 +69,7 @@ class ColumnMappingSuite
   }
 
   test("Test different column order without auto increment column") {
-    if (isEnableAlterPrimaryKey) {
+    if (isEnableAlterPrimaryKey || supportClusteredIndex) {
       cancel()
     }
 

--- a/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
@@ -42,10 +42,11 @@ class IssueTestSuite extends BaseTiSparkTest {
       cancel("currently tidb instance does not support clustered index")
     }
     spark.sqlContext.setConf(TiConfigConst.USE_INDEX_SCAN_FIRST, "true")
-    enableClusteredIndex()
-    tidbStmt.execute("""
-        |drop table if exists `tispark_test`.`clustered0`;
-        |CREATE TABLE `tispark_test`.`clustered0` (
+
+    tidbStmt.execute("drop table if exists `tispark_test`.`clustered0`")
+
+    createTableWithClusteredIndex("""
+        CREATE TABLE `tispark_test`.`clustered0` (
         |  `col_bit0` bit(1) not null,
         |  `col_bit1` bit(1) not null,
         |  `col_int0` int(11) not null,
@@ -53,15 +54,14 @@ class IssueTestSuite extends BaseTiSparkTest {
         |  UNIQUE KEY (`col_int0`),
         |  PRIMARY KEY (`col_bit1`,`col_bit0`)
         |  );
-        |  INSERT INTO `tispark_test`.`clustered0` VALUES (b'1',b'0',-1,-1);
         |""".stripMargin)
+
+    tidbStmt.execute("INSERT INTO `tispark_test`.`clustered0` VALUES (b'1',b'0',-1,-1)")
     val sql = "select * from clustered0"
     spark.sql(s"explain $sql").show(200, false)
     spark.sql(s"$sql").show(200, false)
     runTest(sql, skipJDBC = true)
     spark.sqlContext.setConf(TiConfigConst.USE_INDEX_SCAN_FIRST, "false")
-
-    disableClusteredIndex()
   }
 
   test("partition table with date partition column name") {

--- a/core/src/test/scala/org/apache/spark/sql/catalyst/plans/statistics/StatisticsTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/catalyst/plans/statistics/StatisticsTestSuite.scala
@@ -158,7 +158,7 @@ class StatisticsTestSuite extends BasePlanTest {
     {
       val tableName = "full_data_type_table_idx"
       test(query) {
-        if (isEnableAlterPrimaryKey) {
+        if (isEnableAlterPrimaryKey || supportClusteredIndex) {
           cancel()
         }
         val df = spark.sql(query)
@@ -181,7 +181,7 @@ class StatisticsTestSuite extends BasePlanTest {
     case (query, idxName) =>
       val tableName = "full_data_type_table_idx"
       test(query) {
-        if (isEnableAlterPrimaryKey) {
+        if (isEnableAlterPrimaryKey || supportClusteredIndex) {
           cancel()
         }
         val df = spark.sql(query)

--- a/core/src/test/scala/org/apache/spark/sql/clustered/ClusteredIndexTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/clustered/ClusteredIndexTest.scala
@@ -41,9 +41,6 @@ trait ClusteredIndexTest extends BaseTiSparkTest with BaseEnumerateDataTypesTest
   override def test(): Unit = ???
 
   override def afterAll(): Unit = {
-    if (supportClusteredIndex) {
-      disableClusteredIndex()
-    }
     super.afterAll()
   }
 
@@ -88,9 +85,8 @@ trait ClusteredIndexTest extends BaseTiSparkTest with BaseEnumerateDataTypesTest
   }
 
   protected def test(schema: Schema): Unit = {
-    enableClusteredIndex()
     executeTiDBSQL(s"drop table if exists `$dbName`.`${schema.tableName}`;")
-    executeTiDBSQL(schema.toString)
+    createTableWithClusteredIndex(schema.toString)
 
     var rc = rowCount
     schema.columnInfo.foreach { columnInfo =>

--- a/core/src/test/scala/org/apache/spark/sql/test/SharedSQLContext.scala
+++ b/core/src/test/scala/org/apache/spark/sql/test/SharedSQLContext.scala
@@ -185,16 +185,34 @@ trait SharedSQLContext
     tiDBJDBCClient.supportClusteredIndex
   }
 
-  protected def enableClusteredIndex(): Unit = {
-    _statement.execute("SET GLOBAL tidb_enable_clustered_index = 1")
-    _statement.close()
-    _statement = _tidbConnection.createStatement()
+  protected def createTableWithClusteredIndex(sql: String): Unit = {
+    enableClusteredIndex()
+    val conn = TiDBUtils.createConnectionFactory(jdbcUrl)()
+    val stmt = conn.createStatement()
+    stmt.execute(sql)
+    stmt.close()
+    conn.close()
+    disableClusteredIndex()
   }
 
-  protected def disableClusteredIndex(): Unit = {
-    _statement.execute("SET GLOBAL tidb_enable_clustered_index = 0")
-    _statement.close()
-    _statement = _tidbConnection.createStatement()
+  private def enableClusteredIndex(): Unit = {
+    if (supportClusteredIndex) {
+      val conn = TiDBUtils.createConnectionFactory(jdbcUrl)()
+      val stmt = conn.createStatement()
+      stmt.execute("SET GLOBAL tidb_enable_clustered_index = 1")
+      stmt.close()
+      conn.close()
+    }
+  }
+
+  private def disableClusteredIndex(): Unit = {
+    if (supportClusteredIndex) {
+      val conn = TiDBUtils.createConnectionFactory(jdbcUrl)()
+      val stmt = conn.createStatement()
+      stmt.execute("SET GLOBAL tidb_enable_clustered_index = 0")
+      stmt.close()
+      conn.close()
+    }
   }
 
   protected def timeZoneOffset: String = SharedSQLContext.timeZoneOffset
@@ -344,6 +362,8 @@ trait SharedSQLContext
         s"&useUnicode=true&characterEncoding=UTF-8&zeroDateTimeBehavior=round&useSSL=false" +
         s"&rewriteBatchedStatements=true&autoReconnect=true&failOverReadOnly=false&maxReconnects=10" +
         s"&allowMultiQueries=true&serverTimezone=${timeZone.getDisplayName}&sessionVariables=time_zone='$timeZoneOffset'"
+
+    disableClusteredIndex()
 
     _tidbConnection = TiDBUtils.createConnectionFactory(jdbcUrl)()
     initializeStatement()


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
AutoIncrementSuite test failed with tidb nightly version 

https://internal.pingcap.net/idc-jenkins/blue/organizations/jenkins/tispark_regression_test_daily/detail/tispark_regression_test_daily/2748/pipeline/116/

### What is changed and how it works?
fix the failed tests

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `tidb-ansible` repository
 - Need to be included in the release note
