### PR TITLE
do not select tidb_row_format_version if tidb is 3.x

### DIFF
--- a/core/src/main/scala/com/pingcap/tispark/write/TiBatchWriteTable.scala
+++ b/core/src/main/scala/com/pingcap/tispark/write/TiBatchWriteTable.scala
@@ -54,14 +54,16 @@ class TiBatchWriteTable(
     @transient val tiContext: TiContext,
     val options: TiDBOptions,
     val tiConf: TiConfiguration,
-    @transient val tiDBJDBCClient: TiDBJDBCClient)
+    @transient val tiDBJDBCClient: TiDBJDBCClient,
+    val isTiDBV4: Boolean)
     extends Serializable {
   private final val logger = LoggerFactory.getLogger(getClass.getName)
 
   import com.pingcap.tispark.write.TiBatchWrite._
   @transient private val tiSession = tiContext.tiSession
   // only fetch row format version once for each batch write process
-  private val enableNewRowFormat: Boolean = tiDBJDBCClient.getRowFormatVersion == 2
+  private val enableNewRowFormat: Boolean =
+    if (isTiDBV4) tiDBJDBCClient.getRowFormatVersion == 2 else false
   private var tiTableRef: TiTableReference = _
   private var tiDBInfo: TiDBInfo = _
   private var tiTableInfo: TiTableInfo = _


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
tidb-3.0 does not support variable tidb_row_format_version

### What is changed and how it works?
do not `select @@tidb_row_format_version` if tidb is 3.x

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `tidb-ansible` repository
 - Need to be included in the release note
