### PR TITLE
Fix cacheInvalidateCallback does not work ref #1209

### DIFF
--- a/core/src/test/scala/com/pingcap/tispark/accumulator/AccumulatorSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/accumulator/AccumulatorSuite.scala
@@ -1,22 +1,38 @@
+/*
+ *
+ * Copyright 2022 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package com.pingcap.tispark.accumulator;
 
 import org.apache.log4j.spi.LoggingEvent
 import org.apache.log4j.{AppenderSkeleton, Logger}
 import org.apache.spark.sql.BaseTiSparkTest
-import org.apache.spark.sql.test.SharedSQLContext
 
 import java.util
 import java.util.stream.Collectors;
 
-class AccumulatorSuite extends BaseTiSparkTest{
+class AccumulatorSuite extends BaseTiSparkTest {
   test("cacheInvalidateCallback does not work") {
     val listLogAppender = new ListLogAppender
     val logger = Logger.getRootLogger
     logger.addAppender(listLogAppender)
     try {
       tidbStmt.execute("DROP TABLE IF EXISTS `t1`")
-      tidbStmt.execute(
-        """
+      tidbStmt.execute("""
           |CREATE TABLE `t1` (
           |`a` BIGINT(20)  NOT NULL,
           |`b` varchar(255) NOT NULL,
@@ -30,9 +46,10 @@ class AccumulatorSuite extends BaseTiSparkTest{
     } finally {
       logger.removeAppender(listLogAppender)
     }
-    val pdCacheInvalidateListenerLog = listLogAppender.getLog.stream().filter(
-      e => e.getLoggerName == "com.pingcap.tispark.listener.PDCacheInvalidateListener").
-      collect(Collectors.toList[LoggingEvent])
+    val pdCacheInvalidateListenerLog = listLogAppender.getLog
+      .stream()
+      .filter(e => e.getLoggerName == "com.pingcap.tispark.listener.PDCacheInvalidateListener")
+      .collect(Collectors.toList[LoggingEvent])
     assert(pdCacheInvalidateListenerLog.size() == 1)
   }
 
@@ -46,8 +63,7 @@ class AccumulatorSuite extends BaseTiSparkTest{
       log.add(loggingEvent)
     }
 
-    override def close(): Unit = {
-    }
+    override def close(): Unit = {}
 
     def getLog = new util.ArrayList[LoggingEvent](log)
   }

--- a/core/src/test/scala/com/pingcap/tispark/accumulator/AccumulatorSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/accumulator/AccumulatorSuite.scala
@@ -32,8 +32,7 @@ class AccumulatorSuite extends BaseTiSparkTest {
     logger.addAppender(listLogAppender)
     try {
       tidbStmt.execute("DROP TABLE IF EXISTS `t1`")
-      tidbStmt.execute(
-        """
+      tidbStmt.execute("""
           |CREATE TABLE `t1` (
           |`a` BIGINT(20)  NOT NULL,
           |`b` varchar(255) NOT NULL,

--- a/core/src/test/scala/com/pingcap/tispark/accumulator/AccumulatorSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/accumulator/AccumulatorSuite.scala
@@ -1,0 +1,54 @@
+package com.pingcap.tispark.accumulator;
+
+import org.apache.log4j.spi.LoggingEvent
+import org.apache.log4j.{AppenderSkeleton, Logger}
+import org.apache.spark.sql.BaseTiSparkTest
+import org.apache.spark.sql.test.SharedSQLContext
+
+import java.util
+import java.util.stream.Collectors;
+
+class AccumulatorSuite extends BaseTiSparkTest{
+  test("cacheInvalidateCallback does not work") {
+    val listLogAppender = new ListLogAppender
+    val logger = Logger.getRootLogger
+    logger.addAppender(listLogAppender)
+    try {
+      tidbStmt.execute("DROP TABLE IF EXISTS `t1`")
+      tidbStmt.execute(
+        """
+          |CREATE TABLE `t1` (
+          |`a` BIGINT(20)  NOT NULL,
+          |`b` varchar(255) NOT NULL,
+          |`c` varchar(255) DEFAULT NULL
+          |) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
+              """.stripMargin)
+      spark.sql("SELECT * FROM t1 where a>0 and b > 'aa'").show()
+      tidbStmt.execute(
+        "SPLIT TABLE t1 BETWEEN (-9223372036854775808) AND (-8223372036854775808) REGIONS 300")
+      spark.sql("SELECT * FROM t1 where a>0 and b > 'aa'").show()
+    } finally {
+      logger.removeAppender(listLogAppender)
+    }
+    val pdCacheInvalidateListenerLog = listLogAppender.getLog.stream().filter(
+      e => e.getLoggerName == "com.pingcap.tispark.listener.PDCacheInvalidateListener").
+      collect(Collectors.toList[LoggingEvent])
+    assert(pdCacheInvalidateListenerLog.size() == 1)
+  }
+
+  class ListLogAppender extends AppenderSkeleton {
+
+    final private val log = new util.ArrayList[LoggingEvent]()
+
+    override def requiresLayout = false
+
+    override protected def append(loggingEvent: LoggingEvent): Unit = {
+      log.add(loggingEvent)
+    }
+
+    override def close(): Unit = {
+    }
+
+    def getLog = new util.ArrayList[LoggingEvent](log)
+  }
+}

--- a/core/src/test/scala/com/pingcap/tispark/accumulator/AccumulatorSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/accumulator/AccumulatorSuite.scala
@@ -32,17 +32,18 @@ class AccumulatorSuite extends BaseTiSparkTest {
     logger.addAppender(listLogAppender)
     try {
       tidbStmt.execute("DROP TABLE IF EXISTS `t1`")
-      tidbStmt.execute("""
+      tidbStmt.execute(
+        """
           |CREATE TABLE `t1` (
           |`a` BIGINT(20)  NOT NULL,
           |`b` varchar(255) NOT NULL,
           |`c` varchar(255) DEFAULT NULL
           |) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
               """.stripMargin)
-      spark.sql("SELECT * FROM t1 where a>0 and b > 'aa'").show()
+      spark.sql("SELECT * FROM t1").show()
       tidbStmt.execute(
         "SPLIT TABLE t1 BETWEEN (-9223372036854775808) AND (-8223372036854775808) REGIONS 300")
-      spark.sql("SELECT * FROM t1 where a>0 and b > 'aa'").show()
+      spark.sql("SELECT * FROM t1").show()
     } finally {
       logger.removeAppender(listLogAppender)
     }

--- a/core/src/test/scala/org/apache/spark/sql/catalyst/plans/logical/LogicalPlanTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/catalyst/plans/logical/LogicalPlanTestSuite.scala
@@ -24,12 +24,15 @@ import com.pingcap.tikv.meta.TiColumnInfo.InternalTypeHolder
 import com.pingcap.tikv.meta.{TiDAGRequest, TiTimestamp}
 import com.pingcap.tikv.types.{DataType, DataTypeFactory, IntegerType, MySQLType}
 import com.pingcap.tispark.telemetry.TiSparkTeleInfo
+import org.apache.log4j.spi.LoggingEvent
+import org.apache.log4j.{AppenderSkeleton, Logger}
 import org.apache.spark.sql.catalyst.plans.BasePlanTest
 import org.apache.spark.sql.execution.{ExplainMode, SimpleMode}
 import org.scalatest.Matchers.{be, contain, convertToAnyShouldWrapper}
 import org.tikv.kvproto.Coprocessor
 
 import java.util
+import java.util.stream.Collectors
 
 class LogicalPlanTestSuite extends BasePlanTest {
 

--- a/tikv-client/src/main/java/com/pingcap/tikv/TiSession.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/TiSession.java
@@ -341,6 +341,8 @@ public class TiSession implements AutoCloseable {
    */
   public void injectCallBackFunc(Function<CacheInvalidateEvent, Void> callBackFunc) {
     this.cacheInvalidateCallback = callBackFunc;
+    RegionManager manager = this.getRegionManager();
+    manager.setCacheInvalidateCallback(callBackFunc);
   }
 
   /**

--- a/tikv-client/src/main/java/com/pingcap/tikv/region/RegionManager.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/region/RegionManager.java
@@ -52,7 +52,7 @@ public class RegionManager {
   // https://github.com/pingcap/tispark/issues/1170
   private final RegionCache cache;
 
-  private final Function<CacheInvalidateEvent, Void> cacheInvalidateCallback;
+  private Function<CacheInvalidateEvent, Void> cacheInvalidateCallback;
 
   // To avoid double retrieval, we used the async version of grpc
   // When rpc not returned, instead of call again, it wait for previous one done
@@ -67,7 +67,12 @@ public class RegionManager {
     this.cacheInvalidateCallback = null;
   }
 
-  public Function<CacheInvalidateEvent, Void> getCacheInvalidateCallback() {
+  public synchronized void setCacheInvalidateCallback(
+      Function<CacheInvalidateEvent, Void> cacheInvalidateCallback) {
+    this.cacheInvalidateCallback = cacheInvalidateCallback;
+  }
+
+  public synchronized Function<CacheInvalidateEvent, Void> getCacheInvalidateCallback() {
     return cacheInvalidateCallback;
   }
 


### PR DESCRIPTION
Signed-off-by: qidi1 <1083369179@qq.com>

### What problem does this PR solve? <!--add issue link with summary if exists-->
The original process is shown as below.
```scala
  CacheInvalidateListener
    .initCacheListener(sparkSession.sparkContext, tiSession.getRegionManager)
  tiSession.injectCallBackFunc(CacheInvalidateListener.getInstance())
```
Firstly, call the `getRegionManager` method, `regionManager` is initialized in singleton mode. 
```java
  public synchronized RegionManager getRegionManager() {
    RegionManager res = regionManager;
    if (res == null) {
      synchronized (this) {
        if (regionManager == null) {
          regionManager = new RegionManager(getPDClient(), this.cacheInvalidateCallback);
        }
        res = regionManager;
      }
    }
    return res;
  }
```
Then, call the `injectCallBackFunc` method and initialize `cacheInvalidateCallback`,  but `regionManager` is already initialized. So the `cacheInvaildCallback` cannot be passed into the `regionManager`.
```java
  public void injectCallBackFunc(Function<CacheInvalidateEvent, Void> callBackFunc) {
    this.cacheInvalidateCallback = callBackFunc;
  }
```
### What is changed and how it works?
Add `setCacheInvalidateCallback` method in `RegionManager` , and call the method in `injectCallBackFunc`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test
