### PR TITLE
Fix test fail in TiDB release 4.0

### DIFF
--- a/core/src/test/scala/com/pingcap/tispark/datatype/BatchWriteDataTypeSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datatype/BatchWriteDataTypeSuite.scala
@@ -550,6 +550,9 @@ class BatchWriteDataTypeSuite extends BaseBatchWriteTest("test_data_type", "test
   }
 
   test("Test timestamp pk clustered") {
+    if (!supportClusteredIndex) {
+      cancel("currently tidb instance does not support clustered index")
+    }
     jdbcUpdate(s"""
                   |create table $dbtable(
                   |i timestamp primary key /*T![clustered_index] CLUSTERED */,
@@ -573,6 +576,9 @@ class BatchWriteDataTypeSuite extends BaseBatchWriteTest("test_data_type", "test
   }
 
   test("Test date pk clustered") {
+    if (!supportClusteredIndex) {
+      cancel("currently tidb instance does not support clustered index")
+    }
     jdbcUpdate(s"""
                   |create table $dbtable(
                   |i date primary key /*T![clustered_index] CLUSTERED */,

--- a/core/src/test/scala/com/pingcap/tispark/datatype/BatchWriteDataTypeSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datatype/BatchWriteDataTypeSuite.scala
@@ -552,7 +552,7 @@ class BatchWriteDataTypeSuite extends BaseBatchWriteTest("test_data_type", "test
   test("Test timestamp pk clustered") {
     jdbcUpdate(s"""
                   |create table $dbtable(
-                  |i timestamp primary key CLUSTERED,
+                  |i timestamp primary key /*T![clustered_index] CLUSTERED */,
                   |c1 varchar(64)
                   |)
       """.stripMargin)
@@ -575,7 +575,7 @@ class BatchWriteDataTypeSuite extends BaseBatchWriteTest("test_data_type", "test
   test("Test date pk clustered") {
     jdbcUpdate(s"""
                   |create table $dbtable(
-                  |i date primary key CLUSTERED,
+                  |i date primary key /*T![clustered_index] CLUSTERED */,
                   |c1 varchar(64)
                   |)
       """.stripMargin)

--- a/core/src/test/scala/com/pingcap/tispark/datatype/BatchWriteDataTypeSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/datatype/BatchWriteDataTypeSuite.scala
@@ -555,7 +555,7 @@ class BatchWriteDataTypeSuite extends BaseBatchWriteTest("test_data_type", "test
     }
     jdbcUpdate(s"""
                   |create table $dbtable(
-                  |i timestamp primary key /*T![clustered_index] CLUSTERED */,
+                  |i timestamp primary key CLUSTERED,
                   |c1 varchar(64)
                   |)
       """.stripMargin)
@@ -581,7 +581,7 @@ class BatchWriteDataTypeSuite extends BaseBatchWriteTest("test_data_type", "test
     }
     jdbcUpdate(s"""
                   |create table $dbtable(
-                  |i date primary key /*T![clustered_index] CLUSTERED */,
+                  |i date primary key CLUSTERED,
                   |c1 varchar(64)
                   |)
       """.stripMargin)


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
https://ci.pingcap.net/blue/rest/organizations/jenkins/pipelines/tispark_ghpr_integration_test/runs/703/nodes/105/steps/471/log/?start=0

`Test date pk clustered ` and `Test timestamp pk clustered` fail in the IT with TiDB release-4.0

