### PR TITLE
Cap lock expire time to prevent eternal sleep

### DIFF
--- a/tikv-client/src/main/java/com/pingcap/tikv/txn/LockResolverClientV4.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/txn/LockResolverClientV4.java
@@ -139,6 +139,7 @@ public class LockResolverClientV4 extends AbstractRegionStoreClient
 
       } else {
         long msBeforeLockExpired = TsoUtils.untilExpired(l.getTxnID(), status.getTtl());
+        logger.warn("until expired " + msBeforeLockExpired);
         msBeforeTxnExpired.update(msBeforeLockExpired);
 
         if (forWrite) {

--- a/tikv-client/src/main/java/com/pingcap/tikv/txn/TxnExpireTime.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/txn/TxnExpireTime.java
@@ -32,6 +32,8 @@ public class TxnExpireTime {
   public void update(long lockExpire) {
     if (lockExpire < 0) {
       lockExpire = 0;
+    } else if (lockExpire > 1000) {
+      lockExpire = 1000;
     }
 
     if (!this.initialized) {


### PR DESCRIPTION
Cap lock expire time to 1000 ms to prevent eternal sleep.