### PR TITLE
fix oom cause missing data bug

### DIFF
--- a/tikv-client/src/main/java/com/pingcap/tikv/operation/iterator/DAGIterator.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/operation/iterator/DAGIterator.java
@@ -229,7 +229,6 @@ public abstract class DAGIterator<T> extends CoprocessorIterator<T> {
                 + " tasks not executed due to",
             e);
         // Rethrow to upper levels
-        eof = true;
         throw new RegionTaskException("Handle region task failed:", e);
       }
     }


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
oom during calling `client.coprocess` will cause missing data bug!

### What is changed and how it works?
should not set `eof = true` if oom occures during calling `client.coprocess`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `tidb-ansible` repository
 - Need to be included in the release note
