### PR TITLE
fix bug: write decimal(16, 4) using batch write and read using tiflash

### DIFF
--- a/tikv-client/src/test/java/com/pingcap/tikv/codec/TableCodecV2Test.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/codec/TableCodecV2Test.java
@@ -121,7 +121,7 @@ public class TableCodecV2Test {
                 new int[] {128, 0, 1, 0, 0, 0, 1, 5, 0, 6, 4, 139, 38, 172},
                 MetaUtils.TableBuilder.newBuilder()
                     .name("t")
-                    .addColumn("c1", DecimalType.DECIMAL)
+                    .addColumn("c1", new DecimalType(6, 4))
                     .build(),
                 new Object[] {new BigDecimal("11.9900")}),
             // test bit
@@ -248,7 +248,7 @@ public class TableCodecV2Test {
             .addColumn("c5", StringType.CHAR, 25)
             .addColumn("c6", TimestampType.TIMESTAMP, 5)
             .addColumn("c7", TimeType.TIME, 16)
-            .addColumn("c8", DecimalType.DECIMAL, 8)
+            .addColumn("c8", new DecimalType(6, 4), 8)
             .addColumn("c9", IntegerType.YEAR, 12)
             .addColumn("c10", TEST_ENUM_TYPE, 9)
             // .addColumn("c11", JsonType.JSON, 14)


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
close https://github.com/pingcap/tispark/issues/2053

### What is changed and how it works?
use the `precision` and `frac` from column instead of real data when encoding `Decimal Type`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `tidb-ansible` repository
 - Need to be included in the release note
