### PR TITLE
GPL fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Most of the TiSpark logic is inside a thin layer, namely, the [tikv-client](http
 We will not provide the `mysql-connector-java` dependency because of the limit of the GPL license.
 
 The following versions of TiSpark's jar will no longer include `mysql-connector-java`.
-- TiSpark > 3.0.1 for TiSpark 3.0.x
+- TiSpark > 3.0.1
 - TiSpark > 2.5.1 for TiSpark 2.5.x
 - TiSpark > 2.4.3 for TiSpark 2.4.x
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,24 @@ Most of the TiSpark logic is inside a thin layer, namely, the [tikv-client](http
 - [Example Programs](https://github.com/pingcap/tispark-test/tree/master/tispark-examples)
 - [Telemetry](./docs/telemetry.md)
 
+## About mysql-connector-java
+
+We will not provide the `mysql-connector-java` dependency because of the limit of the GPL license.
+
+The following versions of TiSpark's jar will no longer include `mysql-connector-java`.
+- TiSpark > 3.0.1 for TiSpark 3.0.x
+- TiSpark > 2.5.1 for TiSpark 2.5.x
+- TiSpark > 2.4.3 for TiSpark 2.4.x
+
+Now, TiSpark needs `mysql-connector-java` for writing and auth. Please import `mysql-connector-java` manually when you need to write or auth.
+
+- you can import it by putting the jar into spark jars file
+
+- you can also import it when you submit spark job like
+```
+spark-submit --jars tispark-assembly-3.0_2.12-3.1.0-SNAPSHOT.jar,mysql-connector-java-8.0.29.jar
+```
+
 ## Feature Support
 
 | Feature Support                   | TiSpark 2.4.x | TiSpark 2.5.x | TiSpark 3.0.x  | TiSpark master |

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -25,11 +25,6 @@
             <artifactId>tikv-client</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
-        <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
-            <version>${mysql.connector.version}</version>
-        </dependency>
     </dependencies>
 
     <build>

--- a/assembly/src/main/assembly/assembly.xml
+++ b/assembly/src/main/assembly/assembly.xml
@@ -12,7 +12,6 @@
             <includes>
                 <include>com.pingcap.tispark:tispark-core-internal:jar</include>
                 <include>com.pingcap.tikv:tikv-client:jar</include>
-                <include>mysql:mysql-connector-java:jar</include>
             </includes>
             <unpack>true</unpack>
         </dependencySet>

--- a/core-test/pom.xml
+++ b/core-test/pom.xml
@@ -135,6 +135,7 @@
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
             <version>${mysql.connector.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -121,6 +121,7 @@
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
             <version>${mysql.connector.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.github.oshi</groupId>

--- a/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
@@ -21,13 +21,13 @@ package org.apache.spark.sql
 import java.sql.{Date, Timestamp}
 import java.text.SimpleDateFormat
 import java.util.TimeZone
-
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.util._
 import org.apache.spark.sql.execution.columnar.InMemoryRelation
 import org.apache.spark.sql.types.StructField
 
+import java.time.LocalDateTime
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
 
@@ -303,6 +303,11 @@ abstract class QueryTest extends SparkFunSuite {
         value.asInstanceOf[BigDecimal].setScale(2, BigDecimal.RoundingMode.HALF_UP)
       case _: Date if colType.equalsIgnoreCase("YEAR") =>
         value.toString.split("-")(0)
+      // mysql-connector-j 8.0.29 it will return LocalDateTime for datetime type
+      // mysql-connector-j 5.1.47 will return Timestamp for datetime type
+      // here we just convert LocalDateTime to Timestamp because tispark will return Timestamp now
+      case v: LocalDateTime =>
+        Timestamp.valueOf(v)
       case default =>
         default
     }

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
         <scalafmt.skip>true</scalafmt.skip>
         <scalatest.version>3.0.8</scalatest.version>
         <argLine>-Dfile.encoding=UTF-8 -Duser.timezone=GMT+8</argLine>
-        <mysql.connector.version>5.1.49</mysql.connector.version>
+        <mysql.connector.version>8.0.29</mysql.connector.version>
         <gpg.keyname>fake gpg keyname</gpg.keyname>
         <gpg.skip>true</gpg.skip>
         <javadoc.skip>true</javadoc.skip>


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
If `mysql-connector-J` with the GPL license is included, then the license of TiSpark will also be polluted as GPL

### What is changed and how it works?
upgrade mysql-connector-java from 5.1.49 to 8.0.29 and remove it from the TiSpark'jar to avoid GPL pollution.

Btw, change little tests to be compatible with the upgraded mysql-connector-java.

doc: https://github.com/pingcap/tispark/wiki/Getting-TiSpark#getting-mysql-connector-j

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)


Code changes

 - pom changed
 - some test changed

Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to be included in the release note
