### PR TITLE
fix limit pushdown

### DIFF
--- a/core/src/test/scala/org/apache/spark/sql/catalyst/plans/logical/LogicalPlanTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/catalyst/plans/logical/LogicalPlanTestSuite.scala
@@ -20,6 +20,21 @@ import com.pingcap.tikv.meta.TiTimestamp
 import org.apache.spark.sql.catalyst.plans.BasePlanTest
 
 class LogicalPlanTestSuite extends BasePlanTest {
+
+  // https://github.com/pingcap/tispark/issues/2328
+  test("limit push down fail in df.show") {
+    tidbStmt.execute("DROP TABLE IF EXISTS `test_l`")
+    tidbStmt.execute(
+      "CREATE TABLE `test_l` (`id` int , PRIMARY KEY(`id`)/*T![clustered_index] CLUSTERED */)")
+    // we need to exclude combineLimits to simulate df.show's plan
+    spark.sql(
+      "SET spark.sql.optimizer.excludedRules=org.apache.spark.sql.catalyst.optimizer.CombineLimits")
+    val df = spark.sql("select id from test_l limit 1").limit(21)
+    if (!extractDAGRequests(df).head.toString.contains("Limit")) {
+      fail("Limit not push down")
+    }
+
+  }
   test("fix Residual Filter containing wrong info") {
     val df = spark
       .sql("select * from full_data_type_table where tp_mediumint > 0 order by tp_int")

--- a/core/src/test/scala/org/apache/spark/sql/catalyst/plans/logical/LogicalPlanTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/catalyst/plans/logical/LogicalPlanTestSuite.scala
@@ -30,11 +30,13 @@ class LogicalPlanTestSuite extends BasePlanTest {
     spark.sql(
       "SET spark.sql.optimizer.excludedRules=org.apache.spark.sql.catalyst.optimizer.CombineLimits")
     val df = spark.sql("select id from test_l limit 1").limit(21)
-    if (!extractDAGRequests(df).head.toString.contains("Limit")) {
+    val DAGRequest = extractDAGRequests(df).head.toString
+    spark.sql("SET spark.sql.optimizer.excludedRules=''")
+    if (DAGRequest.contains("Limit")) {
       fail("Limit not push down")
     }
-
   }
+
   test("fix Residual Filter containing wrong info") {
     val df = spark
       .sql("select * from full_data_type_table where tp_mediumint > 0 order by tp_int")

--- a/core/src/test/scala/org/apache/spark/sql/catalyst/plans/logical/LogicalPlanTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/catalyst/plans/logical/LogicalPlanTestSuite.scala
@@ -32,7 +32,7 @@ class LogicalPlanTestSuite extends BasePlanTest {
     val df = spark.sql("select id from test_l limit 1").limit(21)
     val DAGRequest = extractDAGRequests(df).head.toString
     spark.sql("SET spark.sql.optimizer.excludedRules=''")
-    if (DAGRequest.contains("Limit")) {
+    if (!DAGRequest.contains("Limit")) {
       fail("Limit not push down")
     }
   }

--- a/spark-wrapper/spark-3.0/src/main/scala/org/apache/spark/sql/extensions/TiStrategy.scala
+++ b/spark-wrapper/spark-3.0/src/main/scala/org/apache/spark/sql/extensions/TiStrategy.scala
@@ -588,6 +588,8 @@ case class TiStrategy(getOrCreateTiContext: SparkSession => TiContext)(sparkSess
             IntegerLiteral(limit),
             logical.Project(projectList, logical.Sort(order, true, child))) =>
         takeOrderedAndProject(limit, order, child, projectList) :: Nil
+      case logical.Limit(IntegerLiteral(limit), child) =>
+        execution.CollectLimitExec(limit, collectLimit(limit, child)) :: Nil
       // Collapse filters and projections and push plan directly
       case PhysicalOperation(
             projectList,

--- a/spark-wrapper/spark-3.1/src/main/scala/org/apache/spark/sql/extensions/TiStrategy.scala
+++ b/spark-wrapper/spark-3.1/src/main/scala/org/apache/spark/sql/extensions/TiStrategy.scala
@@ -594,6 +594,8 @@ case class TiStrategy(getOrCreateTiContext: SparkSession => TiContext)(sparkSess
             IntegerLiteral(limit),
             logical.Project(projectList, logical.Sort(order, true, child))) =>
         takeOrderedAndProject(limit, order, child, projectList) :: Nil
+      case logical.Limit(IntegerLiteral(limit), child) =>
+        execution.CollectLimitExec(limit, collectLimit(limit, child)) :: Nil
       // Collapse filters and projections and push plan directly
       case PhysicalOperation(
             projectList,

--- a/spark-wrapper/spark-3.2/src/main/scala/org/apache/spark/sql/extensions/TiStrategy.scala
+++ b/spark-wrapper/spark-3.2/src/main/scala/org/apache/spark/sql/extensions/TiStrategy.scala
@@ -594,6 +594,8 @@ case class TiStrategy(getOrCreateTiContext: SparkSession => TiContext)(sparkSess
             IntegerLiteral(limit),
             logical.Project(projectList, logical.Sort(order, true, child))) =>
         takeOrderedAndProject(limit, order, child, projectList) :: Nil
+      case logical.Limit(IntegerLiteral(limit), child) =>
+        execution.CollectLimitExec(limit, collectLimit(limit, child)) :: Nil
       // Collapse filters and projections and push plan directly
       case PhysicalOperation(
             projectList,


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
https://github.com/pingcap/tispark/issues/2328
### The cause of the problems
Dataframe with different actions may have different plans. for example 
```
plan of spark.sql("select * from tidb_catalog.db.table limit 1").show()
ReturnAnswer
+- GlobalLimit 2
   +- LocalLimit 2
      +- Project [cast(id#144L as string) AS id#147]
         +- GlobalLimit 1
            +- LocalLimit 1
               +- RelationV2[id#144L] test.t2

plan of spark.sql("select * from tidb_catalog.db.table limit 1").collect()
ReturnAnswer
+- GlobalLimit 1
   +- LocalLimit 1
      +- RelationV2[id#144L] test.t2
```
But TiSpark's push down of limit only matches some actions, such as `collect`. while limit + `show` is not be matched

### How to solve
we just need to match `logical.Limit(IntegerLiteral(limit), child)` in `TiStrategy`

### Test
