### PR TITLE
new naming rule for tispark's jar

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -9,7 +9,7 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <artifactId>tispark-assembly</artifactId>
+    <artifactId>tispark-assembly-${spark.version.release}_${scala.version.release}</artifactId>
     <packaging>pom</packaging>
     <name>TiSpark Project Assembly</name>
     <url>http://github.copm/pingcap/tispark</url>

--- a/pom.xml
+++ b/pom.xml
@@ -183,7 +183,7 @@
             <properties>
                 <spark.version.compile>3.1.1</spark.version.compile>
                 <spark.version.test>3.1.1</spark.version.test>
-                <spark.version.test>3.1</spark.version.test>
+                <spark.version.release>3.1</spark.version.release>
             </properties>
         </profile>
         <profile>
@@ -194,7 +194,7 @@
             <properties>
                 <spark.version.compile>3.2.1</spark.version.compile>
                 <spark.version.test>3.2.1</spark.version.test>
-                <spark.version.test>3.2</spark.version.test>
+                <spark.version.release>3.2</spark.version.release>
             </properties>
         </profile>
         <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -72,8 +72,10 @@
         <protobuf.version>3.1.0</protobuf.version>
         <spark.version.compile>3.0.2</spark.version.compile>
         <spark.version.test>3.0.2</spark.version.test>
+        <spark.version.release>3.0</spark.version.release>
         <scala.binary.version>2.12</scala.binary.version>
         <scala.version>2.12.10</scala.version>
+        <scala.version.release>2.12.10</scala.version.release>
         <!-- for now, not running scalafmt as part of default verify pipeline -->
         <scalafmt.skip>true</scalafmt.skip>
         <scalatest.version>3.0.8</scalatest.version>
@@ -181,6 +183,7 @@
             <properties>
                 <spark.version.compile>3.1.1</spark.version.compile>
                 <spark.version.test>3.1.1</spark.version.test>
+                <spark.version.test>3.1</spark.version.test>
             </properties>
         </profile>
         <profile>
@@ -191,6 +194,7 @@
             <properties>
                 <spark.version.compile>3.2.1</spark.version.compile>
                 <spark.version.test>3.2.1</spark.version.test>
+                <spark.version.test>3.2</spark.version.test>
             </properties>
         </profile>
         <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <spark.version.release>3.0</spark.version.release>
         <scala.binary.version>2.12</scala.binary.version>
         <scala.version>2.12.10</scala.version>
-        <scala.version.release>2.12.10</scala.version.release>
+        <scala.version.release>2.12</scala.version.release>
         <!-- for now, not running scalafmt as part of default verify pipeline -->
         <scalafmt.skip>true</scalafmt.skip>
         <scalatest.version>3.0.8</scalatest.version>

--- a/spark-wrapper/spark-3.0/pom.xml
+++ b/spark-wrapper/spark-3.0/pom.xml
@@ -9,7 +9,7 @@
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
-    <artifactId>spark-wrapper-spark-3.0</artifactId>
+    <artifactId>spark-wrapper-spark-3.0_${spark.version.release}</artifactId>
     <packaging>jar</packaging>
     <name>TiSpark Project Spark Wrapper Spark-3.0</name>
     <url>http://github.copm/pingcap/tispark</url>

--- a/spark-wrapper/spark-3.0/pom.xml
+++ b/spark-wrapper/spark-3.0/pom.xml
@@ -9,7 +9,7 @@
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
-    <artifactId>spark-wrapper-spark-3.0_${spark.version.release}</artifactId>
+    <artifactId>spark-wrapper-spark-3.0_${scala.version.release}</artifactId>
     <packaging>jar</packaging>
     <name>TiSpark Project Spark Wrapper Spark-3.0</name>
     <url>http://github.copm/pingcap/tispark</url>

--- a/spark-wrapper/spark-3.1/pom.xml
+++ b/spark-wrapper/spark-3.1/pom.xml
@@ -9,7 +9,7 @@
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
-    <artifactId>spark-wrapper-spark-3.1</artifactId>
+    <artifactId>spark-wrapper-spark-3.1_${spark.version.release}</artifactId>
     <packaging>jar</packaging>
     <name>TiSpark Project Spark Wrapper Spark-3.1</name>
     <url>http://github.copm/pingcap/tispark</url>

--- a/spark-wrapper/spark-3.1/pom.xml
+++ b/spark-wrapper/spark-3.1/pom.xml
@@ -9,7 +9,7 @@
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
-    <artifactId>spark-wrapper-spark-3.1_${spark.version.release}</artifactId>
+    <artifactId>spark-wrapper-spark-3.1_${scala.version.release}</artifactId>
     <packaging>jar</packaging>
     <name>TiSpark Project Spark Wrapper Spark-3.1</name>
     <url>http://github.copm/pingcap/tispark</url>

--- a/spark-wrapper/spark-3.2/pom.xml
+++ b/spark-wrapper/spark-3.2/pom.xml
@@ -9,7 +9,7 @@
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
-    <artifactId>spark-wrapper-spark-3.2_${spark.version.release}</artifactId>
+    <artifactId>spark-wrapper-spark-3.2_${scala.version.release}</artifactId>
     <packaging>jar</packaging>
     <name>TiSpark Project Spark Wrapper Spark-3.2</name>
     <url>http://github.copm/pingcap/tispark</url>

--- a/spark-wrapper/spark-3.2/pom.xml
+++ b/spark-wrapper/spark-3.2/pom.xml
@@ -9,7 +9,7 @@
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
-    <artifactId>spark-wrapper-spark-3.2</artifactId>
+    <artifactId>spark-wrapper-spark-3.2_${spark.version.release}</artifactId>
     <packaging>jar</packaging>
     <name>TiSpark Project Spark Wrapper Spark-3.2</name>
     <url>http://github.copm/pingcap/tispark</url>


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
This pr introduces a new naming rule for TiSpsark jar.
`tispark-assembly` will change to `tispark-assembly-${spark_version}_${scala_version}`
`spark-wrapper-spark-3.x` will change to `spark-wrapper-spark-3.x_${scala_version}`

- `${spark_version}`: use the first two numbers of spark version, for example, 3.0 for spark version 3.0.x
- `${scala_version}`: use the first two numbers of scala version, for example, 2.12 for scala version of 2.12.x

in this way we can
- Solve most of the compatibility problems.
- Help user select version easier

