### PR TITLE
use comment to create clustered index table in test

### DIFF
--- a/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
@@ -45,14 +45,14 @@ class IssueTestSuite extends BaseTiSparkTest {
 
     tidbStmt.execute("drop table if exists `tispark_test`.`clustered0`")
 
-    createTableWithClusteredIndex("""
+    tidbStmt.execute("""
         CREATE TABLE `tispark_test`.`clustered0` (
         |  `col_bit0` bit(1) not null,
         |  `col_bit1` bit(1) not null,
         |  `col_int0` int(11) not null,
         |  `col_int1` int(11) not null,
         |  UNIQUE KEY (`col_int0`),
-        |  PRIMARY KEY (`col_bit1`,`col_bit0`)
+        |  PRIMARY KEY (`col_bit1`,`col_bit0`) /*T![clustered_index] CLUSTERED */
         |  );
         |""".stripMargin)
 

--- a/core/src/test/scala/org/apache/spark/sql/clustered/ClusteredIndexTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/clustered/ClusteredIndexTest.scala
@@ -86,7 +86,7 @@ trait ClusteredIndexTest extends BaseTiSparkTest with BaseEnumerateDataTypesTest
 
   protected def test(schema: Schema): Unit = {
     executeTiDBSQL(s"drop table if exists `$dbName`.`${schema.tableName}`;")
-    createTableWithClusteredIndex(schema.toString)
+    executeTiDBSQL(schema.toString(isClusteredIndex = true))
 
     var rc = rowCount
     schema.columnInfo.foreach { columnInfo =>

--- a/core/src/test/scala/org/apache/spark/sql/test/SharedSQLContext.scala
+++ b/core/src/test/scala/org/apache/spark/sql/test/SharedSQLContext.scala
@@ -174,26 +174,12 @@ trait SharedSQLContext
 
   protected def initializeStatement(): Unit = {
     _statement = _tidbConnection.createStatement()
-    if (supportClusteredIndex) {
-      disableClusteredIndex()
-    }
   }
 
   protected def supportClusteredIndex: Boolean = {
     val conn = TiDBUtils.createConnectionFactory(jdbcUrl)()
     val tiDBJDBCClient = new TiDBJDBCClient(conn)
     tiDBJDBCClient.supportClusteredIndex
-  }
-
-  protected def createTableWithClusteredIndex(sql: String): Unit = {
-    enableClusteredIndex()
-    val conn = TiDBUtils.createConnectionFactory(jdbcUrl)()
-    val stmt = conn.createStatement()
-    println(sql)
-    stmt.execute(sql)
-    stmt.close()
-    conn.close()
-    disableClusteredIndex()
   }
 
   private def enableClusteredIndex(): Unit = {

--- a/core/src/test/scala/org/apache/spark/sql/test/generator/Schema.scala
+++ b/core/src/test/scala/org/apache/spark/sql/test/generator/Schema.scala
@@ -80,12 +80,17 @@ case class Schema(
   private val keys: List[String] = indexInfo.map(_.toString)
 
   override def toString: String = {
+    toString(isClusteredIndex = false)
+  }
+
+  def toString(isClusteredIndex: Boolean): String = {
+    val clusteredIndexStr = if (isClusteredIndex) " /*T![clustered_index] CLUSTERED */" else ""
     val index = if (keys.nonEmpty) {
       keys.mkString(",\n|  ", ",\n|  ", "")
     } else ""
     (s"CREATE TABLE `$database`.`$tableName` (\n|  ".stripMargin +
       columns.mkString(",\n|  ") +
-      index +
+      index + clusteredIndexStr +
       "\n|) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin").stripMargin
   }
 }


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
use `SET global tidb_enable_clustered_index = 1;` to create clustered index table in test is not stable

https://internal.pingcap.net/idc-jenkins/blue/organizations/jenkins/tispark_regression_test_daily/detail/tispark_regression_test_daily/2803/pipeline/



### What is changed and how it works?

use comment to create clustered index table in test 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `tidb-ansible` repository
 - Need to be included in the release note
