### PR TITLE
fix bit pushdown

### DIFF
--- a/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
@@ -247,7 +247,7 @@ class IssueTestSuite extends BaseTiSparkTest {
   }
 
   // https://github.com/pingcap/tispark/issues/1147
-  test("Fix Bit Type default value bug") {
+  ignore("Fix Bit Type default value bug") {
     def runBitTest(bitNumber: Int, bitString: String): Unit = {
       tidbStmt.execute("DROP TABLE IF EXISTS t_origin_default_value")
       tidbStmt.execute(

--- a/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
@@ -247,7 +247,7 @@ class IssueTestSuite extends BaseTiSparkTest {
   }
 
   // https://github.com/pingcap/tispark/issues/1147
-  ignore("Fix Bit Type default value bug") {
+  test("Fix Bit Type default value bug") {
     def runBitTest(bitNumber: Int, bitString: String): Unit = {
       tidbStmt.execute("DROP TABLE IF EXISTS t_origin_default_value")
       tidbStmt.execute(

--- a/tikv-client/src/main/java/com/pingcap/tikv/columnar/TiChunkColumnVector.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/columnar/TiChunkColumnVector.java
@@ -169,7 +169,7 @@ public class TiChunkColumnVector extends TiColumnVector {
     if (bytes.length == 0) return 0;
     long result = 0;
     for (byte b : bytes) {
-      result = (result << 8) | b;
+      result = (result << 8) | (b & 0xff);
     }
     return result;
   }


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
TiKV support bit push down in https://github.com/tikv/tikv/pull/11968. But it causes some tests of TiSpark fail. The following are the fail test
- Fix Bit Type default value bug
- Test Convert from java.lang.Short to BIT
- Test Convert from java.lang.Integer to BIT
- Test Convert from java.lang.Long to BIT

This pr fixes those tests. By the way, `Fix Bit Type default value bug` fails because of the TiKV bug. So, ignore it before TiKV fixes it
