### PR TITLE
Release 2.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file.
 
 - Fix the bug that single column condition is in the incorrect if branch [#2393](https://github.com/pingcap/tispark/pull/2393).
 - Fix region may be missed with too many tables [#2442](https://github.com/pingcap/tispark/pull/2442).
-- Fix count can not be pushed down bug [#2468](https://github.com/pingcap/tispark/pull/2468) [#2483](https://github.com/pingcap/tispark/pull/2483)
+- Fix the bug that count can not be pushed down [#2468](https://github.com/pingcap/tispark/pull/2468) [#2483](https://github.com/pingcap/tispark/pull/2483)
 
 ## [TiSpark 2.4.3] 2022-01-25
 ### New feature

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 # TiSpark Changelog
 All notable changes to this project will be documented in this file.
 
+## [TiSpark 2.4.4] 2022-10-09
+
+### Compatibility Changes
+
+- We will not provide the mysql-connector-java dependency because of the limit of the GPL license [#2460](https://github.com/pingcap/tispark/pull/2460).
+
+### Fixes
+
+- Fix the bug that single column condition is in the incorrect if branch [#2393](https://github.com/pingcap/tispark/pull/2393).
+- Fix region may be missed with too many tables [#2442](https://github.com/pingcap/tispark/pull/2442).
+- Fix count can not be pushed down bug [#2468](https://github.com/pingcap/tispark/pull/2468) [#2483](https://github.com/pingcap/tispark/pull/2483)
+
 ## [TiSpark 2.4.3] 2022-01-25
 ### New feature
 -  scala 2.11 and 2.12 are both supported

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -4,12 +4,12 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.pingcap.tispark</groupId>
-        <artifactId>tispark-parent</artifactId>
-        <version>2.4.4-SNAPSHOT</version>
+        <artifactId>tispark-parent_${scala.binary.version}</artifactId>
+        <version>2.4.4-scala_${scala.binary.version}-snapshot</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <artifactId>tispark-assembly-${spark.version.release}_${scala.binary.version}</artifactId>
+    <artifactId>tispark-assembly</artifactId>
     <packaging>pom</packaging>
     <name>TiSpark Project Assembly</name>
     <url>http://github.copm/pingcap/tispark</url>

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -4,12 +4,12 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.pingcap.tispark</groupId>
-        <artifactId>tispark-parent_${scala.binary.version}</artifactId>
-        <version>2.4.4-scala_${scala.binary.version}-snapshot</version>
+        <artifactId>tispark-parent</artifactId>
+        <version>2.4.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <artifactId>tispark-assembly</artifactId>
+    <artifactId>tispark-assembly-${spark.version.release}_${scala.binary.version}</artifactId>
     <packaging>pom</packaging>
     <name>TiSpark Project Assembly</name>
     <url>http://github.copm/pingcap/tispark</url>

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.pingcap.tispark</groupId>
         <artifactId>tispark-parent_${scala.binary.version}</artifactId>
-        <version>2.4.4-scala_${scala.binary.version}-snapshot</version>
+        <version>2.4.4-scala_${scala.binary.version}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core-test/pom.xml
+++ b/core-test/pom.xml
@@ -4,8 +4,8 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.pingcap.tispark</groupId>
-        <artifactId>tispark-parent_${scala.binary.version}</artifactId>
-        <version>2.4.4-scala_${scala.binary.version}-snapshot</version>
+        <artifactId>tispark-parent</artifactId>
+        <version>2.4.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core-test/pom.xml
+++ b/core-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.pingcap.tispark</groupId>
         <artifactId>tispark-parent_${scala.binary.version}</artifactId>
-        <version>2.4.4-scala_${scala.binary.version}-snapshot</version>
+        <version>2.4.4-scala_${scala.binary.version}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core-test/pom.xml
+++ b/core-test/pom.xml
@@ -4,8 +4,8 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.pingcap.tispark</groupId>
-        <artifactId>tispark-parent</artifactId>
-        <version>2.4.4-SNAPSHOT</version>
+        <artifactId>tispark-parent_${scala.binary.version}</artifactId>
+        <version>2.4.4-scala_${scala.binary.version}-snapshot</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -4,8 +4,8 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.pingcap.tispark</groupId>
-        <artifactId>tispark-parent_${scala.binary.version}</artifactId>
-        <version>2.4.4-scala_${scala.binary.version}-snapshot</version>
+        <artifactId>tispark-parent</artifactId>
+        <version>2.4.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.pingcap.tispark</groupId>
         <artifactId>tispark-parent_${scala.binary.version}</artifactId>
-        <version>2.4.4-scala_${scala.binary.version}-snapshot</version>
+        <version>2.4.4-scala_${scala.binary.version}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -4,8 +4,8 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.pingcap.tispark</groupId>
-        <artifactId>tispark-parent</artifactId>
-        <version>2.4.4-SNAPSHOT</version>
+        <artifactId>tispark-parent_${scala.binary.version}</artifactId>
+        <version>2.4.4-scala_${scala.binary.version}-snapshot</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/scripts/version.sh
+++ b/core/scripts/version.sh
@@ -16,7 +16,7 @@
 
 TISPARK_HOME="$(cd "`dirname "$0"`"/../..; pwd)"
 
-TiSparkReleaseVersion=2.4.4-snapshot
+TiSparkReleaseVersion=2.4.4
 TiSparkBuildTS=`date -u '+%Y-%m-%d %I:%M:%S'`
 TiSparkGitHash=`git rev-parse HEAD`
 TiSparkGitBranch=`git rev-parse --abbrev-ref HEAD`

--- a/db-random-test/pom.xml
+++ b/db-random-test/pom.xml
@@ -4,8 +4,8 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.pingcap.tispark</groupId>
-        <artifactId>tispark-parent_${scala.binary.version}</artifactId>
-        <version>2.4.4-scala_${scala.binary.version}-snapshot</version>
+        <artifactId>tispark-parent</artifactId>
+        <version>2.4.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/db-random-test/pom.xml
+++ b/db-random-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.pingcap.tispark</groupId>
         <artifactId>tispark-parent_${scala.binary.version}</artifactId>
-        <version>2.4.4-scala_${scala.binary.version}-snapshot</version>
+        <version>2.4.4-scala_${scala.binary.version}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/db-random-test/pom.xml
+++ b/db-random-test/pom.xml
@@ -4,8 +4,8 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.pingcap.tispark</groupId>
-        <artifactId>tispark-parent</artifactId>
-        <version>2.4.4-SNAPSHOT</version>
+        <artifactId>tispark-parent_${scala.binary.version}</artifactId>
+        <version>2.4.4-scala_${scala.binary.version}-snapshot</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,8 +9,8 @@
     </parent>
 
     <groupId>com.pingcap.tispark</groupId>
-    <artifactId>tispark-parent_${scala.binary.version}</artifactId>
-    <version>2.4.4-scala_${scala.binary.version}-snapshot</version>
+    <artifactId>tispark-parent</artifactId>
+    <version>2.4.4-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>TiSpark Project Parent POM</name>
     <url>http://github.copm/pingcap/tispark</url>
@@ -72,6 +72,7 @@
         <protobuf.version>3.1.0</protobuf.version>
         <spark.version.compile>2.4.6</spark.version.compile>
         <spark.version.test>2.4.6</spark.version.test>
+        <spark.version.release>2.4</spark.version.release>
         <!-- for now, not running scalafmt as part of default verify pipeline -->
         <scalafmt.skip>true</scalafmt.skip>
         <scalatest.version>3.0.8</scalatest.version>
@@ -86,6 +87,8 @@
         <test.exclude.tags/>
         <test.include.tags/>
         <scalaj.version>2.3.0</scalaj.version>
+        <scala.version>2.12.10</scala.version>
+        <scala.binary.version>2.12</scala.binary.version>
     </properties>
     <repositories>
         <repository>
@@ -209,6 +212,7 @@
             <properties>
                 <spark.version.compile>2.3.4</spark.version.compile>
                 <spark.version.test>2.3.4</spark.version.test>
+                <spark.version.release>2.3</spark.version.release>
             </properties>
         </profile>
         <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -9,8 +9,8 @@
     </parent>
 
     <groupId>com.pingcap.tispark</groupId>
-    <artifactId>tispark-parent</artifactId>
-    <version>2.4.4-SNAPSHOT</version>
+    <artifactId>tispark-parent_${scala.binary.version}</artifactId>
+    <version>2.4.4-scala_${scala.binary.version}-snapshot</version>
     <packaging>pom</packaging>
     <name>TiSpark Project Parent POM</name>
     <url>http://github.copm/pingcap/tispark</url>
@@ -72,7 +72,6 @@
         <protobuf.version>3.1.0</protobuf.version>
         <spark.version.compile>2.4.6</spark.version.compile>
         <spark.version.test>2.4.6</spark.version.test>
-        <spark.version.release>2.4</spark.version.release>
         <!-- for now, not running scalafmt as part of default verify pipeline -->
         <scalafmt.skip>true</scalafmt.skip>
         <scalatest.version>3.0.8</scalatest.version>
@@ -87,8 +86,6 @@
         <test.exclude.tags/>
         <test.include.tags/>
         <scalaj.version>2.3.0</scalaj.version>
-        <scala.version>2.12.10</scala.version>
-        <scala.binary.version>2.12</scala.binary.version>
     </properties>
     <repositories>
         <repository>
@@ -212,7 +209,6 @@
             <properties>
                 <spark.version.compile>2.3.4</spark.version.compile>
                 <spark.version.test>2.3.4</spark.version.test>
-                <spark.version.release>2.3</spark.version.release>
             </properties>
         </profile>
         <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>com.pingcap.tispark</groupId>
     <artifactId>tispark-parent_${scala.binary.version}</artifactId>
-    <version>2.4.4-scala_${scala.binary.version}-snapshot</version>
+    <version>2.4.4-scala_${scala.binary.version}</version>
     <packaging>pom</packaging>
     <name>TiSpark Project Parent POM</name>
     <url>http://github.copm/pingcap/tispark</url>

--- a/pom.xml
+++ b/pom.xml
@@ -70,8 +70,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <protobuf.version>3.1.0</protobuf.version>
-        <spark.version.compile>2.4.6</spark.version.compile>
-        <spark.version.test>2.4.6</spark.version.test>
+        <spark.version.compile>2.4.8</spark.version.compile>
+        <spark.version.test>2.4.8</spark.version.test>
         <!-- for now, not running scalafmt as part of default verify pipeline -->
         <scalafmt.skip>true</scalafmt.skip>
         <scalatest.version>3.0.8</scalatest.version>

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,8 @@
         <test.exclude.tags/>
         <test.include.tags/>
         <scalaj.version>2.3.0</scalaj.version>
+        <scala.binary.version>2.12</scala.binary.version>
+        <scala.version>2.12.10</scala.version>
     </properties>
     <repositories>
         <repository>

--- a/spark-wrapper/spark-2.3/pom.xml
+++ b/spark-wrapper/spark-2.3/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.pingcap.tispark</groupId>
         <artifactId>tispark-parent_${scala.binary.version}</artifactId>
-        <version>2.4.4-scala_${scala.binary.version}-snapshot</version>
+        <version>2.4.4-scala_${scala.binary.version}</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/spark-wrapper/spark-2.3/pom.xml
+++ b/spark-wrapper/spark-2.3/pom.xml
@@ -4,12 +4,12 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.pingcap.tispark</groupId>
-        <artifactId>tispark-parent</artifactId>
-        <version>2.4.4-SNAPSHOT</version>
+        <artifactId>tispark-parent_${scala.binary.version}</artifactId>
+        <version>2.4.4-scala_${scala.binary.version}-snapshot</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
-    <artifactId>spark-wrapper-spark-2.3_${scala.binary.version}</artifactId>
+    <artifactId>spark-wrapper-spark-2.3</artifactId>
     <packaging>jar</packaging>
     <name>TiSpark Project Spark Wrapper Spark-2.3</name>
     <url>http://github.copm/pingcap/tispark</url>

--- a/spark-wrapper/spark-2.3/pom.xml
+++ b/spark-wrapper/spark-2.3/pom.xml
@@ -4,12 +4,12 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.pingcap.tispark</groupId>
-        <artifactId>tispark-parent_${scala.binary.version}</artifactId>
-        <version>2.4.4-scala_${scala.binary.version}-snapshot</version>
+        <artifactId>tispark-parent</artifactId>
+        <version>2.4.4-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
-    <artifactId>spark-wrapper-spark-2.3</artifactId>
+    <artifactId>spark-wrapper-spark-2.3_${scala.binary.version}</artifactId>
     <packaging>jar</packaging>
     <name>TiSpark Project Spark Wrapper Spark-2.3</name>
     <url>http://github.copm/pingcap/tispark</url>

--- a/spark-wrapper/spark-2.4/pom.xml
+++ b/spark-wrapper/spark-2.4/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.pingcap.tispark</groupId>
         <artifactId>tispark-parent_${scala.binary.version}</artifactId>
-        <version>2.4.4-scala_${scala.binary.version}-snapshot</version>
+        <version>2.4.4-scala_${scala.binary.version}</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/spark-wrapper/spark-2.4/pom.xml
+++ b/spark-wrapper/spark-2.4/pom.xml
@@ -4,12 +4,12 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.pingcap.tispark</groupId>
-        <artifactId>tispark-parent</artifactId>
-        <version>2.4.4-SNAPSHOT</version>
+        <artifactId>tispark-parent_${scala.binary.version}</artifactId>
+        <version>2.4.4-scala_${scala.binary.version}-snapshot</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
-    <artifactId>spark-wrapper-spark-2.4_${scala.binary.version}</artifactId>
+    <artifactId>spark-wrapper-spark-2.4</artifactId>
     <packaging>jar</packaging>
     <name>TiSpark Project Spark Wrapper Spark-2.4</name>
     <url>http://github.copm/pingcap/tispark</url>

--- a/spark-wrapper/spark-2.4/pom.xml
+++ b/spark-wrapper/spark-2.4/pom.xml
@@ -4,12 +4,12 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.pingcap.tispark</groupId>
-        <artifactId>tispark-parent_${scala.binary.version}</artifactId>
-        <version>2.4.4-scala_${scala.binary.version}-snapshot</version>
+        <artifactId>tispark-parent</artifactId>
+        <version>2.4.4-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
-    <artifactId>spark-wrapper-spark-2.4</artifactId>
+    <artifactId>spark-wrapper-spark-2.4_${scala.binary.version}</artifactId>
     <packaging>jar</packaging>
     <name>TiSpark Project Spark Wrapper Spark-2.4</name>
     <url>http://github.copm/pingcap/tispark</url>

--- a/tikv-client/pom.xml
+++ b/tikv-client/pom.xml
@@ -4,8 +4,8 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.pingcap.tispark</groupId>
-        <artifactId>tispark-parent_${scala.binary.version}</artifactId>
-        <version>2.4.4-scala_${scala.binary.version}-snapshot</version>
+        <artifactId>tispark-parent</artifactId>
+        <version>2.4.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tikv-client/pom.xml
+++ b/tikv-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.pingcap.tispark</groupId>
         <artifactId>tispark-parent_${scala.binary.version}</artifactId>
-        <version>2.4.4-scala_${scala.binary.version}-snapshot</version>
+        <version>2.4.4-scala_${scala.binary.version}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tikv-client/pom.xml
+++ b/tikv-client/pom.xml
@@ -4,8 +4,8 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.pingcap.tispark</groupId>
-        <artifactId>tispark-parent</artifactId>
-        <version>2.4.4-SNAPSHOT</version>
+        <artifactId>tispark-parent_${scala.binary.version}</artifactId>
+        <version>2.4.4-scala_${scala.binary.version}-snapshot</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
1. Bump Spark version from 2.4.6 to 2.4.8
2. Set a default scala version (2.12) .
3. alter the version to 2.4.4
4. add changelog
