### PR TITLE
Fix binary Range column partition test before v5.1.0

### DIFF
--- a/core/src/test/scala/com/pingcap/tispark/partition/PartitionWriteSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/partition/PartitionWriteSuite.scala
@@ -447,7 +447,7 @@ class PartitionWriteSuite extends BaseTiSparkTest {
 
   test("binary type range column replace test") {
     if (StoreVersion.minTiKVVersion("v5.1.0", this.ti.tiSession.getPDClient)) {
-      cancel("Binary range column partition ws supported in TiDB v5.1.0+.")
+      cancel("Binary range column partitioning is supported in TiDB v5.1.0+.")
     }
 
     tidbStmt.execute(

--- a/core/src/test/scala/com/pingcap/tispark/partition/PartitionWriteSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/partition/PartitionWriteSuite.scala
@@ -36,11 +36,6 @@ class PartitionWriteSuite extends BaseTiSparkTest {
     tidbStmt.execute(s"drop table if exists `$database`.`$table`")
   }
 
-  override def afterEach(): Unit = {
-    tidbStmt.execute(s"ADMIN CHECK TABLE `$database`.`$table`")
-    super.afterEach()
-  }
-
   /**
    * hash partition test
    * - append and delete
@@ -93,6 +88,8 @@ class PartitionWriteSuite extends BaseTiSparkTest {
         "p1" -> Array(Array(25), Array(29)),
         "p2" -> Array(),
         "p3" -> Array(Array(35))))
+
+    tidbStmt.execute(s"ADMIN CHECK TABLE `$database`.`$table`")
   }
 
   test("hash partition replace and delete test") {
@@ -186,6 +183,8 @@ class PartitionWriteSuite extends BaseTiSparkTest {
         "p1" -> Array(),
         "p2" -> Array(),
         "p3" -> Array(Array(Date.valueOf("1995-08-08"), "John"))))
+
+    tidbStmt.execute(s"ADMIN CHECK TABLE `$database`.`$table`")
   }
 
   /**
@@ -237,6 +236,8 @@ class PartitionWriteSuite extends BaseTiSparkTest {
     deleteResultSpark.collect() should contain theSameElementsAs Array(Row(65L, "John"))
     checkPartitionJDBCResult(
       Map("p0" -> Array(), "p1" -> Array(), "p2" -> Array(Array(65L, "John"))))
+
+    tidbStmt.execute(s"ADMIN CHECK TABLE `$database`.`$table`")
   }
 
   test("range column replace and delete test") {
@@ -280,6 +281,8 @@ class PartitionWriteSuite extends BaseTiSparkTest {
     deleteResultSpark.collect() should contain theSameElementsAs Array(Row(65L, "John"))
     checkPartitionJDBCResult(
       Map("p0" -> Array(), "p1" -> Array(), "p2" -> Array(Array(65L, "John"))))
+
+    tidbStmt.execute(s"ADMIN CHECK TABLE `$database`.`$table`")
   }
 
   test("dateTime type range column partition replace and delete test") {
@@ -334,6 +337,8 @@ class PartitionWriteSuite extends BaseTiSparkTest {
         "p0" -> Array(),
         "p1" -> Array(Array(LocalDateTime.from(f.parse("1995-08-08 15:15:15")), "John")),
         "p2" -> Array()))
+
+    tidbStmt.execute(s"ADMIN CHECK TABLE `$database`.`$table`")
   }
 
   test("date type range column partition replace and delete test") {
@@ -387,6 +392,8 @@ class PartitionWriteSuite extends BaseTiSparkTest {
         "p0" -> Array(),
         "p1" -> Array(Array(Date.valueOf("1995-08-08"), "John")),
         "p2" -> Array()))
+
+    tidbStmt.execute(s"ADMIN CHECK TABLE `$database`.`$table`")
   }
 
   test("varbinary type range column replace test") {
@@ -434,6 +441,8 @@ class PartitionWriteSuite extends BaseTiSparkTest {
     } should contain theSameElementsAs Array(Row(65L, "John"))
     checkPartitionJDBCResult(
       Map("p0" -> Array(), "p1" -> Array(Array(65L, "John")), "p2" -> Array()))
+
+    tidbStmt.execute(s"ADMIN CHECK TABLE `$database`.`$table`")
   }
 
   test("binary type range column replace test") {
@@ -488,6 +497,8 @@ class PartitionWriteSuite extends BaseTiSparkTest {
     } should contain theSameElementsAs Array(Row(65L, "John\u0000\u0000"))
     checkPartitionJDBCResult(
       Map("p0" -> Array(), "p1" -> Array(Array(65L, "John\u0000\u0000")), "p2" -> Array()))
+
+    tidbStmt.execute(s"ADMIN CHECK TABLE `$database`.`$table`")
   }
 
   /**
@@ -536,6 +547,8 @@ class PartitionWriteSuite extends BaseTiSparkTest {
     deleteResultSpark.collect() should contain theSameElementsAs Array(Row(65L, "John"))
     checkPartitionJDBCResult(
       Map("p0" -> Array(), "p1" -> Array(), "p2" -> Array(Array(65L, "John"))))
+
+    tidbStmt.execute(s"ADMIN CHECK TABLE `$database`.`$table`")
   }
 
   test("range replace and delete test") {
@@ -578,6 +591,8 @@ class PartitionWriteSuite extends BaseTiSparkTest {
     deleteResultSpark.collect() should contain theSameElementsAs Array(Row(65L, "John"))
     checkPartitionJDBCResult(
       Map("p0" -> Array(), "p1" -> Array(), "p2" -> Array(Array(65L, "John"))))
+
+    tidbStmt.execute(s"ADMIN CHECK TABLE `$database`.`$table`")
   }
 
   test("range YEAR() partition replace and delete test") {
@@ -632,6 +647,7 @@ class PartitionWriteSuite extends BaseTiSparkTest {
         "p1" -> Array(Array(Date.valueOf("1995-08-08"), "John")),
         "p2" -> Array()))
 
+    tidbStmt.execute(s"ADMIN CHECK TABLE `$database`.`$table`")
   }
 
   test("unsupported function UNIX_TIMESTAMP() and range partition replace and delete test") {

--- a/core/src/test/scala/com/pingcap/tispark/partition/PartitionWriteSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/partition/PartitionWriteSuite.scala
@@ -16,6 +16,7 @@
 
 package com.pingcap.tispark.partition
 
+import com.pingcap.tikv.StoreVersion
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.{BaseTiSparkTest, Row}
@@ -436,6 +437,10 @@ class PartitionWriteSuite extends BaseTiSparkTest {
   }
 
   test("binary type range column replace test") {
+    if (StoreVersion.minTiKVVersion("v5.1.0", this.ti.tiSession.getPDClient)) {
+      cancel("Binary range column partition ws supported in TiDB v5.1.0+.")
+    }
+
     tidbStmt.execute(
       s"create table `$database`.`$table` (id bigint, name binary(6) unique key) partition by range columns(name) (" +
         s"partition p0 values less than (X'424242424242')," +


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

Binary Range column partition is not supported before TiDBv5.1.0

### What is changed and how it works?

- Check TiDB version when test
- Admin check when table is exists
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test
