### PR TITLE
[close #2389] Fix get stuck when exiting

### DIFF
--- a/core/src/main/scala/com/pingcap/tispark/telemetry/TeleMsg.scala
+++ b/core/src/main/scala/com/pingcap/tispark/telemetry/TeleMsg.scala
@@ -42,11 +42,10 @@ class TeleMsg(sparkSession: SparkSession) {
   val configuration: Map[String, Any] = TiSparkTeleConf.getTiSparkTeleConf()
 
   private def generateTrackId(): String = {
-    var tiSession: TiSession = null
     try {
       val conf = TiConfiguration.createDefault(pdAddr.get)
       TiUtil.sparkConfToTiConfWithoutPD(SparkSession.active.sparkContext.getConf, conf)
-      tiSession = TiSession.getInstance(conf)
+      val tiSession = TiSession.getInstance(conf)
       val snapShot = tiSession.createSnapshot()
       val value = snapShot.get(TRACK_ID.getBytes("UTF-8"))
 
@@ -60,9 +59,6 @@ class TeleMsg(sparkSession: SparkSession) {
       case e: Throwable =>
         logger.warn("Failed to generated telemetry track ID", e.getMessage)
         APP_ID_PREFIX + sparkSession.sparkContext.applicationId
-    } finally {
-      if (tiSession != null)
-        tiSession.close()
     }
   }
 


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix bug #2389.

### What is changed and how it works?
Delete `tiSession.close()` in telemetry.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->


 - Manual test (add detailed scripts or steps below)
1. start spark-shell
```
bin/spark-shell --jars tispark-assembly-3.0_2.12-3.0.0.jar 
```
3. use `tidb catalog` and execute `select` SQL
```
scala> spark.sql("use tidb_catalog")```
scala> spark.sql("select * from ${database}.${table}").show
```
4. execute `:quit` and exit immediately


Code chan
 - Has exported function/method change

Related changes

 - Need to cherry-pick to the release branch
