### PR TITLE
Fix datetime shift before year 1582

### DIFF
--- a/core/src/test/scala/com/pingcap/tispark/datatype/BatchWriteDataTypeSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datatype/BatchWriteDataTypeSuite.scala
@@ -555,4 +555,36 @@ class BatchWriteDataTypeSuite extends BaseBatchWriteTest("test_data_type", "test
     tidbWrite(List(Row("b")), schema, None)
     compareTiDBSelectWithJDBC(List(Row("b ")), schema, sortCol = "a")
   }
+
+  test("Test datetime") {
+
+    compareTiDBWriteWithJDBC {
+      case (writeFunc, _) =>
+        jdbcUpdate(s"drop table if exists $dbtable")
+        jdbcUpdate(s"""
+                      |create table $dbtable(
+                      |id varchar(10),
+                      |dt datetime
+                      |)
+      """.stripMargin)
+
+        val rows = List(
+          Row("test0", Timestamp.valueOf("2020-10-10 05:12:03")),
+          Row("test1", Timestamp.valueOf("2020-10-10 19:12:03")),
+          Row("test2", Timestamp.valueOf("1000-01-01 05:12:03")),
+          Row("test3", Timestamp.valueOf("1000-01-01 19:12:03")),
+          Row("test4", Timestamp.valueOf("1000-01-01 00:00:00")),
+          Row("test5", Timestamp.valueOf("0999-12-31 17:00:00")),
+          Row("test6", Timestamp.valueOf("1582-10-04 23:59:59")),
+          Row("test7", Timestamp.valueOf("1582-10-04 16:59:59")),
+          Row("test8", Timestamp.valueOf("1582-10-14 17:00:00")),
+          Row("test9", Timestamp.valueOf("1582-10-15 00:00:00")))
+
+        val schema =
+          StructType(List(StructField("id", StringType), StructField("dt", TimestampType)))
+
+        writeFunc(rows, schema, None)
+        compareTiDBSelectWithJDBC(rows, schema, sortCol = "id")
+    }
+  }
 }

--- a/tikv-client/src/main/java/com/pingcap/tikv/ExtendedDateTime.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/ExtendedDateTime.java
@@ -19,12 +19,18 @@ package com.pingcap.tikv;
 
 import java.sql.Timestamp;
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
 
 /** Extend joda DateTime to support micro second */
 public class ExtendedDateTime {
 
   private final DateTime dateTime;
   private final int microsOfMillis;
+  private static final DateTimeZone LOCAL_TIME_ZOME = DateTimeZone.getDefault();
+  private static final DateTimeFormatter DATE_TIME_FORMATTER =
+      DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss.S").withZone(LOCAL_TIME_ZOME);
 
   /**
    * if timestamp = 2019-11-11 11:11:11 123456, then dateTime = 2019-11-11 11:11:11 123
@@ -56,12 +62,8 @@ public class ExtendedDateTime {
   }
 
   public Timestamp toTimeStamp() {
-    Timestamp timestamp = new Timestamp(dateTime.getMillis() / 1000 * 1000);
+    Timestamp timestamp = Timestamp.valueOf(dateTime.toString(DATE_TIME_FORMATTER));
     timestamp.setNanos(dateTime.getMillisOfSecond() * 1000000 + microsOfMillis * 1000);
     return timestamp;
-  }
-
-  public long toEpochMicro() {
-    return toTimeStamp().getTime() * 1000 + getMicrosOfMillis();
   }
 }

--- a/tikv-client/src/main/java/com/pingcap/tikv/codec/Codec.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/codec/Codec.java
@@ -519,8 +519,8 @@ public class Codec {
      */
     static long toPackedLong(
         int year, int month, int day, int hour, int minute, int second, int micro) {
-      long ymd = (year * 13 + month) << 5 | day;
-      long hms = hour << 12 | minute << 6 | second;
+      long ymd = (year * 13L + month) << 5 | day;
+      long hms = (long) hour << 12 | (long) minute << 6 | second;
       return ((ymd << 17 | hms) << 24) | micro;
     }
 
@@ -661,11 +661,11 @@ public class Codec {
      * @return a packed long.
      */
     static long toPackedLong(int year, int month, int day) {
-      long ymd = (year * 13 + month) << 5 | day;
+      long ymd = (year * 13L + month) << 5 | day;
       return ymd << 41;
     }
 
-    static LocalDate fromPackedLong(long packed) {
+    public static LocalDate fromPackedLong(long packed) {
       // TODO: As for JDBC behavior, it can be configured to "round" or "toNull"
       // for now we didn't pass in session so we do a toNull behavior
       if (packed == 0) {

--- a/tikv-client/src/main/java/com/pingcap/tikv/codec/RowEncoderV2.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/codec/RowEncoderV2.java
@@ -32,7 +32,6 @@ import java.sql.Timestamp;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
-import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 
 public class RowEncoderV2 {
@@ -309,15 +308,11 @@ public class RowEncoderV2 {
 
   private void encodeTimestamp(CodecDataOutput cdo, Object value, DateTimeZone tz) {
     if (value instanceof Timestamp) {
-      Timestamp timestamp = (Timestamp) value;
-      DateTime dateTime = new DateTime(timestamp.getTime());
-      int nanos = timestamp.getNanos();
-      ExtendedDateTime extendedDateTime = new ExtendedDateTime(dateTime, (nanos / 1000) % 1000);
+      ExtendedDateTime extendedDateTime = Converter.convertToDateTime(value);
       long t = DateTimeCodec.toPackedLong(extendedDateTime, tz);
       encodeInt(cdo, t);
     } else if (value instanceof Date) {
-      ExtendedDateTime extendedDateTime =
-          new ExtendedDateTime(new DateTime(((Date) value).getTime()));
+      ExtendedDateTime extendedDateTime = Converter.convertToDateTime(value);
       long t = DateTimeCodec.toPackedLong(extendedDateTime, tz);
       encodeInt(cdo, t);
     } else {

--- a/tikv-client/src/main/java/com/pingcap/tikv/columnar/TiCoreTime.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/columnar/TiCoreTime.java
@@ -73,7 +73,7 @@ public class TiCoreTime {
     return (int) ((coreTime & SECOND_BIT_FIELD_MASK) >>> SECOND_BIT_FIELD_OFFSET);
   }
 
-  public long getMicroSecond() {
-    return (coreTime & MICROSECOND_BIT_FIELD_MASK) >>> MICROSECOND_BIT_FIELD_OFFSET;
+  public int getMicroSecond() {
+    return (int) ((coreTime & MICROSECOND_BIT_FIELD_MASK) >>> MICROSECOND_BIT_FIELD_OFFSET);
   }
 }

--- a/tikv-client/src/main/java/com/pingcap/tikv/columnar/TiCoreTime.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/columnar/TiCoreTime.java
@@ -28,6 +28,7 @@ public class TiCoreTime {
   private static final long MINUTE_BIT_FIELD_OFFSET = 30, MINUTE_BIT_FIELD_WIDTH = 6;
   private static final long SECOND_BIT_FIELD_OFFSET = 24, SECOND_BIT_FIELD_WIDTH = 6;
   private static final long MICROSECOND_BIT_FIELD_OFFSET = 4, MICROSECOND_BIT_FIELD_WIDTH = 20;
+  private static final long NANOSECOND_BIT_FIELD_OFFSET = 0, NANOSECOND_BIT_FIELD_WIDTH = 24;
   private static final long YEAR_BIT_FIELD_MASK =
       ((1L << YEAR_BIT_FIELD_WIDTH) - 1) << YEAR_BIT_FIELD_OFFSET;
   private static final long MONTH_BIT_FIELD_MASK =
@@ -42,6 +43,8 @@ public class TiCoreTime {
       ((1L << SECOND_BIT_FIELD_WIDTH) - 1) << SECOND_BIT_FIELD_OFFSET;
   private static final long MICROSECOND_BIT_FIELD_MASK =
       ((1L << MICROSECOND_BIT_FIELD_WIDTH) - 1) << MICROSECOND_BIT_FIELD_OFFSET;
+  private static final long NANOSECOND_BIT_FIELD_MASK =
+      ((1L << NANOSECOND_BIT_FIELD_WIDTH) - 1) << NANOSECOND_BIT_FIELD_OFFSET;
 
   private final long coreTime;
 
@@ -75,5 +78,9 @@ public class TiCoreTime {
 
   public int getMicroSecond() {
     return (int) ((coreTime & MICROSECOND_BIT_FIELD_MASK) >>> MICROSECOND_BIT_FIELD_OFFSET);
+  }
+
+  public int getNanoSecond() {
+    return (int) ((coreTime & NANOSECOND_BIT_FIELD_MASK) >>> NANOSECOND_BIT_FIELD_OFFSET);
   }
 }

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/Converter.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/Converter.java
@@ -250,11 +250,12 @@ public class Converter {
       return new ExtendedDateTime(new DateTime((long) val));
     } else if (val instanceof Timestamp) {
       Timestamp timestamp = (Timestamp) val;
-      DateTime dateTime = new DateTime(timestamp.getTime());
+      DateTime dateTime = DateTime.parse(timestamp.toLocalDateTime().toString());
       int nanos = timestamp.getNanos();
       return new ExtendedDateTime(dateTime, (nanos / 1000) % 1000);
     } else if (val instanceof Date) {
-      return new ExtendedDateTime(new DateTime(((Date) val).getTime()));
+      return new ExtendedDateTime(
+          strToDateTime(((Date) val).toLocalDate().toString(), localDateFormatter));
     } else {
       throw new TypeException("Can not cast Object to LocalDateTime ");
     }
@@ -273,13 +274,13 @@ public class Converter {
       return (Date) val;
     } else if (val instanceof String) {
       try {
-        return new Date(DateTime.parse((String) val, localDateFormatter).toDate().getTime());
+        return new Date(strToDateTime((String) val, localDateFormatter).toDate().getTime());
       } catch (Exception e) {
         throw new TypeException(String.format("Error parsing string %s to date", val), e);
       }
     } else if (val instanceof Integer) {
       // when the val is a Integer, it is only have year part of a Date.
-      return new Date((Integer) val, 0, 0);
+      return new Date((Integer) val - 1970, 0, 0);
     } else if (val instanceof Long) {
       return new Date((long) val);
     } else if (val instanceof Timestamp) {
@@ -295,8 +296,10 @@ public class Converter {
     requireNonNull(val, "val is null");
     if (val instanceof BigDecimal) {
       return (BigDecimal) val;
-    } else if (val instanceof Double || val instanceof Float) {
-      return new BigDecimal((Double) val);
+    } else if (val instanceof Double) {
+      return BigDecimal.valueOf((Double) val);
+    } else if (val instanceof Float) {
+      return BigDecimal.valueOf((Float) val);
     } else if (val instanceof BigInteger) {
       return new BigDecimal((BigInteger) val);
     } else if (val instanceof Number) {

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/Converter.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/Converter.java
@@ -280,7 +280,7 @@ public class Converter {
       }
     } else if (val instanceof Integer) {
       // when the val is a Integer, it is only have year part of a Date.
-      return new Date((Integer) val - 1970, 0, 0);
+      return new Date((Integer) val - 1970, 1, 1);
     } else if (val instanceof Long) {
       return new Date((long) val);
     } else if (val instanceof Timestamp) {

--- a/tikv-client/src/test/java/com/pingcap/tikv/codec/TableCodecV2Test.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/codec/TableCodecV2Test.java
@@ -136,12 +136,12 @@ public class TableCodecV2Test {
                 new Object[] {new byte[] {49, 48, 48}}),
             // test date
             TestCase.createNew(
-                new int[] {128, 0, 1, 0, 0, 0, 1, 8, 0, 0, 0, 0, 69, 77, 105, 166, 25},
+                new int[] {128, 0, 1, 0, 0, 0, 1, 8, 0, 0, 0, 0, 0, 0, 104, 166, 25},
                 MetaUtils.TableBuilder.newBuilder()
                     .name("t")
                     .addColumn("c1", DateType.DATE)
                     .build(),
-                new Object[] {new Date(1590007985000L - timezoneOffset)}),
+                new Object[] {Date.valueOf("2020-05-20")}),
             // test datetime
             TestCase.createNew(
                 new int[] {128, 0, 1, 0, 0, 0, 1, 8, 0, 0, 0, 0, 69, 77, 105, 166, 25},
@@ -309,7 +309,36 @@ public class TableCodecV2Test {
     testCase.test();
   }
 
-  public static class TestCase {
+  @Test
+  public void testSpecialDateTimeType() {
+    TestCase testCase =
+        TestCase.createNew(
+            new int[] {128, 0, 1, 0, 0, 0, 1, 8, 0, 0, 0, 0, 0, 0, 66, 178, 12},
+            MetaUtils.TableBuilder.newBuilder()
+                .name("t")
+                .addColumn("c1", DateTimeType.DATETIME)
+                .build(),
+            new Object[] {Timestamp.valueOf("1000-01-01 00:00:00")});
+    testCase.test();
+    testCase =
+        TestCase.createNew(
+            new int[] {128, 0, 1, 0, 0, 0, 1, 8, 0, 0, 0, 0, 0, 0, 255, 177, 12},
+            MetaUtils.TableBuilder.newBuilder()
+                .name("t")
+                .addColumn("c1", TimestampType.TIMESTAMP)
+                .build(),
+            new Object[] {Timestamp.valueOf("1000-01-01 00:00:00")});
+    testCase.test();
+    // test date
+    testCase =
+        TestCase.createNew(
+            new int[] {128, 0, 1, 0, 0, 0, 1, 8, 0, 0, 0, 0, 0, 0, 66, 178, 12},
+            MetaUtils.TableBuilder.newBuilder().name("t").addColumn("c1", DateType.DATE).build(),
+            new Object[] {Date.valueOf("1000-01-01")});
+    testCase.test();
+  }
+
+  private static class TestCase {
     private final byte[] bytes;
     private final TiTableInfo tableInfo;
     private final Handle handle;
@@ -393,7 +422,7 @@ public class TableCodecV2Test {
         } else if (o instanceof byte[]) {
           s.append(Arrays.toString((byte[]) o));
         } else {
-          s.append(o.toString());
+          s.append(o);
         }
       }
       return s.toString();


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix #1701 

Originated from #1752 

When DateTime is less than 1582, the corresponding time will shift due to calendar change.

By using `Datetime.parse(String)`, we will be able to ignore the time-shift offset caused by `getTime()` API.