### PR TITLE
FIX TEST: use NONCLUSTERED

### DIFF
--- a/core/src/test/scala/com/pingcap/tispark/datasource/AutoIncrementSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datasource/AutoIncrementSuite.scala
@@ -22,14 +22,10 @@ import org.apache.spark.sql.types._
 class AutoIncrementSuite extends BaseBatchWriteTest("test_datasource_auto_increment") {
 
   test("alter primary key + auto increment + shard row bits") {
-    if (!isEnableAlterPrimaryKey) {
-      cancel("enable alter-primary-key by changing tidb.toml")
-    }
-
     val schema = StructType(List(StructField("j", LongType)))
 
     jdbcUpdate(
-      s"create table $dbtable(i int NOT NULL AUTO_INCREMENT, j int NOT NULL, primary key (i)) SHARD_ROW_ID_BITS=4")
+      s"create table $dbtable(i int NOT NULL AUTO_INCREMENT, j int NOT NULL, primary key (i) NONCLUSTERED) SHARD_ROW_ID_BITS=4")
 
     val tiTableInfo = ti.tiSession.getCatalog.getTable(dbPrefix + database, table)
     assert(!tiTableInfo.isPkHandle)
@@ -42,7 +38,7 @@ class AutoIncrementSuite extends BaseBatchWriteTest("test_datasource_auto_increm
 
     println(listToString(queryTiDBViaJDBC(s"select _tidb_rowid, i, j from $dbtable")))
 
-    spark.sql(s"select * from $table").show
+    spark.sql(s"select * from $databaseWithPrefix.$table").show
 
     val maxI = queryTiDBViaJDBC(s"select max(i) from $dbtable").head.head.toString.toLong
     assert(maxI < 10000000)
@@ -95,10 +91,6 @@ class AutoIncrementSuite extends BaseBatchWriteTest("test_datasource_auto_increm
   }
 
   test("bigint signed tidb overflow") {
-    if (isEnableAlterPrimaryKey) {
-      cancel()
-    }
-
     val schema = StructType(List(StructField("j", LongType)))
 
     jdbcUpdate(
@@ -126,10 +118,6 @@ class AutoIncrementSuite extends BaseBatchWriteTest("test_datasource_auto_increm
   }
 
   test("bigint signed tispark overflow") {
-    if (isEnableAlterPrimaryKey) {
-      cancel()
-    }
-
     val schema = StructType(List(StructField("j", LongType)))
 
     jdbcUpdate(
@@ -158,10 +146,6 @@ class AutoIncrementSuite extends BaseBatchWriteTest("test_datasource_auto_increm
   }
 
   test("bigint unsigned tidb overflow") {
-    if (isEnableAlterPrimaryKey) {
-      cancel()
-    }
-
     val schema = StructType(List(StructField("j", LongType)))
 
     jdbcUpdate(
@@ -188,10 +172,6 @@ class AutoIncrementSuite extends BaseBatchWriteTest("test_datasource_auto_increm
   }
 
   test("bigint unsigned tispark overflow") {
-    if (isEnableAlterPrimaryKey) {
-      cancel()
-    }
-
     val schema = StructType(List(StructField("j", LongType)))
 
     jdbcUpdate(
@@ -220,10 +200,6 @@ class AutoIncrementSuite extends BaseBatchWriteTest("test_datasource_auto_increm
   }
 
   test("tinyint signed tidb overflow") {
-    if (isEnableAlterPrimaryKey) {
-      cancel()
-    }
-
     val schema = StructType(List(StructField("j", LongType)))
 
     jdbcUpdate(
@@ -251,10 +227,6 @@ class AutoIncrementSuite extends BaseBatchWriteTest("test_datasource_auto_increm
   }
 
   test("tinyint signed tispark overflow") {
-    if (isEnableAlterPrimaryKey) {
-      cancel()
-    }
-
     val schema = StructType(List(StructField("j", LongType)))
 
     jdbcUpdate(
@@ -282,10 +254,6 @@ class AutoIncrementSuite extends BaseBatchWriteTest("test_datasource_auto_increm
   }
 
   test("tinyint unsigned tidb overflow") {
-    if (isEnableAlterPrimaryKey) {
-      cancel()
-    }
-
     val schema = StructType(List(StructField("j", LongType)))
 
     jdbcUpdate(
@@ -312,10 +280,6 @@ class AutoIncrementSuite extends BaseBatchWriteTest("test_datasource_auto_increm
   }
 
   test("tinyint unsigned tispark overflow") {
-    if (isEnableAlterPrimaryKey) {
-      cancel()
-    }
-
     val schema = StructType(List(StructField("j", LongType)))
 
     jdbcUpdate(


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

In TiDB 5.x, alter-primary-key is deprecated. If we need to add or remove the primary key, use the NONCLUSTERED keyword instead when creating the table.
In our case, we just need to use NONCLUSTERED in order to be compatible with SHARD_ROW_ID_BITS. It also makes this test decoupling with TiDB configs.
https://docs.pingcap.com/tidb/stable/tidb-configuration-file#alter-primary-key-deprecated

### What is changed and how it works?

Explicitly specify the table is NONCLUSTERED.
In both situations whether `alter-primary-key` is true or not, tests are passed.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

