### PR TITLE
Fix ResolveLock not called in Scan API

### DIFF
--- a/config/tidb.toml
+++ b/config/tidb.toml
@@ -45,6 +45,9 @@ enable-table-lock = true
 # In order to support "drop primary key" operation , this flag must be true and the table does not have the pkIsHandle flag.
 alter-primary-key = true
 
+# index-limit is used to deal with compatibility issues. It can only be in [64, 64*8].
+index-limit = 512
+
 [log]
 # Log level: info, debug, warn, error, fatal.
 level = "info"

--- a/tikv-client/src/main/java/com/pingcap/tikv/KVClient.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/KVClient.java
@@ -117,25 +117,6 @@ public class KVClient implements AutoCloseable {
     return result;
   }
 
-  /**
-   * Scan key-value pairs from TiKV in range [startKey, ♾), maximum to `limit` pairs
-   *
-   * @param startKey start key, inclusive
-   * @param limit limit of kv pairs
-   * @return list of key-value pairs in range
-   */
-  public List<Kvrpcpb.KvPair> scan(ByteString startKey, long version, int limit)
-      throws GrpcException {
-    Iterator<Kvrpcpb.KvPair> iterator = scanIterator(conf, clientBuilder, startKey, version, limit);
-    List<Kvrpcpb.KvPair> result = new ArrayList<>();
-    iterator.forEachRemaining(result::add);
-    return result;
-  }
-
-  public List<Kvrpcpb.KvPair> scan(ByteString startKey, long version) throws GrpcException {
-    return scan(startKey, version, Integer.MAX_VALUE);
-  }
-
   private List<KvPair> doSendBatchGet(BackOffer backOffer, List<ByteString> keys, long version) {
     ExecutorCompletionService<List<KvPair>> completionService =
         new ExecutorCompletionService<>(executorService);
@@ -252,15 +233,6 @@ public class KVClient implements AutoCloseable {
       ByteString endKey,
       long version) {
     return new ConcreteScanIterator(conf, builder, startKey, endKey, version);
-  }
-
-  private Iterator<Kvrpcpb.KvPair> scanIterator(
-      TiConfiguration conf,
-      RegionStoreClientBuilder builder,
-      ByteString startKey,
-      long version,
-      int limit) {
-    return new ConcreteScanIterator(conf, builder, startKey, version, limit);
   }
 
   /** A Batch containing the region and a list of keys to send */

--- a/tikv-client/src/main/java/com/pingcap/tikv/Snapshot.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/Snapshot.java
@@ -145,21 +145,6 @@ public class Snapshot {
   }
 
   /**
-   * scan all keys after startKey, inclusive
-   *
-   * @param startKey start of keys
-   * @return iterator of kvPair
-   */
-  public Iterator<KvPair> scan(ByteString startKey) {
-    return new ConcreteScanIterator(
-        session.getConf(),
-        session.getRegionStoreClientBuilder(),
-        startKey,
-        timestamp.getVersion(),
-        Integer.MAX_VALUE);
-  }
-
-  /**
    * scan all keys with prefix
    *
    * @param prefix prefix of keys

--- a/tikv-client/src/main/java/com/pingcap/tikv/codec/MetaCodec.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/codec/MetaCodec.java
@@ -26,10 +26,13 @@ import com.pingcap.tikv.util.Pair;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.tikv.kvproto.Kvrpcpb;
 import org.tikv.kvproto.Kvrpcpb.KvPair;
 
 public class MetaCodec {
+  protected static final Logger logger = LoggerFactory.getLogger(MetaCodec.class);
   public static final String ENCODED_DB_PREFIX = "DB";
   public static final String KEY_TID = "TID";
   private static final byte[] META_PREFIX = new byte[] {'m'};
@@ -115,7 +118,7 @@ public class MetaCodec {
     List<Pair<ByteString, ByteString>> fields = new ArrayList<>();
     while (iterator.hasNext()) {
       Kvrpcpb.KvPair kv = iterator.next();
-      if (kv == null || kv.getKey() == null) {
+      if (kv == null || kv.getKey().isEmpty()) {
         continue;
       }
       fields.add(Pair.create(MetaCodec.decodeHashDataKey(kv.getKey()).second, kv.getValue()));

--- a/tikv-client/src/main/java/com/pingcap/tikv/operation/KVErrorHandler.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/operation/KVErrorHandler.java
@@ -315,9 +315,6 @@ public class KVErrorHandler<RespT> implements ErrorHandler<RespT> {
         try {
           resolveLocks(backOffer, locks);
           retry = true;
-          backOffer.doBackOff(
-              BackOffFunction.BackOffFuncType.BoTxnLockFast,
-              new KeyException("resolve " + locks.size() + " locks"));
         } catch (KeyException e) {
           logger.warn("Unable to handle KeyExceptions other than LockException", e);
         }
@@ -330,8 +327,6 @@ public class KVErrorHandler<RespT> implements ErrorHandler<RespT> {
           Lock lock = AbstractLockResolverClient.extractLockFromKeyErr(keyError);
           resolveLock(backOffer, lock);
           retry = true;
-          backOffer.doBackOff(
-              BackOffFunction.BackOffFuncType.BoTxnLockFast, new KeyException("resolve lock"));
         } catch (KeyException e) {
           logger.warn("Unable to handle KeyExceptions other than LockException", e);
         }

--- a/tikv-client/src/main/java/com/pingcap/tikv/operation/iterator/ConcreteScanIterator.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/operation/iterator/ConcreteScanIterator.java
@@ -23,10 +23,12 @@ import com.google.protobuf.ByteString;
 import com.pingcap.tikv.TiConfiguration;
 import com.pingcap.tikv.exception.GrpcException;
 import com.pingcap.tikv.exception.KeyException;
+import com.pingcap.tikv.exception.TiKVException;
 import com.pingcap.tikv.key.Key;
 import com.pingcap.tikv.region.RegionStoreClient;
 import com.pingcap.tikv.region.RegionStoreClient.RegionStoreClientBuilder;
 import com.pingcap.tikv.region.TiRegion;
+import com.pingcap.tikv.util.BackOffFunction;
 import com.pingcap.tikv.util.BackOffer;
 import com.pingcap.tikv.util.ConcreteBackOffer;
 import com.pingcap.tikv.util.Pair;
@@ -44,41 +46,31 @@ public class ConcreteScanIterator extends ScanIterator {
       TiConfiguration conf,
       RegionStoreClientBuilder builder,
       ByteString startKey,
-      long version,
-      int limit) {
-    // Passing endKey as ByteString.EMPTY means that endKey is +INF by default,
-    this(conf, builder, startKey, ByteString.EMPTY, version, limit);
-  }
-
-  public ConcreteScanIterator(
-      TiConfiguration conf,
-      RegionStoreClientBuilder builder,
-      ByteString startKey,
       ByteString endKey,
       long version) {
     // Passing endKey as ByteString.EMPTY means that endKey is +INF by default,
-    this(conf, builder, startKey, endKey, version, Integer.MAX_VALUE);
-  }
-
-  private ConcreteScanIterator(
-      TiConfiguration conf,
-      RegionStoreClientBuilder builder,
-      ByteString startKey,
-      ByteString endKey,
-      long version,
-      int limit) {
-    super(conf, builder, startKey, endKey, limit);
+    super(conf, builder, startKey, endKey, Integer.MAX_VALUE);
     this.version = version;
   }
 
   @Override
   TiRegion loadCurrentRegionToCache() throws GrpcException {
-    TiRegion region;
-    try (RegionStoreClient client = builder.build(startKey)) {
-      region = client.getRegion();
-      BackOffer backOffer = ConcreteBackOffer.newScannerNextMaxBackOff();
-      currentCache = client.scan(backOffer, startKey, version);
-      return region;
+    BackOffer backOffer = ConcreteBackOffer.newScannerNextMaxBackOff();
+    while (true) {
+      try (RegionStoreClient client = builder.build(startKey)) {
+        TiRegion region = client.getRegion();
+        if (limit <= 0) {
+          currentCache = null;
+        } else {
+          try {
+            currentCache = client.scan(backOffer, startKey, limit, version);
+          } catch (final TiKVException e) {
+            backOffer.doBackOff(BackOffFunction.BackOffFuncType.BoRegionMiss, e);
+            continue;
+          }
+        }
+        return region;
+      }
     }
   }
 
@@ -96,25 +88,39 @@ public class ConcreteScanIterator extends ScanIterator {
     }
   }
 
-  @Override
-  public boolean hasNext() {
-    Kvrpcpb.KvPair current;
-    // continue when cache is empty but not null
-    do {
-      current = getCurrent();
-      if (isCacheDrained() && cacheLoadFails()) {
-        endOfScan = true;
-        return false;
-      }
-    } while (currentCache != null && current == null);
-    // for last batch to be processed, we have to check if
-    return !processingLastBatch
-        || current == null
-        || (hasEndKey && Key.toRawKey(current.getKey()).compareTo(endKey) < 0);
+  /**
+   * Cache is drained when - no data extracted - scan limit was not defined - have read the last
+   * index of cache - index not initialized
+   *
+   * @return whether cache is drained
+   */
+  private boolean isCacheDrained() {
+    return currentCache == null || limit <= 0 || index >= currentCache.size() || index == -1;
+  }
+
+  private boolean notEndOfScan() {
+    return limit > 0
+        && !(processingLastBatch
+            && (index >= currentCache.size()
+                || Key.toRawKey(currentCache.get(index).getKey()).compareTo(endKey) >= 0));
   }
 
   @Override
-  public KvPair next() {
+  public boolean hasNext() {
+    if (isCacheDrained() && cacheLoadFails()) {
+      endOfScan = true;
+      return false;
+    }
+    // continue when cache is empty but not null
+    while (currentCache != null && currentCache.isEmpty()) {
+      if (cacheLoadFails()) {
+        return false;
+      }
+    }
+    return notEndOfScan();
+  }
+
+  private Kvrpcpb.KvPair getCurrent() {
     --limit;
     KvPair current = currentCache.get(index++);
 
@@ -127,20 +133,8 @@ public class ConcreteScanIterator extends ScanIterator {
     return current;
   }
 
-  /**
-   * Cache is drained when - no data extracted - scan limit was not defined - have read the last
-   * index of cache - index not initialized
-   *
-   * @return whether cache is drained
-   */
-  private boolean isCacheDrained() {
-    return currentCache == null || limit <= 0 || index >= currentCache.size() || index == -1;
-  }
-
-  private Kvrpcpb.KvPair getCurrent() {
-    if (isCacheDrained()) {
-      return null;
-    }
-    return currentCache.get(index);
+  @Override
+  public Kvrpcpb.KvPair next() {
+    return getCurrent();
   }
 }

--- a/tikv-client/src/main/java/com/pingcap/tikv/operation/iterator/ScanIterator.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/operation/iterator/ScanIterator.java
@@ -48,11 +48,8 @@ public abstract class ScanIterator implements Iterator<Kvrpcpb.KvPair> {
       ByteString endKey,
       int limit) {
     this.startKey = requireNonNull(startKey, "start key is null");
-    if (startKey.isEmpty()) {
-      throw new IllegalArgumentException("start key cannot be empty");
-    }
     this.endKey = Key.toRawKey(requireNonNull(endKey, "end key is null"));
-    this.hasEndKey = !endKey.equals(ByteString.EMPTY);
+    this.hasEndKey = !endKey.isEmpty();
     this.limit = limit;
     this.conf = conf;
     this.builder = builder;
@@ -71,7 +68,7 @@ public abstract class ScanIterator implements Iterator<Kvrpcpb.KvPair> {
     if (endOfScan || processingLastBatch) {
       return true;
     }
-    if (startKey == null || startKey.isEmpty()) {
+    if (startKey == null) {
       return true;
     }
     try {
@@ -89,10 +86,10 @@ public abstract class ScanIterator implements Iterator<Kvrpcpb.KvPair> {
       // Session should be single-threaded itself
       // so that we don't worry about conf change in the middle
       // of a transaction. Otherwise below code might lose data
-      if (currentCache.size() < conf.getScanBatchSize()) {
+      if (currentCache.size() < limit) {
         startKey = curRegionEndKey;
         lastKey = Key.toRawKey(curRegionEndKey);
-      } else if (currentCache.size() > conf.getScanBatchSize()) {
+      } else if (currentCache.size() > limit) {
         throw new IndexOutOfBoundsException(
             "current cache size = "
                 + currentCache.size()
@@ -104,7 +101,8 @@ public abstract class ScanIterator implements Iterator<Kvrpcpb.KvPair> {
         startKey = lastKey.next().toByteString();
       }
       // notify last batch if lastKey is greater than or equal to endKey
-      if (hasEndKey && lastKey.compareTo(endKey) >= 0) {
+      // if startKey is empty, it indicates +∞
+      if (hasEndKey && lastKey.compareTo(endKey) >= 0 || startKey.isEmpty()) {
         processingLastBatch = true;
         startKey = null;
       }

--- a/tikv-client/src/main/java/com/pingcap/tikv/region/RegionStoreClient.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/region/RegionStoreClient.java
@@ -312,12 +312,9 @@ public class RegionStoreClient extends AbstractRegionStoreClient {
   }
 
   public List<KvPair> scan(
-      BackOffer backOffer, ByteString startKey, long version, boolean keyOnly) {
+      BackOffer backOffer, ByteString startKey, int limit, long version, boolean keyOnly) {
     boolean forWrite = false;
     while (true) {
-      // we should refresh region
-      region = regionManager.getRegionByKey(startKey);
-
       Supplier<ScanRequest> request =
           () ->
               ScanRequest.newBuilder()
@@ -325,7 +322,7 @@ public class RegionStoreClient extends AbstractRegionStoreClient {
                   .setStartKey(startKey)
                   .setVersion(version)
                   .setKeyOnly(keyOnly)
-                  .setLimit(getConf().getScanBatchSize())
+                  .setLimit(limit)
                   .build();
 
       KVErrorHandler<ScanResponse> handler =
@@ -343,6 +340,8 @@ public class RegionStoreClient extends AbstractRegionStoreClient {
       if (isScanSuccess(backOffer, resp)) {
         return doScan(resp);
       }
+      // we should refresh region
+      region = regionManager.getRegionByKey(startKey);
     }
   }
 
@@ -379,8 +378,8 @@ public class RegionStoreClient extends AbstractRegionStoreClient {
     return Collections.unmodifiableList(newKvPairs);
   }
 
-  public List<KvPair> scan(BackOffer backOffer, ByteString startKey, long version) {
-    return scan(backOffer, startKey, version, false);
+  public List<KvPair> scan(BackOffer backOffer, ByteString startKey, int limit, long version) {
+    return scan(backOffer, startKey, limit, version, false);
   }
 
   /**

--- a/tikv-client/src/test/java/com/pingcap/tikv/RegionStoreClientTest.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/RegionStoreClientTest.java
@@ -144,7 +144,15 @@ public class RegionStoreClientTest extends MockServerTest {
     server.put("key2", "value2");
     server.put("key4", "value4");
     server.put("key5", "value5");
-    List<Kvrpcpb.KvPair> kvs = client.scan(defaultBackOff(), ByteString.copyFromUtf8("key2"), 1);
+    List<Kvrpcpb.KvPair> kvs =
+        client.scan(defaultBackOff(), ByteString.copyFromUtf8("key2"), 100, 1);
+    assertEquals(3, kvs.size());
+    kvs.forEach(
+        kv ->
+            assertEquals(
+                kv.getKey().toStringUtf8().replace("key", "value"), kv.getValue().toStringUtf8()));
+
+    kvs = client.scan(defaultBackOff(), ByteString.copyFromUtf8("key1"), 3, 1);
     assertEquals(3, kvs.size());
     kvs.forEach(
         kv ->
@@ -153,7 +161,7 @@ public class RegionStoreClientTest extends MockServerTest {
 
     server.putError("error1", KVMockServer.ABORT);
     try {
-      client.scan(defaultBackOff(), ByteString.copyFromUtf8("error1"), 1);
+      client.scan(defaultBackOff(), ByteString.copyFromUtf8("error1"), 100, 1);
       fail();
     } catch (Exception e) {
       assertTrue(true);

--- a/tikv-client/src/test/java/com/pingcap/tikv/meta/MetaUtils.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/meta/MetaUtils.java
@@ -267,7 +267,7 @@ public class MetaUtils {
       kvServer.put(getSchemaVersionKey(), ByteString.copyFromUtf8(String.format("%d", version)));
     }
 
-    public void addTable(int dbId, int tableId, String tableName) {
+    public void addTable(long dbId, long tableId, String tableName) {
       String tableJson =
           String.format(
               "\n"


### PR DESCRIPTION
ResolveLock was not called in Scan API, it would lead to 

* Sometimes the table/database info was not retrieved from TiKV, e.g., `table or view not found`
* Scan API may not get all KV pairs if some of them are locked by another transaction.

