### PR TITLE
FIX: set catalog throw NoSuchElementException

### DIFF
--- a/core/src/test/scala/com/pingcap/tispark/auth/TiAuthIntegrationSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/auth/TiAuthIntegrationSuite.scala
@@ -88,7 +88,6 @@ class TiAuthIntegrationSuite extends SharedSQLContext {
       spark.sql(s"use $dbPrefix$dummyDatabase")
     } else {
       spark.sql(s"use spark_catalog")
-      spark.sql(s"use default")
     }
   }
 

--- a/core/src/test/scala/com/pingcap/tispark/auth/TiAuthIntegrationSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/auth/TiAuthIntegrationSuite.scala
@@ -82,6 +82,16 @@ class TiAuthIntegrationSuite extends SharedSQLContext {
     TiAuthorization.enableAuth = false
   }
 
+  test("Use catalog should success") {
+    if (catalogPluginMode) {
+      spark.sql(s"use tidb_catalog")
+      spark.sql(s"use $dbPrefix$dummyDatabase")
+    } else {
+      spark.sql(s"use spark_catalog")
+      spark.sql(s"use $dbPrefix$dummyDatabase")
+    }
+  }
+
   test("Select without privilege should not be passed") {
     the[SQLException] thrownBy {
       spark.sql(s"select * from `$databaseWithPrefix`.`$table`")

--- a/core/src/test/scala/com/pingcap/tispark/auth/TiAuthIntegrationSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/auth/TiAuthIntegrationSuite.scala
@@ -88,7 +88,7 @@ class TiAuthIntegrationSuite extends SharedSQLContext {
       spark.sql(s"use $dbPrefix$dummyDatabase")
     } else {
       spark.sql(s"use spark_catalog")
-      spark.sql(s"use $dbPrefix$dummyDatabase")
+      spark.sql(s"use default")
     }
   }
 

--- a/spark-wrapper/spark-3.0/src/main/scala/org/apache/spark/sql/extensions/TiAuthorizationRule.scala
+++ b/spark-wrapper/spark-3.0/src/main/scala/org/apache/spark/sql/extensions/TiAuthorizationRule.scala
@@ -45,9 +45,8 @@ case class TiAuthorizationRule(getOrCreateTiContext: SparkSession => TiContext)(
       sa
     case sd: ShowNamespaces =>
       sd
-    case sd @ SetCatalogAndNamespace(catalogManager, catalogName, namespace) =>
+    case sd @ SetCatalogAndNamespace(catalogManager, catalogName, namespace) if (namespace.isDefined) =>
       namespace.get
-        .filter(_ != "tidb_catalog")
         .foreach(TiAuthorization.authorizeForSetDatabase(_, tiAuthorization))
       sd
     case st: ShowTablesCommand =>

--- a/spark-wrapper/spark-3.0/src/main/scala/org/apache/spark/sql/extensions/TiAuthorizationRule.scala
+++ b/spark-wrapper/spark-3.0/src/main/scala/org/apache/spark/sql/extensions/TiAuthorizationRule.scala
@@ -45,7 +45,8 @@ case class TiAuthorizationRule(getOrCreateTiContext: SparkSession => TiContext)(
       sa
     case sd: ShowNamespaces =>
       sd
-    case sd @ SetCatalogAndNamespace(catalogManager, catalogName, namespace) if (namespace.isDefined) =>
+    case sd @ SetCatalogAndNamespace(catalogManager, catalogName, namespace)
+        if (namespace.isDefined) =>
       namespace.get
         .foreach(TiAuthorization.authorizeForSetDatabase(_, tiAuthorization))
       sd

--- a/spark-wrapper/spark-3.0/src/main/scala/org/apache/spark/sql/extensions/TiDDLRule.scala
+++ b/spark-wrapper/spark-3.0/src/main/scala/org/apache/spark/sql/extensions/TiDDLRule.scala
@@ -69,7 +69,8 @@ case class TiDDLRule(getOrCreateTiContext: SparkSession => TiContext, sparkSessi
       // TODO: support other commands that may concern TiSpark catalog.
       case sd: ShowNamespaces =>
         TiShowDatabasesCommand(tiContext, sd)
-      case sd @ SetCatalogAndNamespace(catalogManager, catalogName, namespace) if isSupportedCatalog(sd) && namespace.isDefined =>
+      case sd @ SetCatalogAndNamespace(catalogManager, catalogName, namespace)
+          if isSupportedCatalog(sd) && namespace.isDefined =>
         TiSetDatabaseCommand(tiContext, sd)
       case st: ShowTablesCommand =>
         TiShowTablesCommand(tiContext, st)

--- a/spark-wrapper/spark-3.0/src/main/scala/org/apache/spark/sql/extensions/TiDDLRule.scala
+++ b/spark-wrapper/spark-3.0/src/main/scala/org/apache/spark/sql/extensions/TiDDLRule.scala
@@ -69,7 +69,7 @@ case class TiDDLRule(getOrCreateTiContext: SparkSession => TiContext, sparkSessi
       // TODO: support other commands that may concern TiSpark catalog.
       case sd: ShowNamespaces =>
         TiShowDatabasesCommand(tiContext, sd)
-      case sd: SetCatalogAndNamespace if isSupportedCatalog(sd) =>
+      case sd @ SetCatalogAndNamespace(catalogManager, catalogName, namespace) if isSupportedCatalog(sd) && namespace.isDefined =>
         TiSetDatabaseCommand(tiContext, sd)
       case st: ShowTablesCommand =>
         TiShowTablesCommand(tiContext, st)

--- a/spark-wrapper/spark-3.1/src/main/scala/org/apache/spark/sql/extensions/TiAuthorizationRule.scala
+++ b/spark-wrapper/spark-3.1/src/main/scala/org/apache/spark/sql/extensions/TiAuthorizationRule.scala
@@ -46,7 +46,10 @@ case class TiAuthorizationRule(getOrCreateTiContext: SparkSession => TiContext)(
     case sd: ShowNamespaces =>
       sd
     case sd @ SetCatalogAndNamespace(catalogManager, catalogName, namespace) =>
-      namespace.get.foreach(TiAuthorization.authorizeForSetDatabase(_, tiAuthorization))
+      if (namespace.isDefined) {
+        namespace.get
+          .foreach(TiAuthorization.authorizeForSetDatabase(_, tiAuthorization))
+      }
       sd
     case st: ShowTablesCommand =>
       st

--- a/spark-wrapper/spark-3.1/src/main/scala/org/apache/spark/sql/extensions/TiDDLRule.scala
+++ b/spark-wrapper/spark-3.1/src/main/scala/org/apache/spark/sql/extensions/TiDDLRule.scala
@@ -71,7 +71,7 @@ case class TiDDLRule(getOrCreateTiContext: SparkSession => TiContext, sparkSessi
       // TODO: support other commands that may concern TiSpark catalog.
       case sd: ShowNamespaces =>
         TiShowDatabasesCommand(tiContext, sd)
-      case sd: SetCatalogAndNamespace if isSupportedCatalog(sd) =>
+      case sd @ SetCatalogAndNamespace(catalogManager, catalogName, namespace) if isSupportedCatalog(sd) && namespace.isDefined =>
         TiSetDatabaseCommand(tiContext, sd)
       case st: ShowTablesCommand =>
         TiShowTablesCommand(tiContext, st)

--- a/spark-wrapper/spark-3.1/src/main/scala/org/apache/spark/sql/extensions/TiDDLRule.scala
+++ b/spark-wrapper/spark-3.1/src/main/scala/org/apache/spark/sql/extensions/TiDDLRule.scala
@@ -71,7 +71,8 @@ case class TiDDLRule(getOrCreateTiContext: SparkSession => TiContext, sparkSessi
       // TODO: support other commands that may concern TiSpark catalog.
       case sd: ShowNamespaces =>
         TiShowDatabasesCommand(tiContext, sd)
-      case sd @ SetCatalogAndNamespace(catalogManager, catalogName, namespace) if isSupportedCatalog(sd) && namespace.isDefined =>
+      case sd @ SetCatalogAndNamespace(catalogManager, catalogName, namespace)
+          if isSupportedCatalog(sd) && namespace.isDefined =>
         TiSetDatabaseCommand(tiContext, sd)
       case st: ShowTablesCommand =>
         TiShowTablesCommand(tiContext, st)


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

spark.sql("use ${catalog_name}") will throw "java.util.NoSuchElementException: None.get"
Details see issue #2221.

### What is changed and how does it works?

check namespace is defined or not.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test




