### PR TITLE
optimize the ci output

### DIFF
--- a/core-test/pom.xml
+++ b/core-test/pom.xml
@@ -292,6 +292,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <trimStackTrace>false</trimStackTrace>
+                    <useFile>false</useFile>
                     <skipTests>true</skipTests>
                 </configuration>
             </plugin>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -283,6 +283,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <trimStackTrace>false</trimStackTrace>
+                    <useFile>false</useFile>
                     <skipTests>true</skipTests>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -228,6 +228,8 @@
                         <parallel>suites</parallel>
                         <useUnlimitedThreads>true</useUnlimitedThreads>
                         <forkMode>always</forkMode>
+                        <trimStackTrace>false</trimStackTrace>
+                        <useFile>false</useFile>
                         <excludes>
                             <exclude>${someModule.test.excludes}</exclude>
                         </excludes>


### PR DESCRIPTION
## What is the purpose of the change

The output of the exception stack is not detailed enough, need to print the whole stack. https://stackoverflow.com/questions/2928548/make-mavens-surefire-show-stacktrace-in-console

<img width="1085" alt="image" src="https://user-images.githubusercontent.com/17768378/172125811-2892e14b-d68b-49b8-9e29-356845654b22.png">


## Brief change log

-  set maven-surefire-plugin `trimStackTrace` and `useFile` to false

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage. The result turns out to be

<img width="1318" alt="image" src="https://user-images.githubusercontent.com/17768378/172126202-41a31976-ea4b-4a98-99d6-2d6907215c1b.png">

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): (no)
- The public API: (no)
- The runtime per-record code paths (performance sensitive): (no)

## Documentation

- Does this pull request introduce a new feature? (no)
