### PR TITLE
Bump guava from 26.0-android to 29.0-android

### DIFF
--- a/core-test/pom.xml
+++ b/core-test/pom.xml
@@ -122,7 +122,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>26.0-android</version>
+            <version>29.0-android</version>
         </dependency>
         <!-- For tests -->
         <dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -108,7 +108,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>26.0-android</version>
+            <version>29.0-android</version>
         </dependency>
         <!-- For tests -->
         <dependency>


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
Bumps [guava](https://github.com/google/guava) from 26.0-android to 29.0-android.
