### PR TITLE
Obsolete revision to fix the the bug that fail to import maven dependency

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.pingcap.tispark</groupId>
         <artifactId>tispark-parent</artifactId>
-        <version>${revision}</version>
+        <version>3.1.0-SHAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core-test/pom.xml
+++ b/core-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.pingcap.tispark</groupId>
         <artifactId>tispark-parent</artifactId>
-        <version>${revision}</version>
+        <version>3.1.0-SHAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.pingcap.tispark</groupId>
         <artifactId>tispark-parent</artifactId>
-        <version>${revision}</version>
+        <version>3.1.0-SHAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/db-random-test/pom.xml
+++ b/db-random-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.pingcap.tispark</groupId>
         <artifactId>tispark-parent</artifactId>
-        <version>${revision}</version>
+        <version>3.1.0-SHAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>com.pingcap.tispark</groupId>
     <artifactId>tispark-parent</artifactId>
-    <version>${revision}</version>
+    <version>3.1.0-SHAPSHOT</version>
     <packaging>pom</packaging>
     <name>TiSpark Project Parent POM</name>
     <url>http://github.copm/pingcap/tispark</url>
@@ -92,7 +92,6 @@
         <scalaj.version>2.3.0</scalaj.version>
         <lombok.version>1.18.22</lombok.version>
         <someModule.test.excludes></someModule.test.excludes>
-        <revision>3.1.0-SNAPSHOT</revision>
     </properties>
     <repositories>
         <repository>

--- a/spark-wrapper/spark-3.0/pom.xml
+++ b/spark-wrapper/spark-3.0/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.pingcap.tispark</groupId>
         <artifactId>tispark-parent</artifactId>
-        <version>${revision}</version>
+        <version>3.1.0-SHAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/spark-wrapper/spark-3.1/pom.xml
+++ b/spark-wrapper/spark-3.1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.pingcap.tispark</groupId>
         <artifactId>tispark-parent</artifactId>
-        <version>${revision}</version>
+        <version>3.1.0-SHAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/spark-wrapper/spark-3.2/pom.xml
+++ b/spark-wrapper/spark-3.2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.pingcap.tispark</groupId>
         <artifactId>tispark-parent</artifactId>
-        <version>${revision}</version>
+        <version>3.1.0-SHAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/tikv-client/pom.xml
+++ b/tikv-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.pingcap.tispark</groupId>
         <artifactId>tispark-parent</artifactId>
-        <version>${revision}</version>
+        <version>3.1.0-SHAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
close #2404 

### What is changed and how it works?
This pr reverts commit a411fbda. 
we don't use revision now, because it doesn't work when install or deploy
