### PR TITLE
[close #2361]Update mysql connector from 5.1.44 to 5.1.49

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
         <scalafmt.skip>true</scalafmt.skip>
         <scalatest.version>3.0.8</scalatest.version>
         <argLine>-Dfile.encoding=UTF-8 -Duser.timezone=GMT+8</argLine>
-        <mysql.connector.version>5.1.44</mysql.connector.version>
+        <mysql.connector.version>5.1.48</mysql.connector.version>
         <gpg.keyname>fake gpg keyname</gpg.keyname>
         <gpg.skip>true</gpg.skip>
         <javadoc.skip>true</javadoc.skip>

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
         <scalafmt.skip>true</scalafmt.skip>
         <scalatest.version>3.0.8</scalatest.version>
         <argLine>-Dfile.encoding=UTF-8 -Duser.timezone=GMT+8</argLine>
-        <mysql.connector.version>5.1.48</mysql.connector.version>
+        <mysql.connector.version>5.1.49</mysql.connector.version>
         <gpg.keyname>fake gpg keyname</gpg.keyname>
         <gpg.skip>true</gpg.skip>
         <javadoc.skip>true</javadoc.skip>


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
Close #2361.

### What is changed and how it works?
Update mysql-connector-java from 5.1.44 to 5.1.48.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below): refer manual test in #2361.
 - No code

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch