### PR TITLE
change version to 2.4.4-snapshot

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.pingcap.tispark</groupId>
         <artifactId>tispark-parent_${scala.binary.version}</artifactId>
-        <version>2.4.3-scala_${scala.binary.version}-snapshot</version>
+        <version>2.4.4-scala_${scala.binary.version}-snapshot</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.pingcap.tispark</groupId>
         <artifactId>tispark-parent_${scala.binary.version}</artifactId>
-        <version>2.4.3-scala_${scala.binary.version}</version>
+        <version>2.4.3-scala_${scala.binary.version}-snapshot</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core-test/pom.xml
+++ b/core-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.pingcap.tispark</groupId>
         <artifactId>tispark-parent_${scala.binary.version}</artifactId>
-        <version>2.4.3-scala_${scala.binary.version}-snapshot</version>
+        <version>2.4.4-scala_${scala.binary.version}-snapshot</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core-test/pom.xml
+++ b/core-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.pingcap.tispark</groupId>
         <artifactId>tispark-parent_${scala.binary.version}</artifactId>
-        <version>2.4.3-scala_${scala.binary.version}</version>
+        <version>2.4.3-scala_${scala.binary.version}-snapshot</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.pingcap.tispark</groupId>
         <artifactId>tispark-parent_${scala.binary.version}</artifactId>
-        <version>2.4.3-scala_${scala.binary.version}-snapshot</version>
+        <version>2.4.4-scala_${scala.binary.version}-snapshot</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.pingcap.tispark</groupId>
         <artifactId>tispark-parent_${scala.binary.version}</artifactId>
-        <version>2.4.3-scala_${scala.binary.version}</version>
+        <version>2.4.3-scala_${scala.binary.version}-snapshot</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/scripts/version.sh
+++ b/core/scripts/version.sh
@@ -16,7 +16,7 @@
 
 TISPARK_HOME="$(cd "`dirname "$0"`"/../..; pwd)"
 
-TiSparkReleaseVersion=2.4.3
+TiSparkReleaseVersion=2.4.4-snapshot
 TiSparkBuildTS=`date -u '+%Y-%m-%d %I:%M:%S'`
 TiSparkGitHash=`git rev-parse HEAD`
 TiSparkGitBranch=`git rev-parse --abbrev-ref HEAD`

--- a/db-random-test/pom.xml
+++ b/db-random-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.pingcap.tispark</groupId>
         <artifactId>tispark-parent_${scala.binary.version}</artifactId>
-        <version>2.4.3-scala_${scala.binary.version}-snapshot</version>
+        <version>2.4.4-scala_${scala.binary.version}-snapshot</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/db-random-test/pom.xml
+++ b/db-random-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.pingcap.tispark</groupId>
         <artifactId>tispark-parent_${scala.binary.version}</artifactId>
-        <version>2.4.3-scala_${scala.binary.version}</version>
+        <version>2.4.3-scala_${scala.binary.version}-snapshot</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>com.pingcap.tispark</groupId>
     <artifactId>tispark-parent_${scala.binary.version}</artifactId>
-    <version>2.4.3-scala_${scala.binary.version}</version>
+    <version>2.4.3-scala_${scala.binary.version}-snapshot</version>
     <packaging>pom</packaging>
     <name>TiSpark Project Parent POM</name>
     <url>http://github.copm/pingcap/tispark</url>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>com.pingcap.tispark</groupId>
     <artifactId>tispark-parent_${scala.binary.version}</artifactId>
-    <version>2.4.3-scala_${scala.binary.version}-snapshot</version>
+    <version>2.4.4-scala_${scala.binary.version}-snapshot</version>
     <packaging>pom</packaging>
     <name>TiSpark Project Parent POM</name>
     <url>http://github.copm/pingcap/tispark</url>

--- a/spark-wrapper/spark-2.3/pom.xml
+++ b/spark-wrapper/spark-2.3/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.pingcap.tispark</groupId>
         <artifactId>tispark-parent_${scala.binary.version}</artifactId>
-        <version>2.4.3-scala_${scala.binary.version}-snapshot</version>
+        <version>2.4.4-scala_${scala.binary.version}-snapshot</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/spark-wrapper/spark-2.3/pom.xml
+++ b/spark-wrapper/spark-2.3/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.pingcap.tispark</groupId>
         <artifactId>tispark-parent_${scala.binary.version}</artifactId>
-        <version>2.4.3-scala_${scala.binary.version}</version>
+        <version>2.4.3-scala_${scala.binary.version}-snapshot</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/spark-wrapper/spark-2.4/pom.xml
+++ b/spark-wrapper/spark-2.4/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.pingcap.tispark</groupId>
         <artifactId>tispark-parent_${scala.binary.version}</artifactId>
-        <version>2.4.3-scala_${scala.binary.version}-snapshot</version>
+        <version>2.4.4-scala_${scala.binary.version}-snapshot</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/spark-wrapper/spark-2.4/pom.xml
+++ b/spark-wrapper/spark-2.4/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.pingcap.tispark</groupId>
         <artifactId>tispark-parent_${scala.binary.version}</artifactId>
-        <version>2.4.3-scala_${scala.binary.version}</version>
+        <version>2.4.3-scala_${scala.binary.version}-snapshot</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/tikv-client/pom.xml
+++ b/tikv-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.pingcap.tispark</groupId>
         <artifactId>tispark-parent_${scala.binary.version}</artifactId>
-        <version>2.4.3-scala_${scala.binary.version}-snapshot</version>
+        <version>2.4.4-scala_${scala.binary.version}-snapshot</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tikv-client/pom.xml
+++ b/tikv-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.pingcap.tispark</groupId>
         <artifactId>tispark-parent_${scala.binary.version}</artifactId>
-        <version>2.4.3-scala_${scala.binary.version}</version>
+        <version>2.4.3-scala_${scala.binary.version}-snapshot</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
update version to 2.4.4-snapshot, or TiSpark will get jar from maven