### PR TITLE
update table statistics after batch write

### DIFF
--- a/core/src/main/scala/com/pingcap/tispark/write/TiBatchWrite.scala
+++ b/core/src/main/scala/com/pingcap/tispark/write/TiBatchWrite.scala
@@ -81,7 +81,7 @@ class TiBatchWrite(
   @transient private var tiDBJDBCClient: TiDBJDBCClient = _
   @transient private var tiBatchWriteTables: List[TiBatchWriteTable] = _
   @transient private var startMS: Long = _
-  @transient private var startTs: Long = _
+  private var startTs: Long = _
 
   private def write(): Unit = {
     try {

--- a/core/src/main/scala/com/pingcap/tispark/write/TiBatchWriteTable.scala
+++ b/core/src/main/scala/com/pingcap/tispark/write/TiBatchWriteTable.scala
@@ -74,6 +74,8 @@ class TiBatchWriteTable(
   private var tableLocked: Boolean = false
   private var autoIncProvidedID: Boolean = false
   private var isCommonHandle: Boolean = _
+  private var deltaCount: Long = 0
+  private var modifyCount: Long = 0
 
   tiTableRef = options.getTiTableRef(tiConf)
   tiDBInfo = tiSession.getCatalog.getDatabase(tiTableRef.databaseName)
@@ -116,6 +118,10 @@ class TiBatchWriteTable(
 
     val count = df.count
     logger.info(s"source data count=$count")
+
+    // a rough estimate to deltaCount and modifyCount
+    deltaCount = count
+    modifyCount = count
 
     // auto increment
     val rdd = if (tiTableInfo.hasAutoIncrementColumn) {
@@ -353,6 +359,15 @@ class TiBatchWriteTable(
         tableColSize) != 0 && colsInDf.lengthCompare(tableColSize - 1) != 0) {
       throw new TiBatchWriteException(
         s"table with auto increment column, but data col size ${colsInDf.length} != table column size $tableColSize and table column size - 1 ${tableColSize - 1} ")
+    }
+  }
+
+  // update table statistics: modify_count & count
+  def updateTableStatistics(startTs: Long): Unit = {
+    try {
+      tiDBJDBCClient.updateTableStatistics(startTs, tiTableInfo.getId, deltaCount, modifyCount)
+    } catch {
+      case e: Throwable => logger.warn("updateTableStatistics error!", e)
     }
   }
 


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
using batch write cannot trigger auto table analyze

### What is changed and how it works?
update table statistics after batch write

https://docs.pingcap.com/zh/tidb/stable/statistics#%E5%A2%9E%E9%87%8F%E6%94%B6%E9%9B%86

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `tidb-ansible` repository
 - Need to be included in the release note
