### PR TITLE
Fix: exception when the size of pdAddresse is > 1

### DIFF
--- a/core/src/main/scala/com/pingcap/tispark/auth/TiAuthorization.scala
+++ b/core/src/main/scala/com/pingcap/tispark/auth/TiAuthorization.scala
@@ -114,9 +114,9 @@ case class TiAuthorization private (parameters: Map[String, String], tiConf: TiC
     parsePrivilegeFromRow(input)
   }
 
-  def getPDAddress(): String = {
+  def getPDAddresses(): String = {
     try {
-      jdbcClient.getPDAddress
+      String.join(",", jdbcClient.getPDAddresses)
     } catch {
       case e: Throwable =>
         throw new IllegalArgumentException(

--- a/core/src/main/scala/org/apache/spark/sql/TiContext.scala
+++ b/core/src/main/scala/org/apache/spark/sql/TiContext.scala
@@ -45,7 +45,7 @@ class TiContext(val sparkSession: SparkSession) extends Serializable with Loggin
   final val tiConf: TiConfiguration = TiUtil.sparkConfToTiConf(
     conf,
     if (TiAuthorization.enableAuth) {
-      Option(tiAuthorization.get.getPDAddress())
+      Option(tiAuthorization.get.getPDAddresses())
     } else Option.empty)
   final val tiSession: TiSession = TiSession.getInstance(tiConf)
   lazy val sqlContext: SQLContext = sparkSession.sqlContext

--- a/core/src/main/scala/org/apache/spark/sql/catalyst/catalog/TiCatalog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/catalyst/catalog/TiCatalog.scala
@@ -56,7 +56,7 @@ class TiCatalog extends TableCatalog with SupportsNamespaces {
 
     val pdAddress: String =
       if (TiAuthorization.enableAuth) {
-        tiAuthorization.get.getPDAddress()
+        tiAuthorization.get.getPDAddresses()
       } else {
         if (!options.containsKey("pd.addresses") && !options.containsKey("pd.address")) {
           throw new Exception("missing configuration spark.sql.catalog.tidb_catalog.pd.addresses")

--- a/core/src/test/scala/com/pingcap/tispark/auth/TiAuthIntegrationSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/auth/TiAuthIntegrationSuite.scala
@@ -17,11 +17,10 @@
 package com.pingcap.tispark.auth
 
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.{AnalysisException, Row}
 import org.apache.spark.sql.test.SharedSQLContext
 import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
+import org.apache.spark.sql.{AnalysisException, Row}
 import org.scalatest.Matchers.{
-  an,
   be,
   contain,
   convertToAnyShouldWrapper,
@@ -123,7 +122,7 @@ class TiAuthIntegrationSuite extends SharedSQLContext {
   }
 
   test("Get PD address from TiDB should be correct") {
-    ti.tiAuthorization.get.getPDAddress() should be(pdAddresses)
+    ti.tiAuthorization.get.getPDAddresses() should be(pdAddresses)
   }
 
   test("Use database and select without privilege should not be passed") {

--- a/tikv-client/src/main/java/com/pingcap/tikv/jdbc/JDBCClient.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/jdbc/JDBCClient.java
@@ -61,8 +61,8 @@ public class JDBCClient {
     }
   }
 
-  public String getPDAddress() throws SQLException {
-    return queryForObject(GET_PD_ADDRESS, (rs, rowNum) -> rs.getString(1));
+  public List<String> getPDAddresses() throws SQLException {
+    return query(GET_PD_ADDRESS, (rs, rowNum) -> rs.getString(1));
   }
 
   public String getCurrentUser() throws SQLException {


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

When config with multi pdAddresses, telemetry throw exception
![origin_img_v2_ce4f41f6-749e-44bb-adc6-9f5061e67e7g](https://user-images.githubusercontent.com/17768378/181741778-5369013d-4ee5-42b6-ac9c-186030303050.jpg)

### What is changed and how it works?

- Make the telemetry work with multi pdAddresses
- Make the auth work with multi pdAddresses

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
 tiup cluster start 2 pd nodes, and run the tests

