### PR TITLE
Bump log4j version to fix vulnerability

### DIFF
--- a/core-test/pom.xml
+++ b/core-test/pom.xml
@@ -71,12 +71,12 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.16.0</version>
+            <version>2.17.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.16.0</version>
+            <version>2.17.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -40,12 +40,12 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.16.0</version>
+            <version>2.17.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.16.0</version>
+            <version>2.17.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
Address vulnerability found in log4j 2.16

### What is changed and how it works?
Bump log4j version from 2.16.0 to 2.17.0

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Unit test
 - Integration test
 - No code

Related changes
 - Need to cherry-pick to the release branch
 - Need to be included in the release note

closes: #2184
