### PR TITLE
compatible with tidb_6.1

### DIFF
--- a/config/tidb.toml
+++ b/config/tidb.toml
@@ -1,4 +1,5 @@
 # TiDB Configuration.
+# TiDB Configuration.
 
 # TiDB server host.
 host = "0.0.0.0"
@@ -49,7 +50,7 @@ alter-primary-key = true
 index-limit = 512
 
 # Whether new collations are enabled, as indicated by its name, this configuration entry take effect ONLY when a TiDB cluster bootstraps for the first time.
-new_collations_enabled_on_first_bootstrap = false
+new_collations_enabled_on_first_bootstrap = true
 
 [log]
 # Log level: info, debug, warn, error, fatal.


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
TiSpark needs to support TiDB TLS. In this pr, we will support TiDB v6.1.0 as well as 6.0.0

[TiDB 6.0.0](https://github.com/pingcap/tidb/releases/tag/v6.0.0)
- TiFlash push down：
  - Support pushing down the DAYOFMONTH() and LAST_DAY() functions to TiFlash [#33012](https://github.com/pingcap/tidb/issues/33012)
  - Support pushing down the DAYOFWEEK() and DAYOFYEAR() functions to TiFlash [#33130](https://github.com/pingcap/tidb/issues/33130)
  - Support pushing down the IS_TRUE, IS_FALSE, and IS_TRUE_WITH_NULL functions to TiFlash [#33047](https://github.com/pingcap/tidb/issues/33047)
  - Support pushing down the GREATEST and LEAST functions to TiFlash [#32787](https://github.com/pingcap/tidb/issues/32787)
  - Support pushing down the REGEXP function to TiFlash [#32637](https://github.com/pingcap/tidb/issues/32637)
  - Supports pushing down the DAYNAME() and MONTHNAME() functions to TiFlash [#32594](https://github.com/pingcap/tidb/issues/32594)
- partition table
  - Enable partition pruning for RANGE COLUMNS partitionings on IN conditions and string type columns [#32626](https://github.com/pingcap/tidb/issues/32626)
- others
  - Support using the PointGet plan for queries that read the _tidb_rowid column [#31543](https://github.com/pingcap/tidb/issues/31543)

TiDB v6.1.0 ( [doc](https://docs.pingcap.com/zh/tidb/stable/release-6.1.0) & [release note](https://github.com/pingcap/tidb/releases/tag/v6.1.0))
- collation
  - Support new collation：new_collations_enabled_on_first_bootstrap will be true in default in TiDB 6.0，
  - List partitioning and list COLUMNS partitioning become GA, compatible with MySQL 5.7. [tidb_enable_list_partition](https://docs.pingcap.com/zh/tidb/stable/system-variables#tidb_enable_list_partition-%E4%BB%8E-v50-%E7%89%88%E6%9C%AC%E5%BC%80%E5%A7%8B%E5%BC%95%E5%85%A5) will open in default
- DML
  - Support non-transactional DML statements (only support DELETE)
- support API V2：the config `api-version`  default will be 1 
- default value
  - Support using rand() as the default value of a column [#10377](https://github.com/pingcap/tidb/issues/10377)
  - Support using uuid() as the default value of a column [#33870](https://github.com/pingcap/tidb/issues/33870)
