### PR TITLE
add Aggregates in TiDAGRequest

### DIFF
--- a/core/src/test/scala/org/apache/spark/sql/pushdown/SumPushDownSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/pushdown/SumPushDownSuite.scala
@@ -43,7 +43,7 @@ class SumPushDownSuite extends BasePlanTest {
     "select sum(tp_int) from full_data_type_table_cluster",
     "select sum(tp_double) from full_data_type_table_cluster")
 
-  test("Test - Sum push down") {
+  test("Test - Sum push down cluster") {
     tidbStmt.execute("DROP TABLE IF EXISTS `full_data_type_table_cluster`")
     tidbStmt.execute("""
          CREATE TABLE `full_data_type_table_cluster` (
@@ -75,6 +75,52 @@ class SumPushDownSuite extends BasePlanTest {
         `tp_enum` enum('1','2','3','4') DEFAULT NULL,
         `tp_set` set('a','b','c','d') DEFAULT NULL,
         PRIMARY KEY (`id_dt`)/*T![clustered_index] CLUSTERED */
+      ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+      """)
+
+    allCases.foreach { query =>
+      val df = spark.sql(query)
+      if (!extractCoprocessorRDDs(df).head.toString.contains("Aggregates")) {
+        fail(
+          s"sum is not pushed down in query:$query,DAGRequests:" + extractCoprocessorRDDs(
+            df).head.toString)
+      }
+      runTest(query)
+    }
+  }
+
+  test("Test - Sum push down noncluster") {
+    tidbStmt.execute("DROP TABLE IF EXISTS `full_data_type_table_cluster`")
+    tidbStmt.execute("""
+         CREATE TABLE `full_data_type_table_cluster` (
+        `id_dt` int(11) NOT NULL,
+        `tp_varchar` varchar(45) DEFAULT NULL,
+        `tp_datetime` datetime DEFAULT CURRENT_TIMESTAMP,
+        `tp_blob` blob DEFAULT NULL,
+        `tp_binary` binary(2) DEFAULT NULL,
+        `tp_date` date DEFAULT NULL,
+        `tp_timestamp` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        `tp_year` year DEFAULT NULL,
+        `tp_bigint` bigint(20) DEFAULT NULL,
+        `tp_decimal` decimal(38,18) DEFAULT NULL,
+        `tp_double` double DEFAULT NULL,
+        `tp_float` float DEFAULT NULL,
+        `tp_int` int(11) DEFAULT NULL,
+        `tp_mediumint` mediumint(9) DEFAULT NULL,
+        `tp_real` double DEFAULT NULL,
+        `tp_smallint` smallint(6) DEFAULT NULL,
+        `tp_tinyint` tinyint(4) DEFAULT NULL,
+        `tp_char` char(10) DEFAULT NULL,
+        `tp_nvarchar` varchar(40) DEFAULT NULL,
+        `tp_longtext` longtext DEFAULT NULL,
+        `tp_mediumtext` mediumtext DEFAULT NULL,
+        `tp_text` text DEFAULT NULL,
+        `tp_tinytext` tinytext DEFAULT NULL,
+        `tp_bit` bit(1) DEFAULT NULL,
+        `tp_time` time DEFAULT NULL,
+        `tp_enum` enum('1','2','3','4') DEFAULT NULL,
+        `tp_set` set('a','b','c','d') DEFAULT NULL,
+        PRIMARY KEY (`id_dt`)/*T![clustered_index] NONCLUSTERED */
       ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
       """)
 

--- a/tikv-client/src/main/java/com/pingcap/tikv/meta/TiDAGRequest.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/meta/TiDAGRequest.java
@@ -1039,8 +1039,13 @@ public class TiDAGRequest implements Serializable {
     }
 
     if (!getPushDownAggregates().isEmpty()) {
-      sb.append(", Aggregates: ");
+      sb.append(", PushDownAggregates: ");
       Joiner.on(", ").skipNulls().appendTo(sb, getPushDownAggregates());
+    }
+
+    if (!getAggregates().isEmpty()) {
+      sb.append(", Aggregates: ");
+      Joiner.on(", ").skipNulls().appendTo(sb, getAggregates());
     }
 
     if (!getGroupByItems().isEmpty()) {


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix test `SumPushDownSuite` fail in TiDB release-4.0.

### How to solve
TiDAGRequest has aggregates and pushdownAggregates which have the same meaning.
TiDAGRequest only shows pushdownAggregates when explain, But TiSpark will not set aggregates into pushdownAggregates in `FetchHandleRDD`. 

This pr will show aggregates in TiDAGRequest so that we can see the aggregates in `FetchHandleRDD`.
when `CoprocessorRDD`, we can see both the  aggregates and pushdownAggregates 