### PR TITLE
Fix not leader error due to region not invalidated

### DIFF
--- a/tikv-client/src/main/java/com/pingcap/tikv/codec/KeyUtils.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/codec/KeyUtils.java
@@ -18,9 +18,19 @@ package com.pingcap.tikv.codec;
 import com.google.common.primitives.UnsignedBytes;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.TextFormat;
+import com.pingcap.tikv.key.Key;
 import org.tikv.kvproto.Coprocessor;
 
 public class KeyUtils {
+
+  public static Key getEncodedKey(ByteString key) {
+    if (key.isEmpty()) {
+      // if key is empty, it must be the start key.
+      return Key.toRawKey(key, true);
+    } else {
+      return Key.toRawKey(key);
+    }
+  }
 
   public static String formatBytes(byte[] bytes) {
     if (bytes == null) return "null";

--- a/tikv-client/src/main/java/com/pingcap/tikv/region/TiRegion.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/region/TiRegion.java
@@ -120,10 +120,6 @@ public class TiRegion implements Serializable {
     return meta.getEndKey();
   }
 
-  public Key getRowStartKey() {
-    return Key.toRawKey(getStartKey());
-  }
-
   public Kvrpcpb.Context getContext() {
     return getContext(java.util.Collections.emptySet());
   }


### PR DESCRIPTION
In previous fixes, #1987 #2106, the region cache was not invalidated in the NotLeader situation.