### PR TITLE
Release version 2.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,9 @@ All notable changes to this project will be documented in this file.
 
 ## [TiSpark 2.5.0] 2022-05-16
 ### Fixes
-- Fix limit not push down bug [2335](https://github.com/pingcap/tispark/pull/2335)
+- Fix limit not push down bug [#2335](https://github.com/pingcap/tispark/pull/2335)
 - Fix ClassCastException when cluster index with type Timestamp and Date [#2323](https://github.com/pingcap/tispark/pull/2323)
-- Upgrade jackson-databind from 2.9.10.8 to 2.12.6.1 [2288](https://github.com/pingcap/tispark/pull/2288)
+- Upgrade jackson-databind from 2.9.10.8 to 2.12.6.1 [#2288](https://github.com/pingcap/tispark/pull/2288)
 - Fix the wrong result of _tidb_rowid [#2278](https://github.com/pingcap/tispark/pull/2278)
 - Fix set catalog throw NoSuchElementException [#2254](https://github.com/pingcap/tispark/pull/2254)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 # TiSpark Changelog
 All notable changes to this project will be documented in this file.
 
+## [TiSpark 2.5.0] 2022-05-16
+### Fixes
+- Fix limit not push down bug [2335](https://github.com/pingcap/tispark/pull/2335)
+- Fix ClassCastException when cluster index with type Timestamp and Date [#2323](https://github.com/pingcap/tispark/pull/2323)
+- Upgrade jackson-databind from 2.9.10.8 to 2.12.6.1 [2288](https://github.com/pingcap/tispark/pull/2288)
+- Fix the wrong result of _tidb_rowid [#2278](https://github.com/pingcap/tispark/pull/2278)
+- Fix set catalog throw NoSuchElementException [#2254](https://github.com/pingcap/tispark/pull/2254)
+
+### Documents
+- Add limitation: TLS is not supported [#2281](https://github.com/pingcap/tispark/pull/2281)
+- Add limitation: new collations are not supported [#2251](https://github.com/pingcap/tispark/pull/2251)
+- Update communication channels [#2244](https://github.com/pingcap/tispark/pull/2244)
+
 ## [TiSpark 2.5.0] 2022-01-25
 ### New feature
 - Support Spark 3.1.x and 3.0.x version.

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>com.pingcap.tispark</groupId>
         <artifactId>tispark-parent</artifactId>
-        <version>2.5.0</version>
+        <version>2.5.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <artifactId>tispark-assembly</artifactId>
+    <artifactId>tispark-assembly-${spark.version.release}</artifactId>
     <packaging>pom</packaging>
     <name>TiSpark Project Assembly</name>
     <url>http://github.copm/pingcap/tispark</url>

--- a/core-test/pom.xml
+++ b/core-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.pingcap.tispark</groupId>
         <artifactId>tispark-parent</artifactId>
-        <version>2.5.0</version>
+        <version>2.5.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.pingcap.tispark</groupId>
         <artifactId>tispark-parent</artifactId>
-        <version>2.5.0</version>
+        <version>2.5.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/scripts/version.sh
+++ b/core/scripts/version.sh
@@ -16,7 +16,7 @@
 
 TISPARK_HOME="$(cd "`dirname "$0"`"/../..; pwd)"
 
-TiSparkReleaseVersion=2.5.0
+TiSparkReleaseVersion=2.5.1
 TiSparkBuildTS=`date -u '+%Y-%m-%d %I:%M:%S'`
 TiSparkGitHash=`git rev-parse HEAD`
 TiSparkGitBranch=`git rev-parse --abbrev-ref HEAD`

--- a/db-random-test/pom.xml
+++ b/db-random-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.pingcap.tispark</groupId>
         <artifactId>tispark-parent</artifactId>
-        <version>2.5.0</version>
+        <version>2.5.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>com.pingcap.tispark</groupId>
     <artifactId>tispark-parent</artifactId>
-    <version>2.5.0</version>
+    <version>2.5.1</version>
     <packaging>pom</packaging>
     <name>TiSpark Project Parent POM</name>
     <url>http://github.copm/pingcap/tispark</url>
@@ -70,6 +70,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <protobuf.version>3.1.0</protobuf.version>
+        <spark.version.release>3.0</spark.version.release>
         <spark.version.compile>3.0.2</spark.version.compile>
         <spark.version.test>3.0.2</spark.version.test>
         <scala.binary.version>2.12</scala.binary.version>
@@ -177,8 +178,20 @@
                 <activeByDefault>false</activeByDefault>
             </activation>
             <properties>
+                <spark.version.release>3.1</spark.version.release>
                 <spark.version.compile>3.1.1</spark.version.compile>
                 <spark.version.test>3.1.1</spark.version.test>
+            </properties>
+        </profile>
+        <profile>
+            <id>spark-3.0.2</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <properties>
+                <spark.version.release>3.0</spark.version.release>
+                <spark.version.compile>3.0.2</spark.version.compile>
+                <spark.version.test>3.0.2</spark.version.test>
             </properties>
         </profile>
         <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
         <scalatest.version>3.0.8</scalatest.version>
         <argLine>-Dfile.encoding=UTF-8 -Duser.timezone=GMT+8</argLine>
         <mysql.connector.version>5.1.44</mysql.connector.version>
-        <gpg.keyname>fake gpg keyname</gpg.keyname>
+        <gpg.pub.key>fake gpg keyname</gpg.pub.key>
         <gpg.skip>true</gpg.skip>
         <javadoc.skip>true</javadoc.skip>
         <skipFetchTestData>false</skipFetchTestData>
@@ -275,7 +275,7 @@
                 <artifactId>maven-gpg-plugin</artifactId>
                 <version>1.5</version>
                 <configuration>
-                    <keyname>${gpg.keyname}</keyname>
+                    <keyname>${gpg.pub.key}</keyname>
                     <skip>${gpg.skip}</skip>
                 </configuration>
                 <executions>

--- a/spark-wrapper/spark-3.0/pom.xml
+++ b/spark-wrapper/spark-3.0/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.pingcap.tispark</groupId>
         <artifactId>tispark-parent</artifactId>
-        <version>2.5.0</version>
+        <version>2.5.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/spark-wrapper/spark-3.1/pom.xml
+++ b/spark-wrapper/spark-3.1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.pingcap.tispark</groupId>
         <artifactId>tispark-parent</artifactId>
-        <version>2.5.0</version>
+        <version>2.5.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/tikv-client/pom.xml
+++ b/tikv-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.pingcap.tispark</groupId>
         <artifactId>tispark-parent</artifactId>
-        <version>2.5.0</version>
+        <version>2.5.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
release version 2.5.1
- update version to 2.5.1
- add spark version in jar

### Test
https://oss.sonatype.org/#stagingRepositories
- spark 3.0.3 with tispark-assembly-3.0-2.5.1
- spark 3.1.2 with tispark-assembly-3.1-2.5.1
- spark 3.1.3 with tispark-assembly-3.1-2.5.1