### PR TITLE
Bump jackson-databind from 2.9.10.8 to 2.12.6.1 in /tikv-client

### DIFF
--- a/tikv-client/pom.xml
+++ b/tikv-client/pom.xml
@@ -22,8 +22,8 @@
         <slf4j.version>1.7.16</slf4j.version>
         <grpc.version>1.29.0</grpc.version>
         <powermock.version>1.6.6</powermock.version>
-        <jackson.annotations.version>2.9.10</jackson.annotations.version>
-        <jackson.databind.version>2.9.10.8</jackson.databind.version>
+        <jackson.annotations.version>2.12.6</jackson.annotations.version>
+        <jackson.databind.version>2.12.6.1</jackson.databind.version>
         <trove4j.version>3.0.1</trove4j.version>
         <jetcd.version>0.4.1</jetcd.version>
         <joda-time.version>2.9.9</joda-time.version>


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
https://github.com/pingcap/tispark/pull/2282

`jackson.annotations.version` needs to be changed too.