### PR TITLE
Use command get project version instead of constant value

### DIFF
--- a/core/scripts/version.sh
+++ b/core/scripts/version.sh
@@ -16,7 +16,7 @@
 
 TISPARK_HOME="$(cd "`dirname "$0"`"/../..; pwd)"
 
-TiSparkReleaseVersion=2.6.0-SNAPSHOT
+TiSparkReleaseVersion=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
 TiSparkBuildTS=`date -u '+%Y-%m-%d %I:%M:%S'`
 TiSparkGitHash=`git rev-parse HEAD`
 TiSparkGitBranch=`git rev-parse --abbrev-ref HEAD`


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

Every time when we update the version, we need to modify not only `pom.xml` but also `version.sh`, which is cumbersome.

### What is changed and how it works?

https://stackoverflow.com/questions/3545292/how-to-get-maven-project-version-to-the-bash-command-line

