### PR TITLE
skip test bigint int ClusteredIndexTest because of issue 1997

### DIFF
--- a/core/src/test/scala/org/apache/spark/sql/clustered/ClusteredIndexTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/clustered/ClusteredIndexTest.scala
@@ -17,14 +17,29 @@ package org.apache.spark.sql.clustered
 
 import org.apache.spark.sql.BaseTiSparkTest
 import org.apache.spark.sql.insertion.BaseEnumerateDataTypesTestSpec
-import org.apache.spark.sql.test.generator.DataType.{BIT, BOOLEAN, ReflectedDataType}
+import org.apache.spark.sql.test.generator.DataType.{
+  BIGINT,
+  BIT,
+  BLOB,
+  BOOLEAN,
+  DATE,
+  DECIMAL,
+  DOUBLE,
+  INT,
+  ReflectedDataType,
+  TEXT,
+  TIMESTAMP,
+  VARCHAR
+}
 import org.apache.spark.sql.test.generator.TestDataGenerator._
 import org.apache.spark.sql.test.generator._
 
 import scala.util.Random
 
 trait ClusteredIndexTest extends BaseTiSparkTest with BaseEnumerateDataTypesTestSpec {
-  protected val testDataTypes: List[ReflectedDataType] = baseDataTypes
+  // https://github.com/pingcap/tispark/issues/1997
+  protected val testDataTypes: List[ReflectedDataType] =
+    List(BIT, BOOLEAN, INT, DECIMAL, DOUBLE, TIMESTAMP, DATE, TEXT, VARCHAR, BLOB)
 
   protected val tablePrefix: String = "clustered"
 


### PR DESCRIPTION
skip test bigint in ClusteredIndexTest because of issue https://github.com/pingcap/tispark/issues/1997

revert this PR is issue 1997 is fixed