### PR TITLE
DELETE table statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,10 +220,6 @@ Set time zone by using the `-Duser.timezone` system property (for example, `-Dus
 
 Do not use `spark.sql.session.timeZone`.
 
-## Statistics information
-
-For how TiSpark can benefit from TiDB's statistic information, see [here](./docs/userguide.md).
-
 ## Authorization and authentication
 
 See [here](./docs/authorization_userguide.md).

--- a/README.md
+++ b/README.md
@@ -220,6 +220,10 @@ Set time zone by using the `-Duser.timezone` system property (for example, `-Dus
 
 Do not use `spark.sql.session.timeZone`.
 
+## Statistics information
+
+For how TiSpark can benefit from TiDB's statistic information, see [here](./docs/userguide.md).
+
 ## Authorization and authentication
 
 See [here](./docs/authorization_userguide.md).

--- a/core/src/main/scala/com/pingcap/tispark/TiConfigConst.scala
+++ b/core/src/main/scala/com/pingcap/tispark/TiConfigConst.scala
@@ -36,7 +36,6 @@ object TiConfigConst {
   val REGION_INDEX_SCAN_DOWNGRADE_THRESHOLD: String =
     "spark.tispark.plan.downgrade.index_threshold"
   val UNSUPPORTED_TYPES: String = "spark.tispark.type.unsupported_mysql_types"
-  val ENABLE_AUTO_LOAD_STATISTICS: String = "spark.tispark.statistics.auto_load"
   val CACHE_EXPIRE_AFTER_ACCESS: String = "spark.tispark.statistics.expire_after_access"
   val SHOW_ROWID: String = "spark.tispark.show_rowid"
   val DB_PREFIX: String = "spark.tispark.db_prefix"

--- a/core/src/main/scala/org/apache/spark/sql/TiContext.scala
+++ b/core/src/main/scala/org/apache/spark/sql/TiContext.scala
@@ -69,8 +69,6 @@ class TiContext(val sparkSession: SparkSession) extends Serializable with Loggin
   tiSession.injectCallBackFunc(CacheInvalidateListener.getInstance())
   val meta: MetaManager = new MetaManager(tiSession.getCatalog)
   val debug: DebugTool = new DebugTool
-  val autoLoad: Boolean =
-    conf.getBoolean(TiConfigConst.ENABLE_AUTO_LOAD_STATISTICS, defaultValue = true)
 
   // add backtick for table name in case it contains, e.g., a minus sign
   private def getViewName(dbName: String, tableName: String, dbNameAsPrefix: Boolean): String =

--- a/core/src/test/scala/org/apache/spark/sql/test/SharedSQLContext.scala
+++ b/core/src/test/scala/org/apache/spark/sql/test/SharedSQLContext.scala
@@ -448,7 +448,6 @@ trait SharedSQLContext
       }
       import com.pingcap.tispark.TiConfigConst._
       conf.set(PD_ADDRESSES, pdAddresses)
-      conf.set(ENABLE_AUTO_LOAD_STATISTICS, "true")
       conf.set(ALLOW_INDEX_READ, getFlagOrTrue(_tidbConf, ALLOW_INDEX_READ).toString)
       conf.set("spark.sql.decimalOperations.allowPrecisionLoss", "false")
       conf.set(REQUEST_ISOLATION_LEVEL, SNAPSHOT_ISOLATION_LEVEL)

--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -290,6 +290,19 @@ df.write
 
 Please set `isolationLevel` to `NONE` to avoid large single transactions which might lead to TiDB OOM and also avoid the `ISOLATION LEVEL does not support` error (TiDB currently only supports `REPEATABLE-READ`).
 
+## Statistics information
+
+TiSpark uses the statistic information for:
+
++ Determining which index to use in your query plan with the lowest estimated cost.
++ Small table broadcasting, which enables efficient broadcast join.
+
+For TiSpark to use the statistic information, first make sure that relevant tables have been analyzed.
+
+See [here](https://github.com/pingcap/docs/blob/master/statistics.md) for more details about how to analyze tables.
+
+Since TiSpark 2.0, statistics information is default to auto-load.
+
 ## Reading partition table from TiDB
 
 TiSpark reads the range and hash partition table from TiDB.

--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -290,29 +290,6 @@ df.write
 
 Please set `isolationLevel` to `NONE` to avoid large single transactions which might lead to TiDB OOM and also avoid the `ISOLATION LEVEL does not support` error (TiDB currently only supports `REPEATABLE-READ`).
 
-## Statistics information
-
-TiSpark uses the statistic information for:
-
-+ Determining which index to use in your query plan with the lowest estimated cost.
-+ Small table broadcasting, which enables efficient broadcast join.
-
-For TiSpark to use the statistic information, first make sure that relevant tables have been analyzed.
-
-See [here](https://github.com/pingcap/docs/blob/master/sql/statistics.md) for more details about how to analyze tables.
-
-Since TiSpark 2.0, statistics information is default to auto-load.
-
-> **Note:**
->
-> Table statistics is cached in your Spark driver node's memory, so you need to make sure that the memory is large enough for the statistics information.
-
-Currently, you can adjust these configurations in your `spark.conf` file.
-
-| Property Name | Default | Description
-| --------   | -----:   | :----: |
-| `spark.tispark.statistics.auto_load` | `true` | Whether to load the statistics information automatically during database mapping |
-
 ## Reading partition table from TiDB
 
 TiSpark reads the range and hash partition table from TiDB.


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

Delete unused configuration `spark.tispark.statistics.auto_load`
Delete related document



