### PR TITLE
Close TTLManager before creating a new one

### DIFF
--- a/core/src/main/scala/com/pingcap/tispark/write/TiBatchWrite.scala
+++ b/core/src/main/scala/com/pingcap/tispark/write/TiBatchWrite.scala
@@ -279,6 +279,9 @@ class TiBatchWrite(
 
     // start primary key ttl update
     if (isTTLUpdate) {
+      if (ttlManager != null) {
+        ttlManager.close()
+      }
       ttlManager = new TTLManager(tiConf, startTs, primaryKey.bytes)
       ttlManager.keepAlive()
     }


### PR DESCRIPTION
Previous TTLManager might have not been closed gracefully. We could see logs containing `Channel is shut down` in CI.