### PR TITLE
fix bug exception will be throw when date col is not the first col ref #2537

### DIFF
--- a/core/src/test/scala/com/pingcap/tispark/partition/PartitionWriteSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/partition/PartitionWriteSuite.scala
@@ -652,6 +652,57 @@ class PartitionWriteSuite extends BaseTiSparkTest {
     tidbStmt.execute(s"ADMIN CHECK TABLE `$database`.`$table`")
   }
 
+  test("test Year() partition when date type is not the first column") {
+    tidbStmt.execute(
+      s"create table `$database`.`$table` (name varchar(16), birthday date primary key ) partition by range(YEAR(birthday)) (" +
+        s"partition p0 values less than (1995)," +
+        s"partition p1 values less than (YEAR('1997-01-01'))," +
+        s"partition p2 values less than MAXVALUE)")
+    val data: RDD[Row] = sc.makeRDD(
+      List(
+        "Luo", Row(Date.valueOf("1995-06-15")),
+        "John", Row(Date.valueOf("1995-08-08")),
+        "Jack", Row(Date.valueOf("1993-08-22")),
+        "Mike", Row(Date.valueOf("1999-06-04"))
+      ))
+    val schema: StructType =
+      StructType(List(StructField("name", StringType), StructField("birthday", DateType)))
+    val df = sqlContext.createDataFrame(data, schema)
+    df.write
+      .format("tidb")
+      .options(tidbOptions)
+      .option("database", database)
+      .option("table", table)
+      .mode("append")
+      .save()
+    val insertResultSpark = spark.sql(s"select * from `tidb_catalog`.`$database`.`$table`")
+    insertResultSpark.collect() should contain theSameElementsAs Array(
+      "Luo", Row(Date.valueOf("1995-06-15")),
+      "John", Row(Date.valueOf("1995-08-08")),
+      "Jack", Row(Date.valueOf("1993-08-22")),
+      "Mike", Row(Date.valueOf("1999-06-04")))
+    checkPartitionJDBCResult(
+      Map(
+        "p0" -> Array(Array("Jack", Date.valueOf("1993-08-22"))),
+        "p1" -> Array(
+          Array("Luo", Date.valueOf("1995-06-15")),
+          Array("John", Date.valueOf("1995-08-08"))),
+        "p2" -> Array("Mike", Array(Date.valueOf("1999-06-04")))))
+    spark.sql(
+      s"delete from `tidb_catalog`.`$database`.`$table` where birthday <= '1995-06-15' or name = 'Mike'")
+
+    val deleteResultSpark = spark.sql(s"select * from `tidb_catalog`.`$database`.`$table`")
+    deleteResultSpark.collect() should contain theSameElementsAs Array(
+      Row("John", Date.valueOf("1995-08-08")))
+    checkPartitionJDBCResult(
+      Map(
+        "p0" -> Array(),
+        "p1" -> Array(Array("John", Date.valueOf("1995-08-08"))),
+        "p2" -> Array()))
+
+    tidbStmt.execute(s"ADMIN CHECK TABLE `$database`.`$table`")
+  }
+
   test("unsupported function UNIX_TIMESTAMP() and range partition replace and delete test") {
     tidbStmt.execute(
       s"create table `$database`.`$table` (birthday timestamp primary key , name varchar(16)) partition by range(UNIX_TIMESTAMP(birthday)) (" +

--- a/tikv-client/src/main/java/com/pingcap/tikv/expression/visitor/RangePartitionLocator.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/expression/visitor/RangePartitionLocator.java
@@ -59,9 +59,10 @@ public class RangePartitionLocator extends DefaultVisitor<Boolean, PartitionLoca
         Expression expression = left.getChildren().get(0);
         ColumnRef columnRef = (ColumnRef) expression;
         columnRef.resolve(tableInfo);
-        data = partitionFuncExpr.eval(
-                Constant.create(row.get(columnRef.getColumnOffset(), DateType.DATE)))
-            .getValue();
+        data =
+            partitionFuncExpr
+                .eval(Constant.create(row.get(columnRef.getColumnOffset(), DateType.DATE)))
+                .getValue();
       } else {
         throw new UnsupportedOperationException("Partition write only support YEAR() function");
       }

--- a/tikv-client/src/main/java/com/pingcap/tikv/expression/visitor/RangePartitionLocator.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/expression/visitor/RangePartitionLocator.java
@@ -56,7 +56,12 @@ public class RangePartitionLocator extends DefaultVisitor<Boolean, PartitionLoca
       // TODO: support more function partition
       FuncCallExpr partitionFuncExpr = (FuncCallExpr) left;
       if (partitionFuncExpr.getFuncTp() == YEAR) {
-        data = partitionFuncExpr.eval(Constant.create(row.getDate(0), DateType.DATE)).getValue();
+        Expression expression = left.getChildren().get(0);
+        ColumnRef columnRef = (ColumnRef) expression;
+        columnRef.resolve(tableInfo);
+        data = partitionFuncExpr.eval(
+                Constant.create(row.get(columnRef.getColumnOffset(), DateType.DATE)))
+            .getValue();
       } else {
         throw new UnsupportedOperationException("Partition write only support YEAR() function");
       }


### PR DESCRIPTION
Signed-off-by: qidi1 <1083369179@qq.com>

### What problem does this PR solve? <!--add issue link with summary if exists-->
* Close https://github.com/pingcap/tispark/issues/2537

### What is changed and how it works?
When we insert data into a table which is partitioned by Year. The old code will always use 0 as a col offset to get the date value. When the date type is not the first col, the exception will be thrown out.
Now, we use date col offset in columnRef insert of 0 as the offset to get the date value.  

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test
