### PR TITLE
Fix:db-random-test

### DIFF
--- a/db-random-test/src/main/scala/com/pingcap/tispark/test/RandomTest.scala
+++ b/db-random-test/src/main/scala/com/pingcap/tispark/test/RandomTest.scala
@@ -59,6 +59,9 @@ trait RandomTest {
         } else {
           (dataType, len, s"$desc null")
         }
+      case NullableType.NotNullablePK =>
+          (dataType, len, s"$desc not null primary key")
+
     }
   }
 

--- a/db-random-test/src/main/scala/com/pingcap/tispark/test/RandomTest.scala
+++ b/db-random-test/src/main/scala/com/pingcap/tispark/test/RandomTest.scala
@@ -60,7 +60,7 @@ trait RandomTest {
           (dataType, len, s"$desc null")
         }
       case NullableType.NotNullablePK =>
-          (dataType, len, s"$desc not null primary key")
+        (dataType, len, s"$desc not null primary key")
 
     }
   }

--- a/db-random-test/src/main/scala/com/pingcap/tispark/test/generator/IndexColumn.scala
+++ b/db-random-test/src/main/scala/com/pingcap/tispark/test/generator/IndexColumn.scala
@@ -113,7 +113,7 @@ case class IndexInfo(
     val clusteredIndexStr = if (isClusteredIndex) " /*T![clustered_index] CLUSTERED */" else ""
     val indexColumnString = indexColumns.mkString("(", ",", ")")
     if (isPrimary) {
-      s"PRIMARY KEY $indexColumnString $clusteredIndexStr"
+      s"PRIMARY KEY $indexColumnString$clusteredIndexStr"
     } else if (isUnique) {
       s"UNIQUE KEY $indexColumnString"
     } else {

--- a/db-random-test/src/main/scala/com/pingcap/tispark/test/generator/NullableType.scala
+++ b/db-random-test/src/main/scala/com/pingcap/tispark/test/generator/NullableType.scala
@@ -16,5 +16,5 @@
 package com.pingcap.tispark.test.generator
 
 object NullableType extends Enumeration {
-  val Nullable, NotNullable, NumericNotNullable = Value
+  val Nullable, NotNullable, NumericNotNullable, NotNullablePK = Value
 }

--- a/db-random-test/src/test/scala/com/pingcap/tispark/test/RandomTestSuite.scala
+++ b/db-random-test/src/test/scala/com/pingcap/tispark/test/RandomTestSuite.scala
@@ -30,10 +30,12 @@ class RandomTestSuite extends FunSuite with RandomTest {
 
   private val database = "random_test"
 
-  test("random test") {
+  test("random test with isClusteredIndex") {
     val schemaAndDataList = genSchemaAndData(
       rowCount,
-      List(INT, INT).map(d => genDescription(d, NullableType.NumericNotNullable)),
+      List(
+        genDescription(INT, NullableType.NotNullablePK),
+        genDescription(INT, NullableType.NumericNotNullable)),
       database,
       isClusteredIndex = true)
 
@@ -47,10 +49,39 @@ class RandomTestSuite extends FunSuite with RandomTest {
                    |DROP TABLE IF EXISTS `test_351626634_1517918040`;
                    |CREATE TABLE `random_test`.`test_351626634_1517918040` (
                    |  `col_int0` int(11) not null,
-                   |  `col_int1` int(11) not null
+                   |  `col_int1` int(11) not null,
+                   |  PRIMARY KEY (`col_int0`) /*T![clustered_index] CLUSTERED */
                    |) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
                    |INSERT INTO `test_351626634_1517918040` VALUES (-1,-1);""".stripMargin
     println(schemaAndData.getInitSQLList.mkString("\n"))
+    assert(answer.equals(schemaAndData.getInitSQLList.mkString("\n")))
+  }
+
+  test("random test without isClusteredIndex") {
+    val schemaAndDataList = genSchemaAndData(
+      rowCount,
+      List(
+        genDescription(INT, NullableType.NotNullablePK),
+        genDescription(INT, NullableType.NumericNotNullable)),
+      database,
+      isClusteredIndex = false)
+
+    assert(1 == schemaAndDataList.size)
+    val schemaAndData = schemaAndDataList.head
+
+    assert(rowCount == schemaAndData.data.size)
+
+    val answer = """CREATE DATABASE IF NOT EXISTS `random_test`;
+                   |USE `random_test`;
+                   |DROP TABLE IF EXISTS `test_351626634_1115789266`;
+                   |CREATE TABLE `random_test`.`test_351626634_1115789266` (
+                   |  `col_int0` int(11) not null,
+                   |  `col_int1` int(11) not null,
+                   |  PRIMARY KEY (`col_int0`)
+                   |) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+                   |INSERT INTO `test_351626634_1115789266` VALUES (-1,-1);""".stripMargin
+    println(schemaAndData.getInitSQLList.mkString("\n"))
+    println(answer)
     assert(answer.equals(schemaAndData.getInitSQLList.mkString("\n")))
   }
 }

--- a/db-random-test/src/test/scala/com/pingcap/tispark/test/RandomTestSuite.scala
+++ b/db-random-test/src/test/scala/com/pingcap/tispark/test/RandomTestSuite.scala
@@ -43,12 +43,14 @@ class RandomTestSuite extends FunSuite with RandomTest {
     assert(rowCount == schemaAndData.data.size)
 
     val answer = """CREATE DATABASE IF NOT EXISTS `random_test`;
-                   |DROP TABLE IF EXISTS `random_test`.`test_351626634_1517918040`;
+                   |USE `random_test`;
+                   |DROP TABLE IF EXISTS `test_351626634_1517918040`;
                    |CREATE TABLE `random_test`.`test_351626634_1517918040` (
                    |  `col_int0` int(11) not null,
-                   |  `col_int1` int(11) not null /*T![clustered_index] CLUSTERED */
+                   |  `col_int1` int(11) not null
                    |) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
-                   |INSERT INTO `random_test`.`test_351626634_1517918040` VALUES (-1,-1);""".stripMargin
+                   |INSERT INTO `test_351626634_1517918040` VALUES (-1,-1);""".stripMargin
+    println(schemaAndData.getInitSQLList.mkString("\n"))
     assert(answer.equals(schemaAndData.getInitSQLList.mkString("\n")))
   }
 }

--- a/db-random-test/src/test/scala/com/pingcap/tispark/test/RandomTestSuite.scala
+++ b/db-random-test/src/test/scala/com/pingcap/tispark/test/RandomTestSuite.scala
@@ -30,7 +30,7 @@ class RandomTestSuite extends FunSuite with RandomTest {
 
   private val database = "random_test"
 
-  test("random test with isClusteredIndex") {
+  test("random test with ClusteredIndex") {
     val schemaAndDataList = genSchemaAndData(
       rowCount,
       List(
@@ -53,11 +53,10 @@ class RandomTestSuite extends FunSuite with RandomTest {
                    |  PRIMARY KEY (`col_int0`) /*T![clustered_index] CLUSTERED */
                    |) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
                    |INSERT INTO `test_351626634_1517918040` VALUES (-1,-1);""".stripMargin
-    println(schemaAndData.getInitSQLList.mkString("\n"))
     assert(answer.equals(schemaAndData.getInitSQLList.mkString("\n")))
   }
 
-  test("random test without isClusteredIndex") {
+  test("random test without ClusteredIndex") {
     val schemaAndDataList = genSchemaAndData(
       rowCount,
       List(
@@ -80,8 +79,6 @@ class RandomTestSuite extends FunSuite with RandomTest {
                    |  PRIMARY KEY (`col_int0`)
                    |) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
                    |INSERT INTO `test_351626634_1115789266` VALUES (-1,-1);""".stripMargin
-    println(schemaAndData.getInitSQLList.mkString("\n"))
-    println(answer)
     assert(answer.equals(schemaAndData.getInitSQLList.mkString("\n")))
   }
 }


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
https://github.com/pingcap/tispark/issues/2189

### What is changed and how it works?
Change the code because i think is a small bug for the extra space. Besides,it's why the test 'DataGeneratorSuite' fail.
The bug is introduced with https://github.com/pingcap/tispark/pull/2060 in IndexColumn.scala: https://github.com/pingcap/tispark/pull/2060/files#diff-22c8b596e739ebc64046c1c8314c0785d5487b1525834e0c76a37c14de45e43bR116

change the test because the code changes without the test changes.
- move clusteredIndex to primary key in Schema.scala: https://github.com/pingcap/tispark/pull/2060/files#diff-ad25d5a6aa3dabb5f06c0ba44a3b17787213469281c9a474349935f11593eec2R98
- change some sqls in SchemaAndData.scala: https://github.com/pingcap/tispark/pull/2045/files#diff-262c5d9036ebd92a6208a9233324b90d57608dbe2c72fe1bf0ebf6af55bb770eR29
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)

Code changes

 - Has persistent data change


