### PR TITLE
Add changelog action in master

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -9,9 +9,7 @@ jobs:
     name: Update master changelog
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-        with:
-          ref: master
+      - uses: actions/checkout@v3
       - uses: rhysd/changelog-from-release/action@v2
         with:
           file: CHANGELOG.md

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,7 +1,8 @@
 name: On release published
 on:
   release:
-    types: [published,released]
+    types: [published]
+  workflow_dispatch:
 
 jobs:
   changelog_master:

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,17 @@
+name: On release published
+on:
+  release:
+    types: [published,released]
+
+jobs:
+  changelog:
+    name: Update master changelog
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: master
+      - uses: rhysd/changelog-from-release/action@v2
+        with:
+          file: CHANGELOG.md
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,53 +1,20 @@
 name: On release published
 on:
-  release:
-    types: [published]
   workflow_dispatch:
+    inputs:
+      branch:
+        description: 'branch'
+        required: true
+        default: 'master'
 
 jobs:
-  changelog_master:
-    name: Update master changelog
+  changelog:
+    name: update changelog
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: master
-      - uses: rhysd/changelog-from-release/action@v2
-        with:
-          file: CHANGELOG.md
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-
-  changelog_2_4:
-    name: Update release-2.4 changelog
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          ref: release-2.4
-      - uses: rhysd/changelog-from-release/action@v2
-        with:
-          file: CHANGELOG.md
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-
-  changelog_2_5:
-    name: Update release-2.5 changelog
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          ref: release-2.5
-      - uses: rhysd/changelog-from-release/action@v2
-        with:
-          file: CHANGELOG.md
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-
-  changelog_3_0:
-    name: Update release-3.0 changelog
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          ref: release-3.0
+          ref:  ${{ inputs.branch }}
       - uses: rhysd/changelog-from-release/action@v2
         with:
           file: CHANGELOG.md

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -16,6 +16,7 @@ jobs:
         with:
           file: CHANGELOG.md
           github_token: ${{ secrets.GITHUB_TOKEN }}
+
   changelog_2_4:
     name: Update release-2.4 changelog
     runs-on: ubuntu-latest
@@ -27,6 +28,7 @@ jobs:
         with:
           file: CHANGELOG.md
           github_token: ${{ secrets.GITHUB_TOKEN }}
+
   changelog_2_5:
     name: Update release-2.5 changelog
     runs-on: ubuntu-latest
@@ -38,6 +40,7 @@ jobs:
         with:
           file: CHANGELOG.md
           github_token: ${{ secrets.GITHUB_TOKEN }}
+
   changelog_3_0:
     name: Update release-3.0 changelog
     runs-on: ubuntu-latest

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -4,7 +4,7 @@ on:
     types: [published,released]
 
 jobs:
-  changelog:
+  changelog_master:
     name: Update master changelog
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,9 +1,9 @@
-name: On release published
+name: Update changelog manually
 on:
   workflow_dispatch:
     inputs:
       branch:
-        description: 'branch'
+        description: 'branch name'
         required: true
         default: 'master'
 
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref:  ${{ inputs.branch }}
+          ref: ${{ inputs.branch }}
       - uses: rhysd/changelog-from-release/action@v2
         with:
           file: CHANGELOG.md

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -9,8 +9,44 @@ jobs:
     name: Update master changelog
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v2
+        with:
+          ref: master
       - uses: rhysd/changelog-from-release/action@v2
         with:
           file: CHANGELOG.md
           github_token: ${{ secrets.GITHUB_TOKEN }}
+  changelog_2_4:
+    name: Update release-2.4 changelog
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: release-2.4
+      - uses: rhysd/changelog-from-release/action@v2
+        with:
+          file: CHANGELOG.md
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+  changelog_2_5:
+    name: Update release-2.5 changelog
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: release-2.5
+      - uses: rhysd/changelog-from-release/action@v2
+        with:
+          file: CHANGELOG.md
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+  changelog_3_0:
+    name: Update release-3.0 changelog
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: release-3.0
+      - uses: rhysd/changelog-from-release/action@v2
+        with:
+          file: CHANGELOG.md
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
This action can update the changelog according to the release

This action can only be triggered manually. Once you specify the branch（default master）, the action will update the changelog in this branch.

- see [here](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow) to learn how to run it Manually
- see [GitHub action link](https://github.com/rhysd/changelog-from-release) to learn about the action