### PR TITLE
change PARTITION_PER_SPLIT default value from 1 to 10

### DIFF
--- a/core/src/main/scala/com/pingcap/tispark/utils/TiUtil.scala
+++ b/core/src/main/scala/com/pingcap/tispark/utils/TiUtil.scala
@@ -155,7 +155,7 @@ object TiUtil {
     sqlContext.getConf(TiConfigConst.CHUNK_BATCH_SIZE, "1024").toInt
 
   def getPartitionPerSplit(sqlContext: SQLContext): Int =
-    sqlContext.getConf(TiConfigConst.PARTITION_PER_SPLIT, "10").toInt
+    sqlContext.getConf(TiConfigConst.PARTITION_PER_SPLIT, "1").toInt
 
   def getIsolationReadEngines(sqlContext: SQLContext): List[TiStoreType] =
     getIsolationReadEnginesFromString(


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

change PARTITION_PER_SPLIT default value from 1 to 10

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `tidb-ansible` repository
 - Need to be included in the release note
