### PR TITLE
fix bug test fail in tidb4.0 test

### DIFF
--- a/core/src/main/scala/com/pingcap/tispark/utils/TwoPhaseCommitHepler.scala
+++ b/core/src/main/scala/com/pingcap/tispark/utils/TwoPhaseCommitHepler.scala
@@ -47,7 +47,7 @@ case class TwoPhaseCommitHepler(startTs: Long, options: TiDBOptions) extends Aut
 
   // Init lockTTLSeconds and ttlManager
   private val tikvSupportUpdateTTL: Boolean =
-    StoreVersion.minTiKVVersion("3.0.5", tiSession.getPDClient)
+    StoreVersion.isTiKVVersionGreatEqualVersion(tiSession.getPDClient, "3.0.5")
   private val isTTLUpdate = options.isTTLUpdate(tikvSupportUpdateTTL)
   private val lockTTLSeconds: Long = options.getLockTTLSeconds(tikvSupportUpdateTTL)
   @transient private var ttlManager: TTLManager = _

--- a/core/src/main/scala/com/pingcap/tispark/utils/TwoPhaseCommitHepler.scala
+++ b/core/src/main/scala/com/pingcap/tispark/utils/TwoPhaseCommitHepler.scala
@@ -47,7 +47,7 @@ case class TwoPhaseCommitHepler(startTs: Long, options: TiDBOptions) extends Aut
 
   // Init lockTTLSeconds and ttlManager
   private val tikvSupportUpdateTTL: Boolean =
-    StoreVersion.isTiKVVersionGreatEqualVersion(tiSession.getPDClient, "3.0.5")
+    StoreVersion.isTiKVVersionGreatEqualThanVersion(tiSession.getPDClient, "3.0.5")
   private val isTTLUpdate = options.isTTLUpdate(tikvSupportUpdateTTL)
   private val lockTTLSeconds: Long = options.getLockTTLSeconds(tikvSupportUpdateTTL)
   @transient private var ttlManager: TTLManager = _

--- a/core/src/main/scala/com/pingcap/tispark/write/TiBatchWrite.scala
+++ b/core/src/main/scala/com/pingcap/tispark/write/TiBatchWrite.scala
@@ -140,8 +140,8 @@ class TiBatchWrite(
     // initialize
     tiConf = mergeSparkConfWithDataSourceConf(tiContext.conf, options)
     tiSession = tiContext.tiSession
-    val tikvSupportUpdateTTL = StoreVersion.isTiKVVersionGreatEqualVersion(tiSession.getPDClient, "3.0.5")
-    val isTiDBV4 = StoreVersion.isTiKVVersionGreatEqualVersion(tiSession.getPDClient, "4.0.0")
+    val tikvSupportUpdateTTL = StoreVersion.isTiKVVersionGreatEqualThanVersion(tiSession.getPDClient, "3.0.5")
+    val isTiDBV4 = StoreVersion.isTiKVVersionGreatEqualThanVersion(tiSession.getPDClient, "4.0.0")
     isTTLUpdate = options.isTTLUpdate(tikvSupportUpdateTTL)
     lockTTLSeconds = options.getLockTTLSeconds(tikvSupportUpdateTTL)
     tiDBJDBCClient = new TiDBJDBCClient(TiDBUtils.createConnectionFactory(options.url)())
@@ -428,7 +428,7 @@ class TiBatchWrite(
   }
 
   private def getUseTableLock: Boolean = {
-    if (!options.useTableLock(StoreVersion.isTiKVVersionGreatEqualVersion(tiSession.getPDClient, "4.0.0"))) {
+    if (!options.useTableLock(StoreVersion.isTiKVVersionGreatEqualThanVersion(tiSession.getPDClient, "4.0.0"))) {
       false
     } else {
       if (tiDBJDBCClient.isEnableTableLock) {

--- a/core/src/main/scala/com/pingcap/tispark/write/TiBatchWrite.scala
+++ b/core/src/main/scala/com/pingcap/tispark/write/TiBatchWrite.scala
@@ -140,7 +140,8 @@ class TiBatchWrite(
     // initialize
     tiConf = mergeSparkConfWithDataSourceConf(tiContext.conf, options)
     tiSession = tiContext.tiSession
-    val tikvSupportUpdateTTL = StoreVersion.isTiKVVersionGreatEqualThanVersion(tiSession.getPDClient, "3.0.5")
+    val tikvSupportUpdateTTL =
+      StoreVersion.isTiKVVersionGreatEqualThanVersion(tiSession.getPDClient, "3.0.5")
     val isTiDBV4 = StoreVersion.isTiKVVersionGreatEqualThanVersion(tiSession.getPDClient, "4.0.0")
     isTTLUpdate = options.isTTLUpdate(tikvSupportUpdateTTL)
     lockTTLSeconds = options.getLockTTLSeconds(tikvSupportUpdateTTL)
@@ -428,7 +429,8 @@ class TiBatchWrite(
   }
 
   private def getUseTableLock: Boolean = {
-    if (!options.useTableLock(StoreVersion.isTiKVVersionGreatEqualThanVersion(tiSession.getPDClient, "4.0.0"))) {
+    if (!options.useTableLock(
+        StoreVersion.isTiKVVersionGreatEqualThanVersion(tiSession.getPDClient, "4.0.0"))) {
       false
     } else {
       if (tiDBJDBCClient.isEnableTableLock) {

--- a/core/src/main/scala/com/pingcap/tispark/write/TiBatchWrite.scala
+++ b/core/src/main/scala/com/pingcap/tispark/write/TiBatchWrite.scala
@@ -140,8 +140,8 @@ class TiBatchWrite(
     // initialize
     tiConf = mergeSparkConfWithDataSourceConf(tiContext.conf, options)
     tiSession = tiContext.tiSession
-    val tikvSupportUpdateTTL = StoreVersion.minTiKVVersion("3.0.5", tiSession.getPDClient)
-    val isTiDBV4 = StoreVersion.minTiKVVersion("4.0.0", tiSession.getPDClient)
+    val tikvSupportUpdateTTL = StoreVersion.isTiKVVersionGreatEqualVersion(tiSession.getPDClient, "3.0.5")
+    val isTiDBV4 = StoreVersion.isTiKVVersionGreatEqualVersion(tiSession.getPDClient, "4.0.0")
     isTTLUpdate = options.isTTLUpdate(tikvSupportUpdateTTL)
     lockTTLSeconds = options.getLockTTLSeconds(tikvSupportUpdateTTL)
     tiDBJDBCClient = new TiDBJDBCClient(TiDBUtils.createConnectionFactory(options.url)())
@@ -428,7 +428,7 @@ class TiBatchWrite(
   }
 
   private def getUseTableLock: Boolean = {
-    if (!options.useTableLock(StoreVersion.minTiKVVersion("4.0.0", tiSession.getPDClient))) {
+    if (!options.useTableLock(StoreVersion.isTiKVVersionGreatEqualVersion(tiSession.getPDClient, "4.0.0"))) {
       false
     } else {
       if (tiDBJDBCClient.isEnableTableLock) {

--- a/core/src/test/scala/com/pingcap/tispark/partition/PartitionWriteSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/partition/PartitionWriteSuite.scala
@@ -446,7 +446,7 @@ class PartitionWriteSuite extends BaseTiSparkTest {
   }
 
   test("binary type range column replace test") {
-    if (!StoreVersion.isTiKVVersionGreatEqualVersion(this.ti.tiSession.getPDClient, "v5.1.0")) {
+    if (!StoreVersion.isTiKVVersionGreatEqualThanVersion(this.ti.tiSession.getPDClient, "v5.1.0")) {
       cancel("Binary range column partitioning is supported in TiDB v5.1.0+.")
     }
 

--- a/core/src/test/scala/com/pingcap/tispark/partition/PartitionWriteSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/partition/PartitionWriteSuite.scala
@@ -446,7 +446,7 @@ class PartitionWriteSuite extends BaseTiSparkTest {
   }
 
   test("binary type range column replace test") {
-    if (StoreVersion.minTiKVVersion("v5.1.0", this.ti.tiSession.getPDClient)) {
+    if (!StoreVersion.minTiKVVersion("v5.1.0", this.ti.tiSession.getPDClient)) {
       cancel("Binary range column partitioning is supported in TiDB v5.1.0+.")
     }
 

--- a/core/src/test/scala/com/pingcap/tispark/partition/PartitionWriteSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/partition/PartitionWriteSuite.scala
@@ -446,7 +446,9 @@ class PartitionWriteSuite extends BaseTiSparkTest {
   }
 
   test("binary type range column replace test") {
-    if (!StoreVersion.isTiKVVersionGreatEqualThanVersion(this.ti.tiSession.getPDClient, "v5.1.0")) {
+    if (!StoreVersion.isTiKVVersionGreatEqualThanVersion(
+        this.ti.tiSession.getPDClient,
+        "v5.1.0")) {
       cancel("Binary range column partitioning is supported in TiDB v5.1.0+.")
     }
 

--- a/core/src/test/scala/com/pingcap/tispark/partition/PartitionWriteSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/partition/PartitionWriteSuite.scala
@@ -446,7 +446,7 @@ class PartitionWriteSuite extends BaseTiSparkTest {
   }
 
   test("binary type range column replace test") {
-    if (!StoreVersion.minTiKVVersion("v5.1.0", this.ti.tiSession.getPDClient)) {
+    if (!StoreVersion.isTiKVVersionGreatEqualVersion(this.ti.tiSession.getPDClient, "v5.1.0")) {
       cancel("Binary range column partitioning is supported in TiDB v5.1.0+.")
     }
 

--- a/core/src/test/scala/org/apache/spark/sql/BaseTiSparkTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/BaseTiSparkTest.scala
@@ -18,8 +18,6 @@
 
 package org.apache.spark.sql
 
-import java.sql.Statement
-
 import com.pingcap.tikv.meta.TiTableInfo
 import com.pingcap.tikv.{StoreVersion, TiDBJDBCClient, Version}
 import com.pingcap.tispark.{TiConfigConst, TiDBUtils}
@@ -28,6 +26,7 @@ import org.apache.spark.sql.execution.ExplainMode
 import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions
 import org.apache.spark.sql.test.SharedSQLContext
 
+import java.sql.Statement
 import scala.collection.mutable.ArrayBuffer
 
 class BaseTiSparkTest extends QueryTest with SharedSQLContext {
@@ -130,7 +129,7 @@ class BaseTiSparkTest extends QueryTest with SharedSQLContext {
   }
 
   protected def supportTTLUpdate: Boolean = {
-    StoreVersion.minTiKVVersion(Version.RESOLVE_LOCK_V3, this.ti.tiSession.getPDClient)
+    StoreVersion.isTiKVVersionGreatEqualVersion(this.ti.tiSession.getPDClient, Version.RESOLVE_LOCK_V3)
   }
 
   protected def blockingRead: Boolean = {
@@ -138,7 +137,7 @@ class BaseTiSparkTest extends QueryTest with SharedSQLContext {
   }
 
   protected def nonBlockingRead: Boolean = {
-    StoreVersion.minTiKVVersion(Version.RESOLVE_LOCK_V4, this.ti.tiSession.getPDClient)
+    StoreVersion.isTiKVVersionGreatEqualVersion(this.ti.tiSession.getPDClient, Version.RESOLVE_LOCK_V4)
   }
 
   protected def getTableInfo(databaseName: String, tableName: String): TiTableInfo = {

--- a/core/src/test/scala/org/apache/spark/sql/BaseTiSparkTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/BaseTiSparkTest.scala
@@ -129,7 +129,9 @@ class BaseTiSparkTest extends QueryTest with SharedSQLContext {
   }
 
   protected def supportTTLUpdate: Boolean = {
-    StoreVersion.isTiKVVersionGreatEqualThanVersion(this.ti.tiSession.getPDClient, Version.RESOLVE_LOCK_V3)
+    StoreVersion.isTiKVVersionGreatEqualThanVersion(
+      this.ti.tiSession.getPDClient,
+      Version.RESOLVE_LOCK_V3)
   }
 
   protected def blockingRead: Boolean = {
@@ -137,7 +139,9 @@ class BaseTiSparkTest extends QueryTest with SharedSQLContext {
   }
 
   protected def nonBlockingRead: Boolean = {
-    StoreVersion.isTiKVVersionGreatEqualThanVersion(this.ti.tiSession.getPDClient, Version.RESOLVE_LOCK_V4)
+    StoreVersion.isTiKVVersionGreatEqualThanVersion(
+      this.ti.tiSession.getPDClient,
+      Version.RESOLVE_LOCK_V4)
   }
 
   protected def getTableInfo(databaseName: String, tableName: String): TiTableInfo = {

--- a/core/src/test/scala/org/apache/spark/sql/BaseTiSparkTest.scala
+++ b/core/src/test/scala/org/apache/spark/sql/BaseTiSparkTest.scala
@@ -129,7 +129,7 @@ class BaseTiSparkTest extends QueryTest with SharedSQLContext {
   }
 
   protected def supportTTLUpdate: Boolean = {
-    StoreVersion.isTiKVVersionGreatEqualVersion(this.ti.tiSession.getPDClient, Version.RESOLVE_LOCK_V3)
+    StoreVersion.isTiKVVersionGreatEqualThanVersion(this.ti.tiSession.getPDClient, Version.RESOLVE_LOCK_V3)
   }
 
   protected def blockingRead: Boolean = {
@@ -137,7 +137,7 @@ class BaseTiSparkTest extends QueryTest with SharedSQLContext {
   }
 
   protected def nonBlockingRead: Boolean = {
-    StoreVersion.isTiKVVersionGreatEqualVersion(this.ti.tiSession.getPDClient, Version.RESOLVE_LOCK_V4)
+    StoreVersion.isTiKVVersionGreatEqualThanVersion(this.ti.tiSession.getPDClient, Version.RESOLVE_LOCK_V4)
   }
 
   protected def getTableInfo(databaseName: String, tableName: String): TiTableInfo = {

--- a/core/src/test/scala/org/apache/spark/sql/catalyst/plans/logical/LogicalPlanTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/catalyst/plans/logical/LogicalPlanTestSuite.scala
@@ -130,8 +130,7 @@ class LogicalPlanTestSuite extends BasePlanTest {
   test("fix cannot encode row key with non-long type") {
     tidbStmt.execute("DROP TABLE IF EXISTS `t1`")
     if (StoreVersion.isTiKVVersionGreatEqualThanVersion(this.ti.tiSession.getPDClient, "5.0.0")) {
-      tidbStmt.execute(
-        """
+      tidbStmt.execute("""
           |CREATE TABLE `t1` (
           |  `a` BIGINT UNSIGNED  NOT NULL,
           |  `b` varchar(255) NOT NULL,

--- a/core/src/test/scala/org/apache/spark/sql/catalyst/plans/logical/LogicalPlanTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/catalyst/plans/logical/LogicalPlanTestSuite.scala
@@ -129,7 +129,7 @@ class LogicalPlanTestSuite extends BasePlanTest {
   // https://github.com/pingcap/tispark/issues/2290
   test("fix cannot encode row key with non-long type") {
     tidbStmt.execute("DROP TABLE IF EXISTS `t1`")
-    if (StoreVersion.isTiKVVersionGreatEqualVersion(this.ti.tiSession.getPDClient, "5.0.0")) {
+    if (StoreVersion.isTiKVVersionGreatEqualThanVersion(this.ti.tiSession.getPDClient, "5.0.0")) {
       tidbStmt.execute(
         """
           |CREATE TABLE `t1` (

--- a/core/src/test/scala/org/apache/spark/sql/catalyst/plans/logical/LogicalPlanTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/catalyst/plans/logical/LogicalPlanTestSuite.scala
@@ -129,8 +129,9 @@ class LogicalPlanTestSuite extends BasePlanTest {
   // https://github.com/pingcap/tispark/issues/2290
   test("fix cannot encode row key with non-long type") {
     tidbStmt.execute("DROP TABLE IF EXISTS `t1`")
-    if (StoreVersion.minTiKVVersion("5.0.0", this.ti.tiSession.getPDClient)) {
-      tidbStmt.execute("""
+    if (StoreVersion.isTiKVVersionGreatEqualVersion(this.ti.tiSession.getPDClient, "5.0.0")) {
+      tidbStmt.execute(
+        """
           |CREATE TABLE `t1` (
           |  `a` BIGINT UNSIGNED  NOT NULL,
           |  `b` varchar(255) NOT NULL,

--- a/core/src/test/scala/org/apache/spark/sql/insertion/BatchWritePKAndIndexSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/insertion/BatchWritePKAndIndexSuite.scala
@@ -117,7 +117,7 @@ class BatchWritePKAndIndexSuite
   // https://github.com/pingcap/tispark/issues/2452
   test("test duplicate unique indexes are not deleted error") {
     tidbStmt.execute("drop table if exists `tispark_test`.`t`")
-    if (!StoreVersion.minTiKVVersion("5.0.0", this.ti.tiSession.getPDClient)) {
+    if (!StoreVersion.isTiKVVersionGreatEqualVersion(this.ti.tiSession.getPDClient, "5.0.0")) {
       cancel("TiDB version must bigger than 5.0.0")
     }
     tidbStmt.execute("""
@@ -165,7 +165,7 @@ class BatchWritePKAndIndexSuite
   // https://github.com/pingcap/tispark/issues/2391
   test("test bug fix incorrect uniqueIndex key when table is not intHandle") {
     tidbStmt.execute("drop table if exists `tispark_test`.`t`")
-    if (!StoreVersion.minTiKVVersion("5.0.0", this.ti.tiSession.getPDClient)) {
+    if (!StoreVersion.isTiKVVersionGreatEqualVersion(this.ti.tiSession.getPDClient, "5.0.0")) {
       cancel("TiDB version must bigger than 5.0.0")
     }
     tidbStmt.execute("""

--- a/core/src/test/scala/org/apache/spark/sql/insertion/BatchWritePKAndIndexSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/insertion/BatchWritePKAndIndexSuite.scala
@@ -117,7 +117,7 @@ class BatchWritePKAndIndexSuite
   // https://github.com/pingcap/tispark/issues/2452
   test("test duplicate unique indexes are not deleted error") {
     tidbStmt.execute("drop table if exists `tispark_test`.`t`")
-    if (!StoreVersion.isTiKVVersionGreatEqualVersion(this.ti.tiSession.getPDClient, "5.0.0")) {
+    if (!StoreVersion.isTiKVVersionGreatEqualThanVersion(this.ti.tiSession.getPDClient, "5.0.0")) {
       cancel("TiDB version must bigger than 5.0.0")
     }
     tidbStmt.execute("""
@@ -165,7 +165,7 @@ class BatchWritePKAndIndexSuite
   // https://github.com/pingcap/tispark/issues/2391
   test("test bug fix incorrect uniqueIndex key when table is not intHandle") {
     tidbStmt.execute("drop table if exists `tispark_test`.`t`")
-    if (!StoreVersion.isTiKVVersionGreatEqualVersion(this.ti.tiSession.getPDClient, "5.0.0")) {
+    if (!StoreVersion.isTiKVVersionGreatEqualThanVersion(this.ti.tiSession.getPDClient, "5.0.0")) {
       cancel("TiDB version must bigger than 5.0.0")
     }
     tidbStmt.execute("""

--- a/core/src/test/scala/org/apache/spark/sql/insertion/BatchWritePKAndIndexSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/insertion/BatchWritePKAndIndexSuite.scala
@@ -16,6 +16,7 @@
 
 package org.apache.spark.sql.insertion
 
+import com.pingcap.tikv.StoreVersion
 import com.pingcap.tispark.TiConfigConst
 import com.pingcap.tispark.datasource.BaseBatchWriteTest
 import com.pingcap.tispark.test.generator.DataGenerator._
@@ -116,6 +117,9 @@ class BatchWritePKAndIndexSuite
   // https://github.com/pingcap/tispark/issues/2452
   test("test duplicate unique indexes are not deleted error") {
     tidbStmt.execute("drop table if exists `tispark_test`.`t`")
+    if (StoreVersion.minTiKVVersion("5.0.0", this.ti.tiSession.getPDClient)) {
+      cancel("TiDB version must bigger than 5.0.0")
+    }
     tidbStmt.execute("""
         |CREATE TABLE `tispark_test`.`t` (
         |  `id`  int(20),
@@ -161,6 +165,9 @@ class BatchWritePKAndIndexSuite
   // https://github.com/pingcap/tispark/issues/2391
   test("test bug fix incorrect uniqueIndex key when table is not intHandle") {
     tidbStmt.execute("drop table if exists `tispark_test`.`t`")
+    if (StoreVersion.minTiKVVersion("5.0.0", this.ti.tiSession.getPDClient)) {
+      cancel("TiDB version must bigger than 5.0.0")
+    }
     tidbStmt.execute("""
         |CREATE TABLE `tispark_test`.`t` (
         |  `id`  int(20),

--- a/core/src/test/scala/org/apache/spark/sql/insertion/BatchWritePKAndIndexSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/insertion/BatchWritePKAndIndexSuite.scala
@@ -117,7 +117,7 @@ class BatchWritePKAndIndexSuite
   // https://github.com/pingcap/tispark/issues/2452
   test("test duplicate unique indexes are not deleted error") {
     tidbStmt.execute("drop table if exists `tispark_test`.`t`")
-    if (StoreVersion.minTiKVVersion("5.0.0", this.ti.tiSession.getPDClient)) {
+    if (!StoreVersion.minTiKVVersion("5.0.0", this.ti.tiSession.getPDClient)) {
       cancel("TiDB version must bigger than 5.0.0")
     }
     tidbStmt.execute("""
@@ -165,7 +165,7 @@ class BatchWritePKAndIndexSuite
   // https://github.com/pingcap/tispark/issues/2391
   test("test bug fix incorrect uniqueIndex key when table is not intHandle") {
     tidbStmt.execute("drop table if exists `tispark_test`.`t`")
-    if (StoreVersion.minTiKVVersion("5.0.0", this.ti.tiSession.getPDClient)) {
+    if (!StoreVersion.minTiKVVersion("5.0.0", this.ti.tiSession.getPDClient)) {
       cancel("TiDB version must bigger than 5.0.0")
     }
     tidbStmt.execute("""

--- a/core/src/test/scala/org/apache/spark/sql/insertion/BatchWritePKAndIndexSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/insertion/BatchWritePKAndIndexSuite.scala
@@ -117,7 +117,9 @@ class BatchWritePKAndIndexSuite
   // https://github.com/pingcap/tispark/issues/2452
   test("test duplicate unique indexes are not deleted error") {
     tidbStmt.execute("drop table if exists `tispark_test`.`t`")
-    if (!StoreVersion.isTiKVVersionGreatEqualThanVersion(this.ti.tiSession.getPDClient, "5.0.0")) {
+    if (!StoreVersion.isTiKVVersionGreatEqualThanVersion(
+        this.ti.tiSession.getPDClient,
+        "5.0.0")) {
       cancel("TiDB version must bigger than 5.0.0")
     }
     tidbStmt.execute("""
@@ -165,7 +167,9 @@ class BatchWritePKAndIndexSuite
   // https://github.com/pingcap/tispark/issues/2391
   test("test bug fix incorrect uniqueIndex key when table is not intHandle") {
     tidbStmt.execute("drop table if exists `tispark_test`.`t`")
-    if (!StoreVersion.isTiKVVersionGreatEqualThanVersion(this.ti.tiSession.getPDClient, "5.0.0")) {
+    if (!StoreVersion.isTiKVVersionGreatEqualThanVersion(
+        this.ti.tiSession.getPDClient,
+        "5.0.0")) {
       cancel("TiDB version must bigger than 5.0.0")
     }
     tidbStmt.execute("""

--- a/core/src/test/scala/org/apache/spark/sql/pushdown/CountPushDownSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/pushdown/CountPushDownSuite.scala
@@ -74,7 +74,7 @@ class CountPushDownSuite extends BasePushDownSuite() {
     }
 
     // Count(bit) can push down after 6.0.0
-    if (StoreVersion.isTiKVVersionGreatEqualVersion(ti.tiSession.getPDClient, "6.0.0")) {
+    if (StoreVersion.isTiKVVersionGreatEqualThanVersion(ti.tiSession.getPDClient, "6.0.0")) {
       val query = "select count(tp_bit) from " + tableName
       val df = spark.sql(query)
       if (!extractCoprocessorRDDs(df).head.toString.contains("Aggregates")) {
@@ -86,7 +86,7 @@ class CountPushDownSuite extends BasePushDownSuite() {
     }
 
     // Count(enum) can push down after 5.1.0
-    if (StoreVersion.isTiKVVersionGreatEqualVersion(ti.tiSession.getPDClient, "5.1.0")) {
+    if (StoreVersion.isTiKVVersionGreatEqualThanVersion(ti.tiSession.getPDClient, "5.1.0")) {
       val query = "select count(tp_enum) from " + tableName
       val df = spark.sql(query)
       if (!extractCoprocessorRDDs(df).head.toString.contains("Aggregates")) {
@@ -118,7 +118,7 @@ class CountPushDownSuite extends BasePushDownSuite() {
     }
 
     // Count(bit) can push down after 6.0.0
-    if (StoreVersion.isTiKVVersionGreatEqualVersion(ti.tiSession.getPDClient, "6.0.0")) {
+    if (StoreVersion.isTiKVVersionGreatEqualThanVersion(ti.tiSession.getPDClient, "6.0.0")) {
       val query = "select count(tp_bit) from " + tableName
       val df = spark.sql(query)
       if (!extractCoprocessorRDDs(df).head.toString.contains("Aggregates")) {
@@ -130,7 +130,7 @@ class CountPushDownSuite extends BasePushDownSuite() {
     }
 
     // Count(enum) can push down after 5.1.0
-    if (StoreVersion.isTiKVVersionGreatEqualVersion(ti.tiSession.getPDClient, "5.1.0")) {
+    if (StoreVersion.isTiKVVersionGreatEqualThanVersion(ti.tiSession.getPDClient, "5.1.0")) {
       val query = "select count(tp_enum) from " + tableName
       val df = spark.sql(query)
       if (!extractCoprocessorRDDs(df).head.toString.contains("Aggregates")) {

--- a/core/src/test/scala/org/apache/spark/sql/pushdown/CountPushDownSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/pushdown/CountPushDownSuite.scala
@@ -16,7 +16,7 @@
 
 package org.apache.spark.sql.pushdown
 
-import com.pingcap.tikv.{StoreVersion, Version}
+import com.pingcap.tikv.StoreVersion
 
 /**
  * Count will be pushed down except:
@@ -74,7 +74,7 @@ class CountPushDownSuite extends BasePushDownSuite() {
     }
 
     // Count(bit) can push down after 6.0.0
-    if (StoreVersion.minTiKVVersion("6.0.0", ti.tiSession.getPDClient)) {
+    if (StoreVersion.isTiKVVersionGreatEqualVersion(ti.tiSession.getPDClient, "6.0.0")) {
       val query = "select count(tp_bit) from " + tableName
       val df = spark.sql(query)
       if (!extractCoprocessorRDDs(df).head.toString.contains("Aggregates")) {
@@ -86,7 +86,7 @@ class CountPushDownSuite extends BasePushDownSuite() {
     }
 
     // Count(enum) can push down after 5.1.0
-    if (StoreVersion.minTiKVVersion("5.1.0", ti.tiSession.getPDClient)) {
+    if (StoreVersion.isTiKVVersionGreatEqualVersion(ti.tiSession.getPDClient, "5.1.0")) {
       val query = "select count(tp_enum) from " + tableName
       val df = spark.sql(query)
       if (!extractCoprocessorRDDs(df).head.toString.contains("Aggregates")) {
@@ -118,7 +118,7 @@ class CountPushDownSuite extends BasePushDownSuite() {
     }
 
     // Count(bit) can push down after 6.0.0
-    if (StoreVersion.minTiKVVersion("6.0.0", ti.tiSession.getPDClient)) {
+    if (StoreVersion.isTiKVVersionGreatEqualVersion(ti.tiSession.getPDClient, "6.0.0")) {
       val query = "select count(tp_bit) from " + tableName
       val df = spark.sql(query)
       if (!extractCoprocessorRDDs(df).head.toString.contains("Aggregates")) {
@@ -130,7 +130,7 @@ class CountPushDownSuite extends BasePushDownSuite() {
     }
 
     // Count(enum) can push down after 5.1.0
-    if (StoreVersion.minTiKVVersion("5.1.0", ti.tiSession.getPDClient)) {
+    if (StoreVersion.isTiKVVersionGreatEqualVersion(ti.tiSession.getPDClient, "5.1.0")) {
       val query = "select count(tp_enum) from " + tableName
       val df = spark.sql(query)
       if (!extractCoprocessorRDDs(df).head.toString.contains("Aggregates")) {

--- a/core/src/test/scala/org/apache/spark/sql/test/SharedSQLContext.scala
+++ b/core/src/test/scala/org/apache/spark/sql/test/SharedSQLContext.scala
@@ -170,7 +170,7 @@ trait SharedSQLContext
     // 3.0.x (x >= 14)
     // 3.1.x (x >= 0)
     // >= 4.0.0
-    StoreVersion.isTiKVVersionGreatEqualVersion(ti.tiSession.getPDClient, Version.BATCH_WRITE)
+    StoreVersion.isTiKVVersionGreatEqualThanVersion(ti.tiSession.getPDClient, Version.BATCH_WRITE)
   }
 
   protected def initializeStatement(): Unit = {

--- a/core/src/test/scala/org/apache/spark/sql/test/SharedSQLContext.scala
+++ b/core/src/test/scala/org/apache/spark/sql/test/SharedSQLContext.scala
@@ -18,9 +18,6 @@
 
 package org.apache.spark.sql.test
 
-import java.io.File
-import java.sql.{Connection, Date, Statement}
-import java.util.{Locale, Properties, TimeZone}
 import com.pingcap.tikv.{StoreVersion, TiDBJDBCClient, Version}
 import com.pingcap.tispark.TiDBUtils
 import com.pingcap.tispark.statistics.StatisticsManager
@@ -35,6 +32,9 @@ import org.joda.time.DateTimeZone
 import org.scalatest.concurrent.Eventually
 import org.slf4j.Logger
 
+import java.io.File
+import java.sql.{Connection, Date, Statement}
+import java.util.{Locale, Properties, TimeZone}
 import scala.collection.mutable.ArrayBuffer
 
 /**
@@ -44,7 +44,7 @@ import scala.collection.mutable.ArrayBuffer
  * `tidb_config.properties` must be provided in test resources folder
  */
 trait SharedSQLContext
-    extends SparkFunSuite
+  extends SparkFunSuite
     with Eventually
     with Logging
     with SharedSparkContext {
@@ -170,7 +170,7 @@ trait SharedSQLContext
     // 3.0.x (x >= 14)
     // 3.1.x (x >= 0)
     // >= 4.0.0
-    StoreVersion.minTiKVVersion(Version.BATCH_WRITE, ti.tiSession.getPDClient)
+    StoreVersion.isTiKVVersionGreatEqualVersion(ti.tiSession.getPDClient, Version.BATCH_WRITE)
   }
 
   protected def initializeStatement(): Unit = {
@@ -442,9 +442,9 @@ trait SharedSQLContext
 
         if (_isHiveEnabled) {
           // delete meta store directory to avoid multiple derby instances SPARK-10872
-          import java.io.IOException
-
           import org.apache.commons.io.FileUtils
+
+          import java.io.IOException
           val hiveLocalMetaStorePath = new File("metastore_db")
           try FileUtils.deleteDirectory(hiveLocalMetaStorePath)
           catch {

--- a/core/src/test/scala/org/apache/spark/sql/test/SharedSQLContext.scala
+++ b/core/src/test/scala/org/apache/spark/sql/test/SharedSQLContext.scala
@@ -44,7 +44,7 @@ import scala.collection.mutable.ArrayBuffer
  * `tidb_config.properties` must be provided in test resources folder
  */
 trait SharedSQLContext
-  extends SparkFunSuite
+    extends SparkFunSuite
     with Eventually
     with Logging
     with SharedSparkContext {

--- a/tikv-client/src/main/java/com/pingcap/tikv/StoreVersion.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/StoreVersion.java
@@ -59,7 +59,7 @@ public class StoreVersion {
   }
 
   // return true when every TiKV version >= version
-  public static boolean isTiKVVersionGreatEqualVersion(PDClient pdClient, String version) {
+  public static boolean isTiKVVersionGreatEqualThanVersion(PDClient pdClient, String version) {
     StoreVersion storeVersion = new StoreVersion(version);
 
     BackOffer bo = ConcreteBackOffer.newCustomBackOff(BackOffer.PD_INFO_BACKOFF);

--- a/tikv-client/src/main/java/com/pingcap/tikv/StoreVersion.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/StoreVersion.java
@@ -59,7 +59,7 @@ public class StoreVersion {
   }
 
   // return true when every TiKV version >= version
-  public static boolean minTiKVVersion(String version, PDClient pdClient) {
+  public static boolean isTiKVVersionGreatEqualVersion(PDClient pdClient, String version) {
     StoreVersion storeVersion = new StoreVersion(version);
 
     BackOffer bo = ConcreteBackOffer.newCustomBackOff(BackOffer.PD_INFO_BACKOFF);

--- a/tikv-client/src/main/java/com/pingcap/tikv/region/RegionStoreClient.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/region/RegionStoreClient.java
@@ -130,7 +130,7 @@ public class RegionStoreClient extends AbstractRegionStoreClient {
 
   private synchronized Boolean getIsV4() {
     if (isV4 == null) {
-      isV4 = StoreVersion.isTiKVVersionGreatEqualVersion(pdClient, Version.RESOLVE_LOCK_V4);
+      isV4 = StoreVersion.isTiKVVersionGreatEqualThanVersion(pdClient, Version.RESOLVE_LOCK_V4);
     }
     return isV4;
   }

--- a/tikv-client/src/main/java/com/pingcap/tikv/region/RegionStoreClient.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/region/RegionStoreClient.java
@@ -130,7 +130,7 @@ public class RegionStoreClient extends AbstractRegionStoreClient {
 
   private synchronized Boolean getIsV4() {
     if (isV4 == null) {
-      isV4 = StoreVersion.minTiKVVersion(Version.RESOLVE_LOCK_V4, pdClient);
+      isV4 = StoreVersion.isTiKVVersionGreatEqualVersion(pdClient, Version.RESOLVE_LOCK_V4);
     }
     return isV4;
   }

--- a/tikv-client/src/test/java/com/pingcap/tikv/txn/LockResolverTest.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/txn/LockResolverTest.java
@@ -420,6 +420,6 @@ abstract class LockResolverTest {
   }
 
   boolean supportAsyncCommit() {
-    return StoreVersion.minTiKVVersion(Version.ASYNC_COMMIT, session.getPDClient());
+    return StoreVersion.isTiKVVersionGreatEqualVersion(session.getPDClient(), Version.ASYNC_COMMIT);
   }
 }

--- a/tikv-client/src/test/java/com/pingcap/tikv/txn/LockResolverTest.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/txn/LockResolverTest.java
@@ -420,6 +420,6 @@ abstract class LockResolverTest {
   }
 
   boolean supportAsyncCommit() {
-    return StoreVersion.isTiKVVersionGreatEqualVersion(session.getPDClient(), Version.ASYNC_COMMIT);
+    return StoreVersion.isTiKVVersionGreatEqualThanVersion(session.getPDClient(), Version.ASYNC_COMMIT);
   }
 }

--- a/tikv-client/src/test/java/com/pingcap/tikv/txn/LockResolverTest.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/txn/LockResolverTest.java
@@ -420,6 +420,7 @@ abstract class LockResolverTest {
   }
 
   boolean supportAsyncCommit() {
-    return StoreVersion.isTiKVVersionGreatEqualThanVersion(session.getPDClient(), Version.ASYNC_COMMIT);
+    return StoreVersion.isTiKVVersionGreatEqualThanVersion(
+        session.getPDClient(), Version.ASYNC_COMMIT);
   }
 }


### PR DESCRIPTION
Signed-off-by: qidi1 <1083369179@qq.com>

### What problem does this PR solve? <!--add issue link with summary if exists-->

close: #2479
### What is changed and how it works?

When TiDB version is smaller than `5.0.0`. The `test duplicate unique indexes are not deleted error` and `test bug fix incorrect uniqueIndex key when table is not intHandle` will not run.