### PR TITLE
Fix TiRegion race when invalidating regions in RegionManager

### DIFF
--- a/.ci/integration_test.groovy
+++ b/.ci/integration_test.groovy
@@ -209,7 +209,6 @@ def call(ghprbActualCommit, ghprbCommentBody, ghprbPullId, ghprbPullTitle, ghprb
                         cp .ci/log4j-ci.properties core/src/test/resources/log4j.properties
                         bash core/scripts/version.sh
                         bash core/scripts/fetch-test-data.sh
-                        mv core/src/test core-test/src/
                         bash tikv-client/scripts/proto.sh
                         """
                         }

--- a/.ci/integration_test.groovy
+++ b/.ci/integration_test.groovy
@@ -6,46 +6,85 @@ def call(ghprbActualCommit, ghprbCommentBody, ghprbPullId, ghprbPullTitle, ghprb
     def TIDB_BRANCH = "master"
     def TIKV_BRANCH = "master"
     def PD_BRANCH = "master"
+    def TIFLASH_BRANCH = "master"
     def MVN_PROFILE = "-Pjenkins"
-    def PARALLEL_NUMBER = 9
-    
+    def TEST_MODE = "full"
+    def PARALLEL_NUMBER = 18
+    def TEST_REGION_SIZE = "normal"
+    def TEST_TIFLASH = "false"
+    def TEST_ALTER_PRIMARY_KEY = "true"
+    def TEST_SPARK_CATALOG = "false"
+
     // parse tidb branch
     def m1 = ghprbCommentBody =~ /tidb\s*=\s*([^\s\\]+)(\s|\\|$)/
     if (m1) {
         TIDB_BRANCH = "${m1[0][1]}"
     }
-    m1 = null
     println "TIDB_BRANCH=${TIDB_BRANCH}"
+
     // parse pd branch
     def m2 = ghprbCommentBody =~ /pd\s*=\s*([^\s\\]+)(\s|\\|$)/
     if (m2) {
         PD_BRANCH = "${m2[0][1]}"
     }
-    m2 = null
     println "PD_BRANCH=${PD_BRANCH}"
+
     // parse tikv branch
     def m3 = ghprbCommentBody =~ /tikv\s*=\s*([^\s\\]+)(\s|\\|$)/
     if (m3) {
         TIKV_BRANCH = "${m3[0][1]}"
     }
-    m3 = null
     println "TIKV_BRANCH=${TIKV_BRANCH}"
-    // parse mvn profile
-    def m4 = ghprbCommentBody =~ /profile\s*=\s*([^\s\\]+)(\s|\\|$)/
+
+    // parse tiflash branch
+    def m4 = ghprbCommentBody =~ /tiflash\s*=\s*([^\s\\]+)(\s|\\|$)/
     if (m4) {
-        MVN_PROFILE = MVN_PROFILE + " -P${m4[0][1]}"
+        TIFLASH_BRANCH = "${m4[0][1]}"
     }
-    
-    def readfile = { filename ->
+    println "TIFLASH_BRANCH=${TIFLASH_BRANCH}"
+
+    // parse mvn profile
+    def m5 = ghprbCommentBody =~ /profile\s*=\s*([^\s\\]+)(\s|\\|$)/
+    if (m5) {
+        MVN_PROFILE = MVN_PROFILE + " -P${m5[0][1]}"
+    }
+
+    // parse test mode
+    def m6 = ghprbCommentBody =~ /mode\s*=\s*([^\s\\]+)(\s|\\|$)/
+    if (m6) {
+        TEST_MODE = "${m6[0][1]}"
+    }
+
+    // parse test region size
+    def m7 = ghprbCommentBody =~ /region\s*=\s*([^\s\\]+)(\s|\\|$)/
+    if (m7) {
+        TEST_REGION_SIZE = "${m7[0][1]}"
+    }
+
+    // parse test tiflash
+    def m8 = ghprbCommentBody =~ /test-flash\s*=\s*([^\s\\]+)(\s|\\|$)/
+    if (m8) {
+        TEST_TIFLASH = "${m8[0][1]}"
+    }
+
+    // parse test alter primary key
+    def m9 = ghprbCommentBody =~ /test-alter-primary-key\s*=\s*([^\s\\]+)(\s|\\|$)/
+    if (m9) {
+        TEST_ALTER_PRIMARY_KEY = "${m9[0][1]}"
+    }
+
+    // parse test spark catalog
+    def m100 = ghprbCommentBody =~ /test-spark-catalog\s*=\s*([^\s\\]+)(\s|\\|$)/
+    if (m100) {
+        TEST_SPARK_CATALOG = "${m100[0][1]}"
+    }
+
+    groovy.lang.Closure readfile = { filename ->
         def file = readFile filename
         return file.split("\n") as List
     }
-    
-    def remove_last_str = { str ->
-        return str.substring(0, str.length() - 1)
-    }
-    
-    def get_mvn_str = { total_chunks ->
+
+    groovy.lang.Closure get_mvn_str = { total_chunks ->
         def mvnStr = " -DwildcardSuites="
         for (int i = 0 ; i < total_chunks.size() - 1; i++) {
             // print total_chunks
@@ -55,104 +94,198 @@ def call(ghprbActualCommit, ghprbCommentBody, ghprbPullId, ghprbPullTitle, ghprb
         def trimStr = total_chunks[total_chunks.size() - 1]
         mvnStr = mvnStr + "${trimStr}"
         mvnStr = mvnStr + " -DfailIfNoTests=false"
+        mvnStr = mvnStr + " -DskipAfterFailureCount=1"
         return mvnStr
     }
-    
-    catchError {
-        stage('Prepare') {
-            node ('build_go1120') {
-                println "${NODE_NAME}"
-                container("golang") {
-                    deleteDir()
-                    def ws = pwd()
-    
-                    // tidb
-                    def tidb_sha1 = sh(returnStdout: true, script: "curl ${FILE_SERVER_URL}/download/refs/pingcap/tidb/${TIDB_BRANCH}/sha1").trim()
-                    sh "curl ${FILE_SERVER_URL}/download/builds/pingcap/tidb/${tidb_sha1}/centos7/tidb-server.tar.gz | tar xz"
-                    // tikv
-                    def tikv_sha1 = sh(returnStdout: true, script: "curl ${FILE_SERVER_URL}/download/refs/pingcap/tikv/${TIKV_BRANCH}/sha1").trim()
-                    sh "curl ${FILE_SERVER_URL}/download/builds/pingcap/tikv/${tikv_sha1}/centos7/tikv-server.tar.gz | tar xz"
-                    // pd
-                    def pd_sha1 = sh(returnStdout: true, script: "curl ${FILE_SERVER_URL}/download/refs/pingcap/pd/${PD_BRANCH}/sha1").trim()
-                    sh "curl ${FILE_SERVER_URL}/download/builds/pingcap/pd/${pd_sha1}/centos7/pd-server.tar.gz | tar xz"
-                    stash includes: "bin/**", name: "binaries"
-                    
-                    dir("/home/jenkins/agent/git") {
-                        if (sh(returnStatus: true, script: '[ -d .git ] && [ -f Makefile ] && git rev-parse --git-dir > /dev/null 2>&1') != 0) {
-                            deleteDir()
-                        }
-                        checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: 'master']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'PruneStaleBranch'], [$class: 'CleanBeforeCheckout']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: credentialsId, refspec: '+refs/pull/*:refs/remotes/origin/pr/*', url: 'git@github.com:pingcap/tispark.git']]]
-                    }
-    
-                    dir("go/src/github.com/pingcap/tispark") {
+
+    def label = "regression-test-tispark"
+
+    podTemplate(name: label, label: label, instanceCap: 10, idleMinutes: 10, containers: [
+            containerTemplate(name: 'golang', image: 'hub.pingcap.net/jenkins/centos7_golang-1.12:cached',
+                    envVars: [
+                            envVar(key: 'DOCKER_HOST', value: 'tcp://localhost:2375'),
+                    ], alwaysPullImage: true, ttyEnabled: true, command: 'cat'),
+            containerTemplate(name: 'java', image: 'hub.pingcap.net/jenkins/centos7_golang-1.13_java:cached',
+                    resourceRequestCpu: '8000m',
+                    resourceRequestMemory: '16Gi',
+                    envVars: [
+                            envVar(key: 'DOCKER_HOST', value: 'tcp://localhost:2375'),
+                    ], alwaysPullImage: true, ttyEnabled: true, command: 'cat'),
+    ]) {
+
+        catchError {
+            stage('Prepare') {
+                node (label) {
+                    println "${NODE_NAME}"
+                    container("golang") {
                         deleteDir()
-                        sh """
-                        cp -R /home/jenkins/agent/git/. ./
+
+                        // tidb
+                        def tidb_sha1 = sh(returnStdout: true, script: "curl ${FILE_SERVER_URL}/download/refs/pingcap/tidb/${TIDB_BRANCH}/sha1").trim()
+                        sh "curl ${FILE_SERVER_URL}/download/builds/pingcap/tidb/${tidb_sha1}/centos7/tidb-server.tar.gz | tar xz"
+                        // tikv
+                        def tikv_sha1 = sh(returnStdout: true, script: "curl ${FILE_SERVER_URL}/download/refs/pingcap/tikv/${TIKV_BRANCH}/sha1").trim()
+                        sh "curl ${FILE_SERVER_URL}/download/builds/pingcap/tikv/${tikv_sha1}/centos7/tikv-server.tar.gz | tar xz"
+                        // pd
+                        def pd_sha1 = sh(returnStdout: true, script: "curl ${FILE_SERVER_URL}/download/refs/pingcap/pd/${PD_BRANCH}/sha1").trim()
+                        sh "curl ${FILE_SERVER_URL}/download/builds/pingcap/pd/${pd_sha1}/centos7/pd-server.tar.gz | tar xz"
+                        // tiflash
+                        if (TEST_TIFLASH != "false") {
+                            def tiflash_sha1 = sh(returnStdout: true, script: "curl ${FILE_SERVER_URL}/download/refs/pingcap/tiflash/${TIFLASH_BRANCH}/sha1").trim()
+                            sh "curl ${FILE_SERVER_URL}/download/builds/pingcap/tiflash/${TIFLASH_BRANCH}/${tiflash_sha1}/centos7/tiflash.tar.gz | tar xz"
+                            sh """
+                        cd tiflash
+                        tar -zcvf flash_cluster_manager.tgz flash_cluster_manager/
+                        rm ./flash_cluster_manager.tgz
+                        cd ..
+                        """
+                            stash includes: "tiflash/**", name: "tiflash_binary"
+                        }
+                        // alter-primary-key
+                        if (TEST_ALTER_PRIMARY_KEY == "false") {
+                            sh "sed -i 's/alter-primary-key = true/alter-primary-key = false/' config/tidb.toml"
+                            sh "sed -i 's/alter-primary-key = true/alter-primary-key = false/' config/tidb-4.0.toml"
+                        }
+
+                        stash includes: "bin/**", name: "binaries"
+
+                        dir("/home/jenkins/agent/git/tispark") {
+                            if (sh(returnStatus: true, script: '[ -d .git ] && [ -f Makefile ] && git rev-parse --git-dir > /dev/null 2>&1') != 0) {
+                                deleteDir()
+                            }
+                            checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: 'master']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'PruneStaleBranch'], [$class: 'CleanBeforeCheckout']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: credentialsId, refspec: '+refs/pull/*:refs/remotes/origin/pr/*', url: 'git@github.com:pingcap/tispark.git']]]
+                        }
+
+                        dir("go/src/github.com/pingcap/tispark") {
+                            deleteDir()
+                            sh """
+                        pwd
+                        cp -R /home/jenkins/agent/git/tispark/. ./
                         git checkout -f ${ghprbActualCommit}
-                        find core/src -name '*Suite*' > test
+                        find core/src -name '*Suite*' | grep -v 'MultiColumnPKDataTypeSuite' > test
+                        shuf test -o  test2
+                        mv test2 test
+                        """
+
+                            if (TEST_REGION_SIZE  != "normal") {
+                                sh "sed -i 's/\\# region-max-size = \\\"2MB\\\"/region-max-size = \\\"2MB\\\"/' config/tikv.toml"
+                                sh "sed -i 's/\\# region-split-size = \\\"1MB\\\"/region-split-size = \\\"1MB\\\"/' config/tikv.toml"
+                                sh "cat config/tikv.toml"
+                            }
+
+                            if (TEST_MODE != "simple") {
+                                sh """
+                            find core/src -name '*MultiColumnPKDataTypeSuite*' >> test
+                            """
+                            }
+
+                            if (TEST_TIFLASH != "false") {
+                                sh "cp .ci/tidb_config-for-tiflash-test.properties core/src/test/resources/tidb_config.properties"
+                            }
+
+                            if (TEST_SPARK_CATALOG != "false") {
+                                sh """
+                            touch core/src/test/resources/tidb_config.properties
+                            echo "spark.sql.catalog.tidb_catalog=org.apache.spark.sql.catalyst.catalog.TiCatalog" >> core/src/test/resources/tidb_config.properties
+                            """
+                            }
+
+                            sh """
                         sed -i 's/core\\/src\\/test\\/scala\\///g' test
                         sed -i 's/\\//\\./g' test
                         sed -i 's/\\.scala//g' test
-                        split test -n r/$PARALLEL_NUMBER test_unit_ -a 1 --numeric-suffixes=1
+                        split test -n r/$PARALLEL_NUMBER test_unit_ -a 2 --numeric-suffixes=1
+                        """
+
+                            for (int i = 1; i <= PARALLEL_NUMBER; i++) {
+                                if (i < 10) {
+                                    sh """cat test_unit_0$i"""
+                                } else {
+                                    sh """cat test_unit_$i"""
+                                }
+                            }
+
+                            sh """
                         cp .ci/log4j-ci.properties core/src/test/resources/log4j.properties
                         bash core/scripts/version.sh
                         bash core/scripts/fetch-test-data.sh
+                        mv core/src/test core-test/src/
                         bash tikv-client/scripts/proto.sh
                         """
+                        }
+
+                        stash includes: "go/src/github.com/pingcap/tispark/**", name: "tispark", useDefaultExcludes: false
                     }
-    
-                    stash includes: "go/src/github.com/pingcap/tispark/**", name: "tispark", useDefaultExcludes: false
-                }
-            }
-        }
-    
-        stage('Integration Tests') {
-            def tests = [:]
-    
-            def run_tispark_test = { chunk_suffix ->
-                dir("go/src/github.com/pingcap/tispark") {
-                    run_chunks = readfile("test_unit_${chunk_suffix}")
-                    print run_chunks
-                    def mvnStr = get_mvn_str(run_chunks)
-                    sh """
-                        archive_url=http://172.16.30.25/download/builds/pingcap/tiflash/cache/tiflash-m2-cache_latest.tar.gz
-                        if [ ! "\$(ls -A /maven/.m2/repository)" ]; then curl -sL \$archive_url | tar -zx -C /maven || true; fi
-                    """
-                    sh """
-                        export MAVEN_OPTS="-Xmx6G -XX:MaxPermSize=512M -XX:ReservedCodeCacheSize=51M"
-                        mvn compile ${MVN_PROFILE}
-                        mvn test ${MVN_PROFILE} -Dtest=moo ${mvnStr}
-                    """
                 }
             }
 
-            def run_tikvclient_test = { chunk_suffix ->
-                dir("go/src/github.com/pingcap/tispark") {
-                    sh """
-                        archive_url=http://172.16.30.25/download/builds/pingcap/tiflash/cache/tiflash-m2-cache_latest.tar.gz
+            stage('Integration Tests') {
+                def tests = [:]
+
+                groovy.lang.Closure run_tispark_test = { chunk_suffix ->
+                    dir("go/src/github.com/pingcap/tispark") {
+                        if (chunk_suffix < 10) {
+                            run_chunks = readfile("test_unit_0${chunk_suffix}")
+                        } else {
+                            run_chunks = readfile("test_unit_${chunk_suffix}")
+                        }
+
+                        print run_chunks
+                        def mvnStr = get_mvn_str(run_chunks)
+                        sh """
+                        rm -rf /maven/.m2/repository/*
+                        rm -rf /maven/.m2/settings.xml
+                        rm -rf ~/.m2/settings.xml
+                        archive_url=http://fileserver.pingcap.net/download/builds/pingcap/tispark/cache/tispark-m2-cache-latest.tar.gz
                         if [ ! "\$(ls -A /maven/.m2/repository)" ]; then curl -sL \$archive_url | tar -zx -C /maven || true; fi
                     """
-                    sh """
-                        export MAVEN_OPTS="-Xmx6G -XX:MaxPermSize=512M -XX:ReservedCodeCacheSize=512M"
+                        sh """
+                        export MAVEN_OPTS="-Xmx6G -XX:MaxPermSize=512M"
+                        mvn test ${MVN_PROFILE} -Dtest=moo ${mvnStr}
+                    """
+                    }
+                }
+
+                groovy.lang.Closure run_tikvclient_test = { chunk_suffix ->
+                    dir("go/src/github.com/pingcap/tispark") {
+                        sh """
+                        rm -rf /maven/.m2/repository/*
+                        rm -rf /maven/.m2/settings.xml
+                        rm -rf ~/.m2/settings.xml
+                        archive_url=http://fileserver.pingcap.net/download/builds/pingcap/tispark/cache/tispark-m2-cache-latest.tar.gz
+                        if [ ! "\$(ls -A /maven/.m2/repository)" ]; then curl -sL \$archive_url | tar -zx -C /maven || true; fi
+                    """
+                        sh """
+                        export MAVEN_OPTS="-Xmx6G -XX:MaxPermSize=512M"
                         mvn test ${MVN_PROFILE} -am -pl tikv-client
                     """
-                    unstash "CODECOV_TOKEN"
-                    sh 'curl -s https://codecov.io/bash | bash -s - -t @CODECOV_TOKEN'
+                        unstash "CODECOV_TOKEN"
+                        sh 'curl -s https://codecov.io/bash | bash -s - -t @CODECOV_TOKEN'
+                    }
                 }
-            }
-    
-            def run_intergration_test = { chunk_suffix, run_test ->
-                node("test_java") {
-                    println "${NODE_NAME}"
-                    container("java") {
-                        def ws = pwd()
-                        deleteDir()
-                        unstash 'binaries'
-                        unstash 'tispark'
-    
-                        try {
-                            if(TIDB_BRANCH.contains("4.0") && TIKV_BRANCH.contains("4.0") && PD_BRANCH.contains("4.0")) {
-                                sh """
+
+                groovy.lang.Closure run_intergration_test = { chunk_suffix, run_test ->
+                    node(label) {
+                        println "${NODE_NAME}"
+                        container("java") {
+                            deleteDir()
+                            unstash 'binaries'
+                            unstash 'tispark'
+                            if (TEST_TIFLASH != "false") {
+                                unstash 'tiflash_binary'
+                            }
+
+                            try {
+
+                                groovy.lang.Closure isv4 = { branch_name ->
+                                    if (branch_name.startsWith("v4") || branch_name.startsWith("release-4") || branch_name == "master") {
+                                        return true
+                                    }
+                                    return false
+                                }
+
+                                if (isv4(TIDB_BRANCH) || isv4(TIKV_BRANCH) || isv4(PD_BRANCH)) {
+                                    sh """
                                 rm go/src/github.com/pingcap/tispark/config/pd.toml
                                 rm go/src/github.com/pingcap/tispark/config/tikv.toml
                                 rm go/src/github.com/pingcap/tispark/config/tidb.toml
@@ -160,13 +293,16 @@ def call(ghprbActualCommit, ghprbCommentBody, ghprbPullId, ghprbPullTitle, ghprb
                                 mv go/src/github.com/pingcap/tispark/config/tikv-4.0.toml go/src/github.com/pingcap/tispark/config/tikv.toml
                                 mv go/src/github.com/pingcap/tispark/config/tidb-4.0.toml go/src/github.com/pingcap/tispark/config/tidb.toml
                                 """
-                            }
+                                }
 
-                            sh """
-                            sudo sysctl -w net.ipv4.ip_local_port_range='10000 30000'
+                                sh """
+                            #sudo sysctl -w net.ipv4.ip_local_port_range=\'1000 30000\'
                             killall -9 tidb-server || true
                             killall -9 tikv-server || true
                             killall -9 pd-server || true
+                            killall -9 tiflash || true
+                            killall -9 java || true
+                            touch tiflash_cmd_line.log
                             sleep 10
                             bin/pd-server --name=pd --data-dir=pd --config=go/src/github.com/pingcap/tispark/config/pd.toml &>pd.log &
                             sleep 10
@@ -177,45 +313,71 @@ def call(ghprbActualCommit, ghprbCommentBody, ghprbPullId, ghprbPullTitle, ghprb
                             bin/tidb-server --store=tikv --path="127.0.0.1:2379" --config=go/src/github.com/pingcap/tispark/config/tidb.toml &>tidb.log &
                             sleep 60
                             """
-    
-                            timeout(60) {
-                                run_test(chunk_suffix)
-                            }
-                        } catch (err) {
-                            sh """
+
+                                if (TEST_TIFLASH != "false") {
+                                    sh """
+                                export LD_LIBRARY_PATH=/home/jenkins/agent/workspace/tispark_ghpr_integration_test/tiflash
+                                ls -l \$LD_LIBRARY_PATH
+                                tiflash/tiflash server config --config-file go/src/github.com/pingcap/tispark/config/tiflash.toml &>tiflash_cmd_line.log &
+                                ps aux | grep 'tiflash'
+                                sleep 60
+                                """
+                                    sh "ps aux | grep 'tiflash'"
+                                }
+
+                                timeout(120) {
+                                    run_test(chunk_suffix)
+                                }
+                            } catch (err) {
+                                sh """
                             ps aux | grep '-server' || true
                             curl -s 127.0.0.1:2379/pd/api/v1/status || true
                             """
-                            sh "cat pd.log"
-                            sh "cat tikv.log"
-                            sh "cat tidb.log"
-                            throw err
+                                sh "cat pd.log"
+                                sh "cat tikv.log"
+                                sh "cat tidb.log"
+                                if (TEST_TIFLASH != "false") {
+                                    sh """
+                                touch tiflash_cmd_line.log
+                                touch tiflash/tiflash_error.log
+                                touch tiflash/tiflash.log
+                                touch tiflash/tiflash_cluster_manager.log
+                                touch tiflash/tiflash_tikv.log
+                                """
+                                    sh "cat tiflash_cmd_line.log"
+                                    sh "cat tiflash/tiflash_error.log"
+                                    sh "cat tiflash/tiflash.log"
+                                    sh "cat tiflash/tiflash_cluster_manager.log"
+                                    sh "cat tiflash/tiflash_tikv.log"
+                                }
+                                throw err
+                            }
                         }
                     }
                 }
+
+                for (int i = 1; i <= PARALLEL_NUMBER; i++) {
+                    int x = i
+                    tests["Integration test = $i"] = {run_intergration_test(x, run_tispark_test)}
+                }
+                tests["Integration tikv-client test"] = {run_intergration_test(0, run_tikvclient_test)}
+
+                parallel tests
             }
 
-           for (int i = 1; i <= PARALLEL_NUMBER; i++) {
-                int x = i
-                tests["Integration test = $i"] = {run_intergration_test(x, run_tispark_test)}
-            }
-            tests["Integration tikv-client test"] = {run_intergration_test(0, run_tikvclient_test)}
-    
-            parallel tests
+            currentBuild.result = "SUCCESS"
         }
-    
-        currentBuild.result = "SUCCESS"
+
     }
-    
     stage('Summary') {
         def duration = ((System.currentTimeMillis() - currentBuild.startTimeInMillis) / 1000 / 60).setScale(2, BigDecimal.ROUND_HALF_UP)
         def slackmsg = "[#${ghprbPullId}: ${ghprbPullTitle}]" + "\n" +
-        "${ghprbPullLink}" + "\n" +
-        "${ghprbPullDescription}" + "\n" +
-        "Integration Common Test Result: `${currentBuild.result}`" + "\n" +
-        "Elapsed Time: `${duration} mins` " + "\n" +
-        "${env.RUN_DISPLAY_URL}"
-    
+                "${ghprbPullLink}" + "\n" +
+                "${ghprbPullDescription}" + "\n" +
+                "Integration Common Test Result: `${currentBuild.result}`" + "\n" +
+                "Elapsed Time: `${duration} mins` " + "\n" +
+                "${env.RUN_DISPLAY_URL}"
+
         if (currentBuild.result != "SUCCESS") {
             slackSend channel: channel, color: 'danger', teamDomain: teamDomain, tokenCredentialId: tokenCredentialId, message: "${slackmsg}"
         }
@@ -223,4 +385,3 @@ def call(ghprbActualCommit, ghprbCommentBody, ghprbPullId, ghprbPullTitle, ghprb
 }
 
 return this
-

--- a/tikv-client/src/main/java/com/pingcap/tikv/TiSession.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/TiSession.java
@@ -119,7 +119,10 @@ public class TiSession implements AutoCloseable {
           indexScanThreadPool =
               Executors.newFixedThreadPool(
                   conf.getIndexScanConcurrency(),
-                  new ThreadFactoryBuilder().setDaemon(true).build());
+                  new ThreadFactoryBuilder()
+                      .setNameFormat("indexScan-thread-%d")
+                      .setDaemon(true)
+                      .build());
         }
         res = indexScanThreadPool;
       }
@@ -135,7 +138,10 @@ public class TiSession implements AutoCloseable {
           tableScanThreadPool =
               Executors.newFixedThreadPool(
                   conf.getTableScanConcurrency(),
-                  new ThreadFactoryBuilder().setDaemon(true).build());
+                  new ThreadFactoryBuilder()
+                      .setNameFormat("tableScan-thread-%d")
+                      .setDaemon(true)
+                      .build());
         }
         res = tableScanThreadPool;
       }

--- a/tikv-client/src/main/java/com/pingcap/tikv/operation/KVErrorHandler.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/operation/KVErrorHandler.java
@@ -200,6 +200,7 @@ public class KVErrorHandler<RespT> implements ErrorHandler<RespT> {
         // region has outdated version，please try later.
         logger.warn(String.format("Stale Epoch encountered for region [%s]", region));
         this.regionManager.onRegionStale(region);
+        notifyRegionCacheInvalidate(region.getId());
         return false;
       } else if (error.hasServerIsBusy()) {
         // this error is reported from kv:

--- a/tikv-client/src/main/java/com/pingcap/tikv/operation/KVErrorHandler.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/operation/KVErrorHandler.java
@@ -64,6 +64,10 @@ public class KVErrorHandler<RespT> implements ErrorHandler<RespT> {
   private void invalidateRegionStoreCache(TiRegion ctxRegion) {
     regionManager.invalidateRegion(ctxRegion);
     regionManager.invalidateStore(ctxRegion.getLeader().getStoreId());
+    notifyRegionStoreCacheInvalidate(
+      ctxRegion.getId(),
+      ctxRegion.getLeader().getStoreId(),
+      CacheInvalidateEvent.CacheType.REGION_STORE);
   }
 
   /** Used for notifying Spark driver to invalidate cache from Spark workers. */
@@ -169,6 +173,8 @@ public class KVErrorHandler<RespT> implements ErrorHandler<RespT> {
 
         if (!retry) {
           this.regionManager.invalidateRegion(region);
+          notifyRegionStoreCacheInvalidate(
+            region.getId(), newStoreId, CacheInvalidateEvent.CacheType.LEADER);
         }
 
         backOffer.doBackOff(backOffFuncType, new GrpcException(error.toString()));

--- a/tikv-client/src/main/java/com/pingcap/tikv/operation/KVErrorHandler.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/operation/KVErrorHandler.java
@@ -173,8 +173,7 @@ public class KVErrorHandler<RespT> implements ErrorHandler<RespT> {
 
         if (!retry) {
           this.regionManager.invalidateRegion(region);
-          notifyRegionStoreCacheInvalidate(
-            region.getId(), newStoreId, CacheInvalidateEvent.CacheType.LEADER);
+          notifyRegionCacheInvalidate(region.getId());
         }
 
         backOffer.doBackOff(backOffFuncType, new GrpcException(error.toString()));
@@ -191,8 +190,7 @@ public class KVErrorHandler<RespT> implements ErrorHandler<RespT> {
                 "Store Not Match happened with region id %d, store id %d, actual store id %d",
                 region.getId(), storeId, actualStoreId));
 
-        this.regionManager.invalidateRegion(region);
-        this.regionManager.invalidateStore(storeId);
+        invalidateRegionStoreCache(region);
         // recv.onStoreNotMatch(this.regionManager.getStoreById(storeId));
         // assume this is a low probability error, do not retry, just re-split the request by
         // throwing it out.

--- a/tikv-client/src/main/java/com/pingcap/tikv/operation/KVErrorHandler.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/operation/KVErrorHandler.java
@@ -29,26 +29,24 @@ import com.pingcap.tikv.util.BackOffer;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import java.util.function.Function;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.tikv.kvproto.Errorpb;
 
 // TODO: consider refactor to Builder mode
 public class KVErrorHandler<RespT> implements ErrorHandler<RespT> {
-  private static final Logger logger = Logger.getLogger(KVErrorHandler.class);
-  private static final int NO_LEADER_STORE_ID =
-      0; // if there's currently no leader of a store, store id is set to 0
+  private static final Logger logger = LoggerFactory.getLogger(KVErrorHandler.class);
+  // if a store does not have leader currently, store id is set to 0
+  private static final int NO_LEADER_STORE_ID = 0;
   private final Function<RespT, Errorpb.Error> getRegionError;
   private final Function<CacheInvalidateEvent, Void> cacheInvalidateCallBack;
   private final RegionManager regionManager;
   private final RegionErrorReceiver recv;
-  private final TiRegion ctxRegion;
 
   public KVErrorHandler(
       RegionManager regionManager,
       RegionErrorReceiver recv,
-      TiRegion ctxRegion,
       Function<RespT, Errorpb.Error> getRegionError) {
-    this.ctxRegion = ctxRegion;
     this.recv = recv;
     this.regionManager = regionManager;
     this.getRegionError = getRegionError;
@@ -64,12 +62,8 @@ public class KVErrorHandler<RespT> implements ErrorHandler<RespT> {
   }
 
   private void invalidateRegionStoreCache(TiRegion ctxRegion) {
-    regionManager.invalidateRegion(ctxRegion.getId());
+    regionManager.invalidateRegion(ctxRegion);
     regionManager.invalidateStore(ctxRegion.getLeader().getStoreId());
-    notifyRegionStoreCacheInvalidate(
-        ctxRegion.getId(),
-        ctxRegion.getLeader().getStoreId(),
-        CacheInvalidateEvent.CacheType.REGION_STORE);
   }
 
   /** Used for notifying Spark driver to invalidate cache from Spark workers. */
@@ -119,11 +113,14 @@ public class KVErrorHandler<RespT> implements ErrorHandler<RespT> {
 
   // Referenced from TiDB
   // store/tikv/region_request.go - onRegionError
+
+  /** @return true: client should retry */
   @Override
   public boolean handleResponseError(BackOffer backOffer, RespT resp) {
+    TiRegion region = recv.getRegion();
     if (resp == null) {
       String msg =
-          String.format("Request Failed with unknown reason for region region [%s]", ctxRegion);
+          String.format("Request Failed with unknown reason for region region [%s]", region);
       logger.warn(msg);
       return handleRequestError(backOffer, new GrpcException(msg));
     }
@@ -137,37 +134,41 @@ public class KVErrorHandler<RespT> implements ErrorHandler<RespT> {
         // 1. cache is outdated, region has changed its leader, can be solved by re-fetching from PD
         // 2. leader of current region is missing, need to wait and then fetch region info from PD
         long newStoreId = error.getNotLeader().getLeader().getStoreId();
-        boolean retry = true;
+        boolean retry;
 
         // update Leader here
         logger.warn(
             String.format(
                 "NotLeader Error with region id %d and store id %d, new store id %d",
-                ctxRegion.getId(), ctxRegion.getLeader().getStoreId(), newStoreId));
+                region.getId(), region.getLeader().getStoreId(), newStoreId));
 
         BackOffFunction.BackOffFuncType backOffFuncType;
         // if there's current no leader, we do not trigger update pd cache logic
         // since issuing store = NO_LEADER_STORE_ID requests to pd will definitely fail.
         if (newStoreId != NO_LEADER_STORE_ID) {
-          if (!this.regionManager.updateLeader(ctxRegion.getId(), newStoreId)
-              || !recv.onNotLeader(this.regionManager.getStoreById(newStoreId))) {
-            // If update leader fails, we need to fetch new region info from pd,
-            // and re-split key range for new region. Setting retry to false will
-            // stop retry and enter handleCopResponse logic, which would use RegionMiss
-            // backOff strategy to wait, fetch new region and re-split key range.
-            // onNotLeader is only needed when updateLeader succeeds, thus switch
-            // to a new store address.
-            retry = false;
-          }
-          notifyRegionStoreCacheInvalidate(
-              ctxRegion.getId(), newStoreId, CacheInvalidateEvent.CacheType.LEADER);
+          // If update leader fails, we need to fetch new region info from pd,
+          // and re-split key range for new region. Setting retry to false will
+          // stop retry and enter handleCopResponse logic, which would use RegionMiss
+          // backOff strategy to wait, fetch new region and re-split key range.
+          // onNotLeader is only needed when updateLeader succeeds, thus switch
+          // to a new store address.
+          TiRegion newRegion = this.regionManager.updateLeader(region, newStoreId);
+          retry =
+              newRegion != null
+                  && recv.onNotLeader(this.regionManager.getStoreById(newStoreId), newRegion);
 
           backOffFuncType = BackOffFunction.BackOffFuncType.BoUpdateLeader;
         } else {
           logger.info(
               String.format(
-                  "Received zero store id, from region %d try next time", ctxRegion.getId()));
+                  "Received zero store id, from region %d try next time", region.getId()));
+
           backOffFuncType = BackOffFunction.BackOffFuncType.BoRegionMiss;
+          retry = false;
+        }
+
+        if (!retry) {
+          this.regionManager.invalidateRegion(region);
         }
 
         backOffer.doBackOff(backOffFuncType, new GrpcException(error.toString()));
@@ -177,22 +178,24 @@ public class KVErrorHandler<RespT> implements ErrorHandler<RespT> {
         // this error is reported from raftstore:
         // store_id requested at the moment is inconsistent with that expected
         // Solution：re-fetch from PD
-        long storeId = ctxRegion.getLeader().getStoreId();
+        long storeId = region.getLeader().getStoreId();
+        long actualStoreId = error.getStoreNotMatch().getActualStoreId();
         logger.warn(
             String.format(
-                "Store Not Match happened with region id %d, store id %d",
-                ctxRegion.getId(), storeId));
+                "Store Not Match happened with region id %d, store id %d, actual store id %d",
+                region.getId(), storeId, actualStoreId));
 
+        this.regionManager.invalidateRegion(region);
         this.regionManager.invalidateStore(storeId);
-        recv.onStoreNotMatch(this.regionManager.getStoreById(storeId));
-        notifyStoreCacheInvalidate(storeId);
-        return true;
+        // recv.onStoreNotMatch(this.regionManager.getStoreById(storeId));
+        // assume this is a low probability error, do not retry, just re-split the request by
+        // throwing it out.
+        return false;
       } else if (error.hasEpochNotMatch()) {
         // this error is reported from raftstore:
         // region has outdated version，please try later.
-        logger.warn(String.format("Stale Epoch encountered for region [%s]", ctxRegion));
-        this.regionManager.onRegionStale(ctxRegion.getId());
-        notifyRegionCacheInvalidate(ctxRegion.getId());
+        logger.warn(String.format("Stale Epoch encountered for region [%s]", region));
+        this.regionManager.onRegionStale(region);
         return false;
       } else if (error.hasServerIsBusy()) {
         // this error is reported from kv:
@@ -200,19 +203,23 @@ public class KVErrorHandler<RespT> implements ErrorHandler<RespT> {
         logger.warn(
             String.format(
                 "Server is busy for region [%s], reason: %s",
-                ctxRegion, error.getServerIsBusy().getReason()));
+                region, error.getServerIsBusy().getReason()));
         backOffer.doBackOff(
             BackOffFunction.BackOffFuncType.BoServerBusy,
             new StatusRuntimeException(
                 Status.fromCode(Status.Code.UNAVAILABLE).withDescription(error.toString())));
+        backOffer.doBackOff(
+            BackOffFunction.BackOffFuncType.BoRegionMiss, new GrpcException(error.getMessage()));
         return true;
       } else if (error.hasStaleCommand()) {
         // this error is reported from raftstore:
         // command outdated, please try later
-        logger.warn(String.format("Stale command for region [%s]", ctxRegion));
+        logger.warn(String.format("Stale command for region [%s]", region));
+        backOffer.doBackOff(
+            BackOffFunction.BackOffFuncType.BoRegionMiss, new GrpcException(error.getMessage()));
         return true;
       } else if (error.hasRaftEntryTooLarge()) {
-        logger.warn(String.format("Raft too large for region [%s]", ctxRegion));
+        logger.warn(String.format("Raft too large for region [%s]", region));
         throw new StatusRuntimeException(
             Status.fromCode(Status.Code.UNAVAILABLE).withDescription(error.toString()));
       } else if (error.hasKeyNotInRegion()) {
@@ -223,14 +230,20 @@ public class KVErrorHandler<RespT> implements ErrorHandler<RespT> {
         logger.error(
             String.format(
                 "Key not in region [%s] for key [%s], this error should not happen here.",
-                ctxRegion, KeyUtils.formatBytesUTF8(invalidKey)));
+                region, KeyUtils.formatBytesUTF8(invalidKey)));
         throw new StatusRuntimeException(Status.UNKNOWN.withDescription(error.toString()));
       }
 
-      logger.warn(String.format("Unknown error %s for region [%s]", error.toString(), ctxRegion));
+      logger.warn(String.format("Unknown error %s for region [%s]", error, region));
       // For other errors, we only drop cache here.
       // Upper level may split this task.
-      invalidateRegionStoreCache(ctxRegion);
+      invalidateRegionStoreCache(region);
+      // retry if raft proposal is dropped, it indicates the store is in the middle of transition
+      if (error.getMessage().contains("Raft ProposalDropped")) {
+        backOffer.doBackOff(
+            BackOffFunction.BackOffFuncType.BoRegionMiss, new GrpcException(error.getMessage()));
+        return true;
+      }
     }
 
     return false;
@@ -238,18 +251,17 @@ public class KVErrorHandler<RespT> implements ErrorHandler<RespT> {
 
   @Override
   public boolean handleRequestError(BackOffer backOffer, Exception e) {
-    regionManager.onRequestFail(ctxRegion);
+    TiRegion region = recv.getRegion();
+    regionManager.onRequestFail(region);
     notifyRegionStoreCacheInvalidate(
-        ctxRegion.getId(),
-        ctxRegion.getLeader().getStoreId(),
-        CacheInvalidateEvent.CacheType.REQ_FAILED);
+        region.getId(), region.getLeader().getStoreId(), CacheInvalidateEvent.CacheType.REQ_FAILED);
 
     backOffer.doBackOff(
         BackOffFunction.BackOffFuncType.BoTiKVRPC,
         new GrpcException(
             "send tikv request error: " + e.getMessage() + ", try next peer later", e));
     // TiKV maybe down, so do not retry in `callWithRetry`
-    // should refetch the new leader from PD and send request to it
+    // should re-fetch the new leader from PD and send request to it
     return false;
   }
 }

--- a/tikv-client/src/main/java/com/pingcap/tikv/operation/KVErrorHandler.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/operation/KVErrorHandler.java
@@ -65,9 +65,9 @@ public class KVErrorHandler<RespT> implements ErrorHandler<RespT> {
     regionManager.invalidateRegion(ctxRegion);
     regionManager.invalidateStore(ctxRegion.getLeader().getStoreId());
     notifyRegionStoreCacheInvalidate(
-      ctxRegion.getId(),
-      ctxRegion.getLeader().getStoreId(),
-      CacheInvalidateEvent.CacheType.REGION_STORE);
+        ctxRegion.getId(),
+        ctxRegion.getLeader().getStoreId(),
+        CacheInvalidateEvent.CacheType.REGION_STORE);
   }
 
   /** Used for notifying Spark driver to invalidate cache from Spark workers. */

--- a/tikv-client/src/main/java/com/pingcap/tikv/region/RegionErrorReceiver.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/region/RegionErrorReceiver.java
@@ -23,4 +23,6 @@ public interface RegionErrorReceiver {
   boolean onNotLeader(Store store);
 
   void onStoreNotMatch(Store store);
+
+  TiRegion getRegion();
 }

--- a/tikv-client/src/main/java/com/pingcap/tikv/region/RegionErrorReceiver.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/region/RegionErrorReceiver.java
@@ -20,7 +20,7 @@ package com.pingcap.tikv.region;
 import org.tikv.kvproto.Metapb.Store;
 
 public interface RegionErrorReceiver {
-  boolean onNotLeader(Store store);
+  boolean onNotLeader(Store store, TiRegion region);
 
   void onStoreNotMatch(Store store);
 

--- a/tikv-client/src/main/java/com/pingcap/tikv/region/RegionManager.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/region/RegionManager.java
@@ -54,7 +54,7 @@ public class RegionManager {
   // To avoid double retrieval, we used the async version of grpc
   // When rpc not returned, instead of call again, it wait for previous one done
   public RegionManager(
-    ReadOnlyPDClient pdClient, Function<CacheInvalidateEvent, Void> cacheInvalidateCallback) {
+      ReadOnlyPDClient pdClient, Function<CacheInvalidateEvent, Void> cacheInvalidateCallback) {
     this.cache = new RegionCache(pdClient);
     this.cacheInvalidateCallback = cacheInvalidateCallback;
   }
@@ -88,7 +88,7 @@ public class RegionManager {
       }
       if (logger.isDebugEnabled()) {
         logger.debug(
-          String.format("getRegionByKey key[%s] -> ID[%s]", formatBytesUTF8(key), regionId));
+            String.format("getRegionByKey key[%s] -> ID[%s]", formatBytesUTF8(key), regionId));
       }
 
       if (regionId == null) {

--- a/tikv-client/src/main/java/com/pingcap/tikv/region/RegionManager.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/region/RegionManager.java
@@ -28,6 +28,7 @@ import com.pingcap.tikv.event.CacheInvalidateEvent;
 import com.pingcap.tikv.exception.GrpcException;
 import com.pingcap.tikv.exception.TiClientInternalException;
 import com.pingcap.tikv.key.Key;
+import com.pingcap.tikv.util.BackOffer;
 import com.pingcap.tikv.util.ConcreteBackOffer;
 import com.pingcap.tikv.util.Pair;
 import java.util.ArrayList;
@@ -35,17 +36,20 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.tikv.kvproto.Metapb.Peer;
 import org.tikv.kvproto.Metapb.Store;
 import org.tikv.kvproto.Metapb.StoreState;
 
 @SuppressWarnings("UnstableApiUsage")
 public class RegionManager {
-  private static final Logger logger = Logger.getLogger(RegionManager.class);
+  private static final Logger logger = LoggerFactory.getLogger(RegionManager.class);
+  // TODO: the region cache logic need rewrite.
+  // https://github.com/pingcap/tispark/issues/1170
   private final RegionCache cache;
 
-  private Function<CacheInvalidateEvent, Void> cacheInvalidateCallback;
+  private final Function<CacheInvalidateEvent, Void> cacheInvalidateCallback;
 
   // To avoid double retrieval, we used the async version of grpc
   // When rpc not returned, instead of call again, it wait for previous one done
@@ -53,6 +57,108 @@ public class RegionManager {
       ReadOnlyPDClient pdClient, Function<CacheInvalidateEvent, Void> cacheInvalidateCallback) {
     this.cache = new RegionCache(pdClient);
     this.cacheInvalidateCallback = cacheInvalidateCallback;
+  }
+
+  public RegionManager(ReadOnlyPDClient pdClient) {
+    this.cache = new RegionCache(pdClient);
+    this.cacheInvalidateCallback = null;
+  }
+
+  public Function<CacheInvalidateEvent, Void> getCacheInvalidateCallback() {
+    return cacheInvalidateCallback;
+  }
+
+  public ReadOnlyPDClient getPDClient() {
+    return this.cache.pdClient;
+  }
+
+  public TiRegion getRegionByKey(ByteString key) {
+    return getRegionByKey(key, ConcreteBackOffer.newGetBackOff());
+  }
+
+  public TiRegion getRegionByKey(ByteString key, BackOffer backOffer) {
+    return cache.getRegionByKey(key, backOffer);
+  }
+
+  @Deprecated
+  // Do not use GetRegionByID when retrying request.
+  //
+  //   A,B |_______|_____|
+  //   A   |_____________|
+  // Consider region A, B. After merge of (A, B) -> A, region ID B does not exist.
+  // This request is unrecoverable.
+  public TiRegion getRegionById(long regionId) {
+    return cache.getRegionById(ConcreteBackOffer.newGetBackOff(), regionId);
+  }
+
+  public Pair<TiRegion, Store> getRegionStorePairByKey(ByteString key) {
+    return getRegionStorePairByKey(key, ConcreteBackOffer.newGetBackOff());
+  }
+
+  public Pair<TiRegion, Store> getRegionStorePairByKey(ByteString key, BackOffer backOffer) {
+    TiRegion region = cache.getRegionByKey(key, backOffer);
+    if (region == null) {
+      throw new TiClientInternalException("Region not exist for key:" + formatBytesUTF8(key));
+    }
+    if (!region.isValid()) {
+      throw new TiClientInternalException("Region invalid: " + region.toString());
+    }
+
+    Peer leader = region.getLeader();
+    long storeId = leader.getStoreId();
+    return Pair.create(region, cache.getStoreById(storeId, backOffer));
+  }
+
+  public Store getStoreById(long id) {
+    return getStoreById(id, ConcreteBackOffer.newGetBackOff());
+  }
+
+  public Store getStoreById(long id, BackOffer backOffer) {
+    return cache.getStoreById(id, backOffer);
+  }
+
+  public void onRegionStale(TiRegion region) {
+    cache.invalidateRegion(region);
+  }
+
+  public synchronized TiRegion updateLeader(TiRegion region, long storeId) {
+    TiRegion r = cache.getRegionFromCache(region.getId());
+    if (r != null) {
+      if (r.getLeader().getStoreId() == storeId) {
+        return r;
+      }
+      TiRegion newRegion = r.switchPeer(storeId);
+      if (newRegion != null) {
+        cache.putRegion(newRegion);
+        return newRegion;
+      }
+      // failed to switch leader, possibly region is outdated, we need to drop region cache from
+      // regionCache
+      logger.warn("Cannot find peer when updating leader (" + region.getId() + "," + storeId + ")");
+    }
+    return null;
+  }
+
+  /**
+   * Clears all cache when a TiKV server does not respond
+   *
+   * @param region region
+   */
+  public void onRequestFail(TiRegion region) {
+    onRequestFail(region, region.getLeader().getStoreId());
+  }
+
+  private void onRequestFail(TiRegion region, long storeId) {
+    cache.invalidateRegion(region);
+    cache.invalidateAllRegionForStore(storeId);
+  }
+
+  public void invalidateStore(long storeId) {
+    cache.invalidateStore(storeId);
+  }
+
+  public void invalidateRegion(TiRegion region) {
+    cache.invalidateRegion(region);
   }
 
   public static class RegionCache {
@@ -69,17 +175,22 @@ public class RegionManager {
       this.pdClient = pdClient;
     }
 
-    public synchronized TiRegion getRegionByKey(ByteString key) {
+    public synchronized TiRegion getRegionByKey(ByteString key, BackOffer backOffer) {
       Long regionId;
-      regionId = keyToRegionIdCache.get(Key.toRawKey(key));
+      if (key.isEmpty()) {
+        // if key is empty, it must be the start key.
+        regionId = keyToRegionIdCache.get(Key.toRawKey(key, true));
+      } else {
+        regionId = keyToRegionIdCache.get(Key.toRawKey(key));
+      }
       if (logger.isDebugEnabled()) {
         logger.debug(
             String.format("getRegionByKey key[%s] -> ID[%s]", formatBytesUTF8(key), regionId));
       }
 
       if (regionId == null) {
-        logger.debug("Key not find in keyToRegionIdCache:" + formatBytesUTF8(key));
-        TiRegion region = pdClient.getRegionByKey(ConcreteBackOffer.newGetBackOff(), key);
+        logger.debug("Key not found in keyToRegionIdCache:" + formatBytesUTF8(key));
+        TiRegion region = pdClient.getRegionByKey(backOffer, key);
         if (!putRegion(region)) {
           throw new TiClientInternalException("Invalid Region: " + region.toString());
         }
@@ -102,13 +213,14 @@ public class RegionManager {
       return true;
     }
 
-    private synchronized TiRegion getRegionById(long regionId) {
+    @Deprecated
+    private synchronized TiRegion getRegionById(BackOffer backOffer, long regionId) {
       TiRegion region = regionCache.get(regionId);
       if (logger.isDebugEnabled()) {
         logger.debug(String.format("getRegionByKey ID[%s] -> Region[%s]", regionId, region));
       }
       if (region == null) {
-        region = pdClient.getRegionByID(ConcreteBackOffer.newGetBackOff(), regionId);
+        region = pdClient.getRegionByID(backOffer, regionId);
         if (!putRegion(region)) {
           throw new TiClientInternalException("Invalid Region: " + region.toString());
         }
@@ -116,17 +228,22 @@ public class RegionManager {
       return region;
     }
 
+    private synchronized TiRegion getRegionFromCache(long regionId) {
+      return regionCache.get(regionId);
+    }
+
     /** Removes region associated with regionId from regionCache. */
-    public synchronized void invalidateRegion(long regionId) {
+    public synchronized void invalidateRegion(TiRegion region) {
       try {
         if (logger.isDebugEnabled()) {
-          logger.debug(String.format("invalidateRegion ID[%s]", regionId));
+          logger.debug(String.format("invalidateRegion ID[%s]", region.getId()));
         }
-        TiRegion region = regionCache.get(regionId);
-        keyToRegionIdCache.remove(makeRange(region.getStartKey(), region.getEndKey()));
+        TiRegion oldRegion = regionCache.get(region.getId());
+        if (oldRegion != null && oldRegion == region) {
+          keyToRegionIdCache.remove(makeRange(region.getStartKey(), region.getEndKey()));
+          regionCache.remove(region.getId());
+        }
       } catch (Exception ignore) {
-      } finally {
-        regionCache.remove(regionId);
       }
     }
 
@@ -152,11 +269,11 @@ public class RegionManager {
       storeCache.remove(storeId);
     }
 
-    public synchronized Store getStoreById(long id) {
+    public synchronized Store getStoreById(long id, BackOffer backOffer) {
       try {
         Store store = storeCache.get(id);
         if (store == null) {
-          store = pdClient.getStore(ConcreteBackOffer.newGetBackOff(), id);
+          store = pdClient.getStore(backOffer, id);
         }
         if (store.getState().equals(StoreState.Tombstone)) {
           return null;
@@ -167,85 +284,5 @@ public class RegionManager {
         throw new GrpcException(e);
       }
     }
-  }
-
-  public Function<CacheInvalidateEvent, Void> getCacheInvalidateCallback() {
-    return cacheInvalidateCallback;
-  }
-
-  public TiRegion getRegionByKey(ByteString key) {
-    return cache.getRegionByKey(key);
-  }
-
-  public TiRegion getRegionById(long regionId) {
-    return cache.getRegionById(regionId);
-  }
-
-  public Pair<TiRegion, Store> getRegionStorePairByKey(ByteString key) {
-    TiRegion region = cache.getRegionByKey(key);
-    if (region == null) {
-      throw new TiClientInternalException("Region not exist for key:" + formatBytesUTF8(key));
-    }
-    if (!region.isValid()) {
-      throw new TiClientInternalException("Region invalid: " + region.toString());
-    }
-    Peer leader = region.getLeader();
-    long storeId = leader.getStoreId();
-    return Pair.create(region, cache.getStoreById(storeId));
-  }
-
-  public Pair<TiRegion, Store> getRegionStorePairByRegionId(long id) {
-    TiRegion region = cache.getRegionById(id);
-    if (!region.isValid()) {
-      throw new TiClientInternalException("Region invalid: " + region.toString());
-    }
-    Peer leader = region.getLeader();
-    long storeId = leader.getStoreId();
-    return Pair.create(region, cache.getStoreById(storeId));
-  }
-
-  public Store getStoreById(long id) {
-    return cache.getStoreById(id);
-  }
-
-  public void onRegionStale(long regionId) {
-    cache.invalidateRegion(regionId);
-  }
-
-  public boolean updateLeader(long regionId, long storeId) {
-    TiRegion r = cache.regionCache.get(regionId);
-    if (r != null) {
-      if (!r.switchPeer(storeId)) {
-        // failed to switch leader, possibly region is outdated, we need to drop region cache from
-        // regionCache
-        logger.warn("Cannot find peer when updating leader (" + regionId + "," + storeId + ")");
-        // drop region cache using verId
-        cache.invalidateRegion(regionId);
-        return false;
-      }
-    }
-    return true;
-  }
-
-  /**
-   * Clears all cache when a TiKV server does not respond
-   *
-   * @param region region
-   */
-  public void onRequestFail(TiRegion region) {
-    onRequestFail(region.getId(), region.getLeader().getStoreId());
-  }
-
-  public void onRequestFail(long regionId, long storeId) {
-    cache.invalidateRegion(regionId);
-    cache.invalidateAllRegionForStore(storeId);
-  }
-
-  public void invalidateStore(long storeId) {
-    cache.invalidateStore(storeId);
-  }
-
-  public void invalidateRegion(long regionId) {
-    cache.invalidateRegion(regionId);
   }
 }

--- a/tikv-client/src/main/java/com/pingcap/tikv/region/RegionStoreClient.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/region/RegionStoreClient.java
@@ -759,19 +759,17 @@ public class RegionStoreClient extends AbstractGRPCClient<TikvBlockingStub, Tikv
    * @param newStore the new store presented by NotLeader Error
    * @return false when re-split is needed.
    */
-  @Override
-  public boolean onNotLeader(Store newStore) {
+  public boolean onNotLeader(Store newStore, TiRegion newRegion) {
     if (logger.isDebugEnabled()) {
       logger.debug(region + ", new leader = " + newStore.getId());
     }
-    TiRegion cachedRegion = regionManager.getRegionById(region.getId());
-    // When switch leader fails or the region changed its key range,
+    // When switch leader fails or the region changed its region epoch,
     // it would be necessary to re-split task's key range for new region.
-    if (!region.getStartKey().equals(cachedRegion.getStartKey())
-        || !region.getEndKey().equals(cachedRegion.getEndKey())) {
+    if (!region.getRegionEpoch().equals(newRegion.getRegionEpoch())) {
+      regionManager.invalidateRegion(newRegion);
       return false;
     }
-    region = cachedRegion;
+    region = newRegion;
     String addressStr = regionManager.getStoreById(region.getLeader().getStoreId()).getAddress();
     ManagedChannel channel = channelFactory.getChannel(addressStr);
     blockingStub = TikvGrpc.newBlockingStub(channel);
@@ -785,8 +783,8 @@ public class RegionStoreClient extends AbstractGRPCClient<TikvBlockingStub, Tikv
     ManagedChannel channel = channelFactory.getChannel(addressStr);
     blockingStub = TikvGrpc.newBlockingStub(channel);
     asyncStub = TikvGrpc.newStub(channel);
-    if (logger.isDebugEnabled() && region.getLeader().getStoreId() != store.getId()) {
-      logger.debug(
+    if (region.getLeader().getStoreId() != store.getId()) {
+      logger.warn(
           "store_not_match may occur? "
               + region
               + ", original store = "

--- a/tikv-client/src/main/java/com/pingcap/tikv/region/TiRegion.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/region/TiRegion.java
@@ -56,6 +56,13 @@ public class TiRegion implements Serializable {
     this.commandPri = commandPri;
   }
 
+  public TiRegion(TiRegion oldRegion, Peer newLeader) {
+    this.meta = oldRegion.getMeta();
+    this.isolationLevel = oldRegion.isolationLevel;
+    this.commandPri = oldRegion.commandPri;
+    this.leader = newLeader;
+  }
+
   private Region decodeRegion(Region region, boolean isRawRegion) {
     Region.Builder builder =
         Region.newBuilder()
@@ -134,7 +141,7 @@ public class TiRegion implements Serializable {
     List<Peer> peers = meta.getPeersList();
     for (Peer p : peers) {
       if (p.getStoreId() == leaderStoreID) {
-        return new TiRegion(this.meta, p, this.isolationLevel, this.commandPri);
+        return new TiRegion(this, p);
       }
     }
     return null;

--- a/tikv-client/src/test/java/com/pingcap/tikv/RegionManagerTest.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/RegionManagerTest.java
@@ -130,7 +130,7 @@ public class RegionManagerTest extends PDMockServerTest {
     TiRegion regionToSearch = mgr.getRegionById(regionId);
     assertEquals(region, regionToSearch);
 
-    mgr.invalidateRegion(regionId);
+    mgr.invalidateRegion(region);
 
     // This will in turn invoke rpc and results in an error
     // since we set just one rpc response

--- a/tikv-client/src/test/java/com/pingcap/tikv/txn/LockResolverTest.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/txn/LockResolverTest.java
@@ -96,7 +96,6 @@ public class LockResolverTest {
           new KVErrorHandler<>(
               session.getRegionManager(),
               client,
-              region,
               resp -> resp.hasRegionError() ? resp.getRegionError() : null);
 
       PrewriteResponse resp =
@@ -202,7 +201,6 @@ public class LockResolverTest {
           new KVErrorHandler<>(
               session.getRegionManager(),
               client,
-              tiRegion,
               resp -> resp.hasRegionError() ? resp.getRegionError() : null);
 
       CommitResponse resp =

--- a/tikv-client/src/test/java/com/pingcap/tikv/util/RangeSplitterTest.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/util/RangeSplitterTest.java
@@ -47,19 +47,6 @@ public class RangeSplitterTest {
     }
 
     @Override
-    public Pair<TiRegion, Metapb.Store> getRegionStorePairByRegionId(long id) {
-      Map.Entry<KeyRange, TiRegion> entry =
-          mockRegionMap
-              .entrySet()
-              .stream()
-              .filter(e -> e.getValue().getId() == id)
-              .findFirst()
-              .get();
-      return Pair.create(
-          entry.getValue(), Metapb.Store.newBuilder().setId(entry.getValue().getId()).build());
-    }
-
-    @Override
     public Pair<TiRegion, Metapb.Store> getRegionStorePairByKey(ByteString key) {
       for (Map.Entry<KeyRange, TiRegion> entry : mockRegionMap.entrySet()) {
         KeyRange range = entry.getKey();


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
This is a fix for release-2.1 only.

In the previous implementation of the RegionManager, when the regions are invalidated, it is possible that the region in RegionManager is either not correctly invalidated due to race, or not correctly re-fetched.

RegionManager has race when encountering the following processes:
1. `invalidateRegion()` may be inconsistent when the handler tries to invalidate the region in RegionCache, but the region was previously updated by another process (e.g., `updateLeader()`).
2. the region was invalidated in keyToRegionIdCache, but the corresponding range is not correct.
3. if the invalidated range was smaller than the original, it creates a dangerous key range, where all keys in this range do not have a corresponding region id.
4. when fetching the region from the cache using `getRegionByKey()`, we look first into the key range cache, where it points to the non-existing region.

### What is changed and how it works?
Use CAS operations when trying to invalidate regions. Forbid the usage of the region id.

Future works:
For current usage, the cache invalidator has to find the region by its id because they are not on the same JVM. This operation should be carefully dealt with.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to be included in the release note
