### PR TITLE
Partition write support new collations

### DIFF
--- a/core/src/test/scala/com/pingcap/tispark/partition/PartitionBaseSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/partition/PartitionBaseSuite.scala
@@ -21,7 +21,7 @@ import org.scalatest.Matchers.{contain, convertToAnyShouldWrapper}
 
 import java.sql.ResultSet
 
-class PartitionBaseSuite extends BaseTiSparkTest{
+class PartitionBaseSuite extends BaseTiSparkTest {
 
   val table: String = "test_partition_write"
   val database: String = "tispark_test"

--- a/core/src/test/scala/com/pingcap/tispark/partition/PartitionBaseSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/partition/PartitionBaseSuite.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.pingcap.tispark.partition
 
 import org.apache.spark.sql.BaseTiSparkTest

--- a/core/src/test/scala/com/pingcap/tispark/partition/PartitionBaseSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/partition/PartitionBaseSuite.scala
@@ -1,0 +1,41 @@
+package com.pingcap.tispark.partition
+
+import org.apache.spark.sql.BaseTiSparkTest
+import org.scalatest.Matchers.{contain, convertToAnyShouldWrapper}
+
+import java.sql.ResultSet
+
+class PartitionBaseSuite extends BaseTiSparkTest{
+
+  val table: String = "test_partition_write"
+  val database: String = "tispark_test"
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    tidbStmt.execute(s"drop table if exists `$database`.`$table`")
+  }
+
+  protected def checkPartitionJDBCResult(expected: Map[String, Array[Array[Any]]]) = {
+    for ((partition, result) <- expected) {
+      val insertResultJDBC =
+        tidbStmt.executeQuery(s"select * from `$database`.`$table` partition(${partition})")
+      checkJDBCResult(insertResultJDBC, result)
+    }
+  }
+
+  def checkJDBCResult(resultJDBC: ResultSet, rows: Array[Array[Any]]): Unit = {
+    val rsMetaData = resultJDBC.getMetaData
+    var sqlData: Seq[Seq[AnyRef]] = Seq()
+    while (resultJDBC.next()) {
+      var row: Seq[AnyRef] = Seq()
+      for (i <- 1 to rsMetaData.getColumnCount) {
+        resultJDBC.getObject(i) match {
+          case x: Array[Byte] => row = row :+ new String(x)
+          case _ => row = row :+ resultJDBC.getObject(i)
+        }
+      }
+      sqlData = sqlData :+ row
+    }
+    sqlData should contain theSameElementsAs rows
+  }
+}

--- a/core/src/test/scala/com/pingcap/tispark/partition/PartitionNewCollationSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/partition/PartitionNewCollationSuite.scala
@@ -59,12 +59,8 @@ class PartitionNewCollationSuite extends PartitionBaseSuite {
       .save()
 
     val insertResultSpark = spark.sql(s"select * from `tidb_catalog`.`$database`.`$table`")
-    insertResultSpark.collect() should contain theSameElementsAs Array(
-      Row(57L, "A"))
-    checkPartitionJDBCResult(
-      Map(
-        "p0" -> Array(Array(57L, "A")),
-        "p1" -> Array()))
+    insertResultSpark.collect() should contain theSameElementsAs Array(Row(57L, "A"))
+    checkPartitionJDBCResult(Map("p0" -> Array(Array(57L, "A")), "p1" -> Array()))
 
     tidbStmt.execute(s"ADMIN CHECK TABLE `$database`.`$table`")
   }
@@ -90,12 +86,8 @@ class PartitionNewCollationSuite extends PartitionBaseSuite {
       .save()
 
     val insertResultSpark = spark.sql(s"select * from `tidb_catalog`.`$database`.`$table`")
-    insertResultSpark.collect() should contain theSameElementsAs Array(
-      Row(57L, "A"))
-    checkPartitionJDBCResult(
-      Map(
-        "p0" -> Array(),
-        "p1" -> Array(Array(57L, "A"))))
+    insertResultSpark.collect() should contain theSameElementsAs Array(Row(57L, "A"))
+    checkPartitionJDBCResult(Map("p0" -> Array(), "p1" -> Array(Array(57L, "A"))))
 
     tidbStmt.execute(s"ADMIN CHECK TABLE `$database`.`$table`")
   }
@@ -125,12 +117,8 @@ class PartitionNewCollationSuite extends PartitionBaseSuite {
       .save()
 
     val insertResultSpark = spark.sql(s"select * from `tidb_catalog`.`$database`.`$table`")
-    insertResultSpark.collect() should contain theSameElementsAs Array(
-      Row(57L, "ß"))
-    checkPartitionJDBCResult(
-      Map(
-        "p0" -> Array(Array(57L, "ß")),
-        "p1" -> Array()))
+    insertResultSpark.collect() should contain theSameElementsAs Array(Row(57L, "ß"))
+    checkPartitionJDBCResult(Map("p0" -> Array(Array(57L, "ß")), "p1" -> Array()))
 
     tidbStmt.execute(s"ADMIN CHECK TABLE `$database`.`$table`")
   }
@@ -156,14 +144,9 @@ class PartitionNewCollationSuite extends PartitionBaseSuite {
       .save()
 
     val insertResultSpark = spark.sql(s"select * from `tidb_catalog`.`$database`.`$table`")
-    insertResultSpark.collect() should contain theSameElementsAs Array(
-      Row(57L, "ß"))
-    checkPartitionJDBCResult(
-      Map(
-        "p0" -> Array(),
-        "p1" -> Array(Array(57L, "ß"))))
+    insertResultSpark.collect() should contain theSameElementsAs Array(Row(57L, "ß"))
+    checkPartitionJDBCResult(Map("p0" -> Array(), "p1" -> Array(Array(57L, "ß"))))
 
     tidbStmt.execute(s"ADMIN CHECK TABLE `$database`.`$table`")
   }
 }
-

--- a/core/src/test/scala/com/pingcap/tispark/partition/PartitionNewCollationSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/partition/PartitionNewCollationSuite.scala
@@ -20,6 +20,7 @@ import com.pingcap.tikv.meta.Collation
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types.{LongType, StringType, StructField, StructType}
+import org.scalatest.Matchers
 import org.scalatest.Matchers.{contain, convertToAnyShouldWrapper}
 
 class PartitionNewCollationSuite extends PartitionBaseSuite {
@@ -146,6 +147,44 @@ class PartitionNewCollationSuite extends PartitionBaseSuite {
     val insertResultSpark = spark.sql(s"select * from `tidb_catalog`.`$database`.`$table`")
     insertResultSpark.collect() should contain theSameElementsAs Array(Row(57L, "ß"))
     checkPartitionJDBCResult(Map("p0" -> Array(), "p1" -> Array(Array(57L, "ß"))))
+
+    tidbStmt.execute(s"ADMIN CHECK TABLE `$database`.`$table`")
+  }
+
+  test("range column read with utf8mb4_unicode_ci collation") {
+    checkNewCollationEnabled()
+    tidbStmt.execute(
+      s"create table `$database`.`$table` (id bigint, name varchar(16) unique key) CHARSET utf8mb4 COLLATE utf8mb4_unicode_ci partition by range columns(name) (" +
+        s"partition p0 values less than ('d')," +
+        s"partition p1 values less than ('t')," +
+        s"partition p2 values less than MAXVALUE)")
+
+    tidbStmt.execute(s"insert into `$database`.`$table` VALUES (17, 'f')")
+
+    // tispark will prune partition ang query p0, p1
+    val insertResultSpark =
+      spark.sql(s"select * from `tidb_catalog`.`$database`.`$table` where name < 'G'")
+    insertResultSpark.collect() should contain theSameElementsAs Array(Row(17L, "f"))
+    checkPartitionJDBCResult(Map("p0" -> Array(), "p1" -> Array(Array(17L, "f"))))
+
+    tidbStmt.execute(s"ADMIN CHECK TABLE `$database`.`$table`")
+  }
+
+  test("range column read with utf8mb4_bin collation") {
+    checkNewCollationEnabled()
+    tidbStmt.execute(
+      s"create table `$database`.`$table` (id bigint, name varchar(16) unique key) CHARSET utf8mb4 COLLATE utf8mb4_bin partition by range columns(name) (" +
+        s"partition p0 values less than ('d')," +
+        s"partition p1 values less than ('t')," +
+        s"partition p2 values less than MAXVALUE)")
+
+    tidbStmt.execute(s"insert into `$database`.`$table` VALUES (17, 'f')")
+
+    // tispark will prune partition ang only query p0
+    val insertResultSpark =
+      spark.sql(s"select * from `tidb_catalog`.`$database`.`$table` where name < 'G'")
+    insertResultSpark.collect() shouldBe Matchers.empty
+    checkPartitionJDBCResult(Map("p0" -> Array(), "p1" -> Array(Array(17L, "f"))))
 
     tidbStmt.execute(s"ADMIN CHECK TABLE `$database`.`$table`")
   }

--- a/core/src/test/scala/com/pingcap/tispark/partition/PartitionNewCollationSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/partition/PartitionNewCollationSuite.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.pingcap.tispark.partition
 
 import com.pingcap.tikv.meta.Collation

--- a/core/src/test/scala/com/pingcap/tispark/partition/PartitionNewCollationSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/partition/PartitionNewCollationSuite.scala
@@ -88,7 +88,6 @@ class PartitionNewCollationSuite extends PartitionBaseSuite {
    * For utf8mb4_general_ci collation, "ß" < "ss"
    * For utf8mb4_unicode_ci collation, "ß" = "ss"
    */
-  /
   test("range column with utf8mb4_general_ci collation \"ss\" and \"ß\"") {
     checkNewCollationEnabled()
     tidbStmt.execute(

--- a/core/src/test/scala/com/pingcap/tispark/partition/PartitionNewCollationSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/partition/PartitionNewCollationSuite.scala
@@ -1,0 +1,154 @@
+package com.pingcap.tispark.partition
+
+import com.pingcap.tikv.meta.Collation
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.types.{LongType, StringType, StructField, StructType}
+import org.scalatest.Matchers.{contain, convertToAnyShouldWrapper}
+
+class PartitionNewCollationSuite extends PartitionBaseSuite {
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+  }
+
+  private def checkNewCollationEnabled(): Unit = {
+    if (!Collation.isNewCollationEnabled) {
+      cancel()
+    }
+  }
+
+  /**
+   * For utf8mb4_bin collation, "A" < "a"
+   * For utf8mb4_general_ci collation, "A" = "a"
+   */
+  test("range column with bin collation \"a\" and \"A\"") {
+    checkNewCollationEnabled()
+    tidbStmt.execute(
+      s"create table `$database`.`$table` (id bigint, name varchar(16) unique key) CHARSET utf8mb4 COLLATE utf8mb4_bin  partition by range columns(name) (" +
+        s"partition p0 values less than ('a')," +
+        s"partition p1 values less than MAXVALUE)")
+
+    val data: RDD[Row] = sc.makeRDD(List(Row(57L, "A")))
+    val schema: StructType =
+      StructType(List(StructField("id", LongType), StructField("name", StringType)))
+    val df = sqlContext.createDataFrame(data, schema)
+    df.write
+      .format("tidb")
+      .options(tidbOptions)
+      .option("database", database)
+      .option("table", table)
+      .option("replace", "false")
+      .mode("append")
+      .save()
+
+    val insertResultSpark = spark.sql(s"select * from `tidb_catalog`.`$database`.`$table`")
+    insertResultSpark.collect() should contain theSameElementsAs Array(
+      Row(57L, "A"))
+    checkPartitionJDBCResult(
+      Map(
+        "p0" -> Array(Array(57L, "A")),
+        "p1" -> Array()))
+
+    tidbStmt.execute(s"ADMIN CHECK TABLE `$database`.`$table`")
+  }
+
+  test("range column with utf8mb4_general_ci collation \"a\" and \"A\"") {
+    checkNewCollationEnabled()
+    tidbStmt.execute(
+      s"create table `$database`.`$table` (id bigint, name varchar(16) unique key) CHARSET utf8mb4 COLLATE utf8mb4_general_ci partition by range columns(name) (" +
+        s"partition p0 values less than ('a')," +
+        s"partition p1 values less than MAXVALUE)")
+
+    val data: RDD[Row] = sc.makeRDD(List(Row(57L, "A")))
+    val schema: StructType =
+      StructType(List(StructField("id", LongType), StructField("name", StringType)))
+    val df = sqlContext.createDataFrame(data, schema)
+    df.write
+      .format("tidb")
+      .options(tidbOptions)
+      .option("database", database)
+      .option("table", table)
+      .option("replace", "false")
+      .mode("append")
+      .save()
+
+    val insertResultSpark = spark.sql(s"select * from `tidb_catalog`.`$database`.`$table`")
+    insertResultSpark.collect() should contain theSameElementsAs Array(
+      Row(57L, "A"))
+    checkPartitionJDBCResult(
+      Map(
+        "p0" -> Array(),
+        "p1" -> Array(Array(57L, "A"))))
+
+    tidbStmt.execute(s"ADMIN CHECK TABLE `$database`.`$table`")
+  }
+
+  /**
+   * For utf8mb4_general_ci collation, "ß" < "ss"
+   * For utf8mb4_unicode_ci collation, "ß" = "ss"
+   */
+  /
+  test("range column with utf8mb4_general_ci collation \"ss\" and \"ß\"") {
+    checkNewCollationEnabled()
+    tidbStmt.execute(
+      s"create table `$database`.`$table` (id bigint, name varchar(16) unique key) CHARSET utf8mb4 COLLATE utf8mb4_general_ci partition by range columns(name) (" +
+        s"partition p0 values less than ('ss')," +
+        s"partition p1 values less than MAXVALUE)")
+
+    val data: RDD[Row] = sc.makeRDD(List(Row(57L, "ß")))
+    val schema: StructType =
+      StructType(List(StructField("id", LongType), StructField("name", StringType)))
+    val df = sqlContext.createDataFrame(data, schema)
+    df.write
+      .format("tidb")
+      .options(tidbOptions)
+      .option("database", database)
+      .option("table", table)
+      .option("replace", "false")
+      .mode("append")
+      .save()
+
+    val insertResultSpark = spark.sql(s"select * from `tidb_catalog`.`$database`.`$table`")
+    insertResultSpark.collect() should contain theSameElementsAs Array(
+      Row(57L, "ß"))
+    checkPartitionJDBCResult(
+      Map(
+        "p0" -> Array(Array(57L, "ß")),
+        "p1" -> Array()))
+
+    tidbStmt.execute(s"ADMIN CHECK TABLE `$database`.`$table`")
+  }
+
+  test("range column with utf8mb4_unicode_ci collation \"ss\" and \"ß\"") {
+    checkNewCollationEnabled()
+    tidbStmt.execute(
+      s"create table `$database`.`$table` (id bigint, name varchar(16) unique key) CHARSET utf8mb4 COLLATE utf8mb4_unicode_ci partition by range columns(name) (" +
+        s"partition p0 values less than ('ss')," +
+        s"partition p1 values less than MAXVALUE)")
+
+    val data: RDD[Row] = sc.makeRDD(List(Row(57L, "ß")))
+    val schema: StructType =
+      StructType(List(StructField("id", LongType), StructField("name", StringType)))
+    val df = sqlContext.createDataFrame(data, schema)
+    df.write
+      .format("tidb")
+      .options(tidbOptions)
+      .option("database", database)
+      .option("table", table)
+      .option("replace", "false")
+      .mode("append")
+      .save()
+
+    val insertResultSpark = spark.sql(s"select * from `tidb_catalog`.`$database`.`$table`")
+    insertResultSpark.collect() should contain theSameElementsAs Array(
+      Row(57L, "ß"))
+    checkPartitionJDBCResult(
+      Map(
+        "p0" -> Array(),
+        "p1" -> Array(Array(57L, "ß"))))
+
+    tidbStmt.execute(s"ADMIN CHECK TABLE `$database`.`$table`")
+  }
+}
+

--- a/core/src/test/scala/com/pingcap/tispark/partition/PartitionWriteSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/partition/PartitionWriteSuite.scala
@@ -18,22 +18,18 @@ package com.pingcap.tispark.partition
 
 import com.pingcap.tikv.util.ConvertUpstreamUtils
 import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.Row
 import org.apache.spark.sql.types._
-import org.apache.spark.sql.{BaseTiSparkTest, Row}
 import org.scalatest.Matchers.{contain, convertToAnyShouldWrapper, have, the}
 
-import java.sql.{Date, ResultSet, Timestamp}
+import java.sql.{Date, Timestamp}
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
-class PartitionWriteSuite extends BaseTiSparkTest {
-
-  val table: String = "test_partition_write"
-  val database: String = "tispark_test"
+class PartitionWriteSuite extends PartitionBaseSuite {
 
   override def beforeEach(): Unit = {
     super.beforeEach()
-    tidbStmt.execute(s"drop table if exists `$database`.`$table`")
   }
 
   /**
@@ -845,29 +841,5 @@ class PartitionWriteSuite extends BaseTiSparkTest {
         .mode("append")
         .save()
     } should have message s"Unsupported function: UNIX_TIMESTAMP"
-  }
-
-  private def checkPartitionJDBCResult(expected: Map[String, Array[Array[Any]]]) = {
-    for ((partition, result) <- expected) {
-      val insertResultJDBC =
-        tidbStmt.executeQuery(s"select * from `$database`.`$table` partition(${partition})")
-      checkJDBCResult(insertResultJDBC, result)
-    }
-  }
-
-  def checkJDBCResult(resultJDBC: ResultSet, rows: Array[Array[Any]]): Unit = {
-    val rsMetaData = resultJDBC.getMetaData
-    var sqlData: Seq[Seq[AnyRef]] = Seq()
-    while (resultJDBC.next()) {
-      var row: Seq[AnyRef] = Seq()
-      for (i <- 1 to rsMetaData.getColumnCount) {
-        resultJDBC.getObject(i) match {
-          case x: Array[Byte] => row = row :+ new String(x)
-          case _ => row = row :+ resultJDBC.getObject(i)
-        }
-      }
-      sqlData = sqlData :+ row
-    }
-    sqlData should contain theSameElementsAs rows
   }
 }

--- a/docs/userguide_3.0.md
+++ b/docs/userguide_3.0.md
@@ -409,8 +409,10 @@ There are two ways to write into partition table:
 2. Use delete statement with Spark SQL.
 
 > [!NOTE]
-> Currently we only support writing into the partition table with utf8mb4_bin collation
-
+> Because different character sets and collations have different sort orders, the character sets and 
+> collations in use may affect which partition of a table partitioned by RANGE COLUMNS a given row 
+> is stored in when using string columns as partitioning columns.
+> For supported character sets and collations, see [Limitations](../README.md#limitations)
 
 ### Other Features
 - [Push down](features/push_down.md)

--- a/tikv-client/src/main/java/com/pingcap/tikv/expression/visitor/RangePartitionLocator.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/expression/visitor/RangePartitionLocator.java
@@ -26,9 +26,14 @@ import com.pingcap.tikv.expression.Expression;
 import com.pingcap.tikv.expression.FuncCallExpr;
 import com.pingcap.tikv.expression.LogicalBinaryExpression;
 import com.pingcap.tikv.expression.LogicalBinaryExpression.Type;
+import com.pingcap.tikv.meta.Collation;
 import com.pingcap.tikv.meta.TiTableInfo;
+import com.pingcap.tikv.meta.collate.BinPaddingCollator;
+import com.pingcap.tikv.meta.collate.GeneralCICollator;
+import com.pingcap.tikv.meta.collate.UnicodeCICollator;
 import com.pingcap.tikv.partition.PartitionedTable.PartitionLocatorContext;
 import com.pingcap.tikv.row.Row;
+import com.pingcap.tikv.types.DataType;
 import com.pingcap.tikv.types.DateType;
 import com.pingcap.tikv.types.IntegerType;
 import java.nio.charset.StandardCharsets;
@@ -45,12 +50,14 @@ public class RangePartitionLocator extends DefaultVisitor<Boolean, PartitionLoca
   @Override
   public Boolean visit(ComparisonBinaryExpression node, PartitionLocatorContext context) {
     Object data;
+    DataType dataType;
     Row row = context.getRow();
     TiTableInfo tableInfo = context.getTableInfo();
     Expression left = node.getLeft();
     if (left instanceof ColumnRef) {
       ColumnRef columnRef = (ColumnRef) left;
       columnRef.resolve(tableInfo);
+      dataType = columnRef.getDataType();
       data = row.get(columnRef.getColumnOffset(), columnRef.getDataType());
     } else if (left instanceof FuncCallExpr) {
       // TODO: support more function partition
@@ -59,6 +66,7 @@ public class RangePartitionLocator extends DefaultVisitor<Boolean, PartitionLoca
         Expression expression = left.getChildren().get(0);
         ColumnRef columnRef = (ColumnRef) expression;
         columnRef.resolve(tableInfo);
+        dataType = IntegerType.BIGINT;
         data =
             partitionFuncExpr
                 .eval(Constant.create(row.get(columnRef.getColumnOffset(), DateType.DATE)))
@@ -87,10 +95,11 @@ public class RangePartitionLocator extends DefaultVisitor<Boolean, PartitionLoca
     }
     Operator comparisonType = node.getComparisonType();
 
-    return evaluateComparison(data, boundString, comparisonType);
+    return evaluateComparison(data, dataType, boundString, comparisonType);
   }
 
-  Boolean evaluateComparison(Object data, String boundString, Operator comparisonType) {
+  Boolean evaluateComparison(Object data, DataType dataType, String boundString,
+      Operator comparisonType) {
     // MYSQL IntegerType, we can convert to long and then compare.
     if (data instanceof Number) {
       long dataLongValue = ((Number) data).longValue();
@@ -104,12 +113,39 @@ public class RangePartitionLocator extends DefaultVisitor<Boolean, PartitionLoca
           throw new UnsupportedOperationException("Unsupported comparison type: " + comparisonType);
       }
     } else if (data instanceof String) {
+      int collation = dataType.getCollationCode();
       String dataStringValue = (String) data;
       switch (comparisonType) {
         case GREATER_EQUAL:
-          return dataStringValue.compareTo(boundString) >= 0;
+          if (Collation.isNewCollationEnabled()) {
+            if (Collation.isUTF8GeneralCICollation(collation)) {
+              return GeneralCICollator.compare(dataStringValue, boundString) >= 0;
+            } else if (Collation.isUTF8UnicodeCICollation(collation)) {
+              return UnicodeCICollator.compare(dataStringValue, boundString) >= 0;
+            } else if (Collation.isBinCollation(collation)) {
+              return BinPaddingCollator.compare(dataStringValue, boundString) >= 0;
+            } else {
+              throw new UnsupportedOperationException(
+                  "Unsupported collation: " + collation);
+            }
+          } else {
+            return BinPaddingCollator.compare(dataStringValue, boundString) >= 0;
+          }
         case LESS_THAN:
-          return dataStringValue.compareTo(boundString) < 0;
+          if (Collation.isNewCollationEnabled()) {
+            if (Collation.isUTF8GeneralCICollation(collation)) {
+              return GeneralCICollator.compare(dataStringValue, boundString) < 0;
+            } else if (Collation.isUTF8UnicodeCICollation(collation)) {
+              return UnicodeCICollator.compare(dataStringValue, boundString) < 0;
+            } else if (Collation.isBinCollation(collation)) {
+              return BinPaddingCollator.compare(dataStringValue, boundString) < 0;
+            } else {
+              throw new UnsupportedOperationException(
+                  "Unsupported collation: " + collation);
+            }
+          } else {
+            return BinPaddingCollator.compare(dataStringValue, boundString) < 0;
+          }
         default:
           throw new UnsupportedOperationException("Unsupported comparison type: " + comparisonType);
       }
@@ -117,9 +153,9 @@ public class RangePartitionLocator extends DefaultVisitor<Boolean, PartitionLoca
       String dataStringValue = new String((byte[]) data, StandardCharsets.UTF_8);
       switch (comparisonType) {
         case GREATER_EQUAL:
-          return dataStringValue.compareTo(boundString) >= 0;
+          return BinPaddingCollator.compare(dataStringValue, boundString) >= 0;
         case LESS_THAN:
-          return dataStringValue.compareTo(boundString) < 0;
+          return BinPaddingCollator.compare(dataStringValue, boundString) < 0;
         default:
           throw new UnsupportedOperationException("Unsupported comparison type: " + comparisonType);
       }

--- a/tikv-client/src/main/java/com/pingcap/tikv/expression/visitor/RangePartitionLocator.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/expression/visitor/RangePartitionLocator.java
@@ -98,6 +98,10 @@ public class RangePartitionLocator extends DefaultVisitor<Boolean, PartitionLoca
     return evaluateComparison(data, dataType, boundString, comparisonType);
   }
 
+  /**
+   * A better way to compare data is to use the encoded typed key.
+   * @see com.pingcap.tikv.expression.RangeColumnPartitionPruner#visit(ComparisonBinaryExpression node, LogicalBinaryExpression parent)
+   */
   Boolean evaluateComparison(
       Object data, DataType dataType, String boundString, Operator comparisonType) {
     // MYSQL IntegerType, we can convert to long and then compare.

--- a/tikv-client/src/main/java/com/pingcap/tikv/expression/visitor/RangePartitionLocator.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/expression/visitor/RangePartitionLocator.java
@@ -98,8 +98,8 @@ public class RangePartitionLocator extends DefaultVisitor<Boolean, PartitionLoca
     return evaluateComparison(data, dataType, boundString, comparisonType);
   }
 
-  Boolean evaluateComparison(Object data, DataType dataType, String boundString,
-      Operator comparisonType) {
+  Boolean evaluateComparison(
+      Object data, DataType dataType, String boundString, Operator comparisonType) {
     // MYSQL IntegerType, we can convert to long and then compare.
     if (data instanceof Number) {
       long dataLongValue = ((Number) data).longValue();
@@ -125,8 +125,7 @@ public class RangePartitionLocator extends DefaultVisitor<Boolean, PartitionLoca
             } else if (Collation.isBinCollation(collation)) {
               return BinPaddingCollator.compare(dataStringValue, boundString) >= 0;
             } else {
-              throw new UnsupportedOperationException(
-                  "Unsupported collation: " + collation);
+              throw new UnsupportedOperationException("Unsupported collation: " + collation);
             }
           } else {
             return BinPaddingCollator.compare(dataStringValue, boundString) >= 0;
@@ -140,8 +139,7 @@ public class RangePartitionLocator extends DefaultVisitor<Boolean, PartitionLoca
             } else if (Collation.isBinCollation(collation)) {
               return BinPaddingCollator.compare(dataStringValue, boundString) < 0;
             } else {
-              throw new UnsupportedOperationException(
-                  "Unsupported collation: " + collation);
+              throw new UnsupportedOperationException("Unsupported collation: " + collation);
             }
           } else {
             return BinPaddingCollator.compare(dataStringValue, boundString) < 0;

--- a/tikv-client/src/main/java/com/pingcap/tikv/expression/visitor/RangePartitionLocator.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/expression/visitor/RangePartitionLocator.java
@@ -100,7 +100,9 @@ public class RangePartitionLocator extends DefaultVisitor<Boolean, PartitionLoca
 
   /**
    * A better way to compare data is to use the encoded typed key.
-   * @see com.pingcap.tikv.expression.RangeColumnPartitionPruner#visit(ComparisonBinaryExpression node, LogicalBinaryExpression parent)
+   *
+   * @see com.pingcap.tikv.expression.RangeColumnPartitionPruner#visit(ComparisonBinaryExpression
+   *     node, LogicalBinaryExpression parent)
    */
   Boolean evaluateComparison(
       Object data, DataType dataType, String boundString, Operator comparisonType) {

--- a/tikv-client/src/test/java/com/pingcap/tikv/expression/visitor/PartitionLocatorTest.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/expression/visitor/PartitionLocatorTest.java
@@ -19,6 +19,11 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import com.pingcap.tikv.expression.ComparisonBinaryExpression.Operator;
+import com.pingcap.tikv.types.BytesType;
+import com.pingcap.tikv.types.DateType;
+import com.pingcap.tikv.types.IntegerType;
+import com.pingcap.tikv.types.StringType;
+import com.pingcap.tikv.types.TimestampType;
 import java.sql.Date;
 import java.sql.Timestamp;
 import org.junit.Test;
@@ -32,29 +37,29 @@ public class PartitionLocatorTest {
     assertTrue(
         locator.evaluateComparison(
             Timestamp.valueOf("1995-01-01 00:00:00"),
-            "1995-01-01 00:00:00",
+            TimestampType.TIMESTAMP, "1995-01-01 00:00:00",
             Operator.GREATER_EQUAL));
     assertFalse(
         locator.evaluateComparison(
-            Timestamp.valueOf("1995-01-01 00:00:00"), "1995-01-01 00:00:00", Operator.LESS_THAN));
+            Timestamp.valueOf("1995-01-01 00:00:00"), TimestampType.TIMESTAMP, "1995-01-01 00:00:00", Operator.LESS_THAN));
     // >
     assertTrue(
         locator.evaluateComparison(
             Timestamp.valueOf("1995-01-01 10:00:00"),
-            "1995-01-01 00:00:00",
+            TimestampType.TIMESTAMP, "1995-01-01 00:00:00",
             Operator.GREATER_EQUAL));
     assertFalse(
         locator.evaluateComparison(
-            Timestamp.valueOf("1995-01-01 10:00:00"), "1995-01-01 00:00:00", Operator.LESS_THAN));
+            Timestamp.valueOf("1995-01-01 10:00:00"), TimestampType.TIMESTAMP, "1995-01-01 00:00:00", Operator.LESS_THAN));
     // <
     assertFalse(
         locator.evaluateComparison(
             Timestamp.valueOf("1995-01-01 10:00:00"),
-            "1995-01-02 00:00:00",
+            TimestampType.TIMESTAMP, "1995-01-02 00:00:00",
             Operator.GREATER_EQUAL));
     assertTrue(
         locator.evaluateComparison(
-            Timestamp.valueOf("1995-01-01 10:00:00"), "1995-01-02 00:00:00", Operator.LESS_THAN));
+            Timestamp.valueOf("1995-01-01 10:00:00"), TimestampType.TIMESTAMP, "1995-01-02 00:00:00", Operator.LESS_THAN));
   }
 
   @Test
@@ -63,76 +68,76 @@ public class PartitionLocatorTest {
     // =
     assertTrue(
         locator.evaluateComparison(
-            Date.valueOf("1995-01-01"), "1995-01-01", Operator.GREATER_EQUAL));
+            Date.valueOf("1995-01-01"), DateType.DATE, "1995-01-01", Operator.GREATER_EQUAL));
     assertFalse(
-        locator.evaluateComparison(Date.valueOf("1995-01-01"), "1995-01-01", Operator.LESS_THAN));
+        locator.evaluateComparison(Date.valueOf("1995-01-01"), DateType.DATE, "1995-01-01", Operator.LESS_THAN));
     // >
     assertTrue(
         locator.evaluateComparison(
-            Date.valueOf("1995-02-01"), "1995-01-01", Operator.GREATER_EQUAL));
+            Date.valueOf("1995-02-01"), DateType.DATE, "1995-01-01", Operator.GREATER_EQUAL));
     assertFalse(
-        locator.evaluateComparison(Date.valueOf("1995-02-01"), "1995-01-01", Operator.LESS_THAN));
+        locator.evaluateComparison(Date.valueOf("1995-02-01"), DateType.DATE, "1995-01-01", Operator.LESS_THAN));
     // <
     assertFalse(
         locator.evaluateComparison(
-            Date.valueOf("1995-01-01"), "1995-02-01", Operator.GREATER_EQUAL));
+            Date.valueOf("1995-01-01"), DateType.DATE, "1995-02-01", Operator.GREATER_EQUAL));
     assertTrue(
-        locator.evaluateComparison(Date.valueOf("1995-01-01"), "1995-02-01", Operator.LESS_THAN));
+        locator.evaluateComparison(Date.valueOf("1995-01-01"), DateType.DATE, "1995-02-01", Operator.LESS_THAN));
   }
 
   @Test
   public void testShort() {
     RangePartitionLocator locator = new RangePartitionLocator();
     // =
-    assertTrue(locator.evaluateComparison((short) 56, "56", Operator.GREATER_EQUAL));
-    assertFalse(locator.evaluateComparison((short) 56, "56", Operator.LESS_THAN));
+    assertTrue(locator.evaluateComparison((short) 56, IntegerType.SMALLINT, "56", Operator.GREATER_EQUAL));
+    assertFalse(locator.evaluateComparison((short) 56, IntegerType.SMALLINT, "56", Operator.LESS_THAN));
     // >
-    assertTrue(locator.evaluateComparison((short) 119, "56", Operator.GREATER_EQUAL));
-    assertFalse(locator.evaluateComparison((short) 119, "56", Operator.LESS_THAN));
+    assertTrue(locator.evaluateComparison((short) 119, IntegerType.SMALLINT, "56", Operator.GREATER_EQUAL));
+    assertFalse(locator.evaluateComparison((short) 119, IntegerType.SMALLINT, "56", Operator.LESS_THAN));
     // <
-    assertFalse(locator.evaluateComparison((short) 56, "119", Operator.GREATER_EQUAL));
-    assertTrue(locator.evaluateComparison((short) 56, "119", Operator.LESS_THAN));
+    assertFalse(locator.evaluateComparison((short) 56, IntegerType.SMALLINT, "119", Operator.GREATER_EQUAL));
+    assertTrue(locator.evaluateComparison((short) 56, IntegerType.SMALLINT, "119", Operator.LESS_THAN));
   }
 
   @Test
   public void testLong() {
     RangePartitionLocator locator = new RangePartitionLocator();
     // =
-    assertTrue(locator.evaluateComparison((long) 56, "56", Operator.GREATER_EQUAL));
-    assertFalse(locator.evaluateComparison((long) 56, "56", Operator.LESS_THAN));
+    assertTrue(locator.evaluateComparison((long) 56, IntegerType.BIGINT, "56", Operator.GREATER_EQUAL));
+    assertFalse(locator.evaluateComparison((long) 56, IntegerType.BIGINT, "56", Operator.LESS_THAN));
     // >
-    assertTrue(locator.evaluateComparison((long) 119, "56", Operator.GREATER_EQUAL));
-    assertFalse(locator.evaluateComparison((long) 119, "56", Operator.LESS_THAN));
+    assertTrue(locator.evaluateComparison((long) 119, IntegerType.BIGINT, "56", Operator.GREATER_EQUAL));
+    assertFalse(locator.evaluateComparison((long) 119, IntegerType.BIGINT, "56", Operator.LESS_THAN));
     // <
-    assertFalse(locator.evaluateComparison((long) 56, "119", Operator.GREATER_EQUAL));
-    assertTrue(locator.evaluateComparison((long) 56, "119", Operator.LESS_THAN));
+    assertFalse(locator.evaluateComparison((long) 56, IntegerType.BIGINT, "119", Operator.GREATER_EQUAL));
+    assertTrue(locator.evaluateComparison((long) 56, IntegerType.BIGINT, "119", Operator.LESS_THAN));
   }
 
   @Test
   public void testString() {
     RangePartitionLocator locator = new RangePartitionLocator();
     // =
-    assertTrue(locator.evaluateComparison("long", "long", Operator.GREATER_EQUAL));
-    assertFalse(locator.evaluateComparison("long", "long", Operator.LESS_THAN));
+    assertTrue(locator.evaluateComparison("long", StringType.VARCHAR, "long", Operator.GREATER_EQUAL));
+    assertFalse(locator.evaluateComparison("long", StringType.VARCHAR, "long", Operator.LESS_THAN));
     // >
-    assertTrue(locator.evaluateComparison("long", "loNg", Operator.GREATER_EQUAL));
-    assertFalse(locator.evaluateComparison("long", "long", Operator.LESS_THAN));
+    assertTrue(locator.evaluateComparison("long", StringType.VARCHAR, "loNg", Operator.GREATER_EQUAL));
+    assertFalse(locator.evaluateComparison("long", StringType.VARCHAR, "long", Operator.LESS_THAN));
     // <
-    assertFalse(locator.evaluateComparison("LoNg", "loNg", Operator.GREATER_EQUAL));
-    assertTrue(locator.evaluateComparison("LoNg", "loNg", Operator.LESS_THAN));
+    assertFalse(locator.evaluateComparison("LoNg", StringType.VARCHAR, "loNg", Operator.GREATER_EQUAL));
+    assertTrue(locator.evaluateComparison("LoNg", StringType.VARCHAR, "loNg", Operator.LESS_THAN));
   }
 
   @Test
   public void testByte() {
     RangePartitionLocator locator = new RangePartitionLocator();
     // =
-    assertTrue(locator.evaluateComparison("long".getBytes(), "long", Operator.GREATER_EQUAL));
-    assertFalse(locator.evaluateComparison("long".getBytes(), "long", Operator.LESS_THAN));
+    assertTrue(locator.evaluateComparison("long".getBytes(), BytesType.BLOB, "long", Operator.GREATER_EQUAL));
+    assertFalse(locator.evaluateComparison("long".getBytes(), BytesType.BLOB, "long", Operator.LESS_THAN));
     // >
-    assertTrue(locator.evaluateComparison("long".getBytes(), "loNg", Operator.GREATER_EQUAL));
-    assertFalse(locator.evaluateComparison("long".getBytes(), "long", Operator.LESS_THAN));
+    assertTrue(locator.evaluateComparison("long".getBytes(), BytesType.BLOB, "loNg", Operator.GREATER_EQUAL));
+    assertFalse(locator.evaluateComparison("long".getBytes(), BytesType.BLOB, "long", Operator.LESS_THAN));
     // <
-    assertFalse(locator.evaluateComparison("LoNg".getBytes(), "loNg", Operator.GREATER_EQUAL));
-    assertTrue(locator.evaluateComparison("LoNg".getBytes(), "loNg", Operator.LESS_THAN));
+    assertFalse(locator.evaluateComparison("LoNg".getBytes(), BytesType.BLOB, "loNg", Operator.GREATER_EQUAL));
+    assertTrue(locator.evaluateComparison("LoNg".getBytes(), BytesType.BLOB, "loNg", Operator.LESS_THAN));
   }
 }

--- a/tikv-client/src/test/java/com/pingcap/tikv/expression/visitor/PartitionLocatorTest.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/expression/visitor/PartitionLocatorTest.java
@@ -37,29 +37,41 @@ public class PartitionLocatorTest {
     assertTrue(
         locator.evaluateComparison(
             Timestamp.valueOf("1995-01-01 00:00:00"),
-            TimestampType.TIMESTAMP, "1995-01-01 00:00:00",
+            TimestampType.TIMESTAMP,
+            "1995-01-01 00:00:00",
             Operator.GREATER_EQUAL));
     assertFalse(
         locator.evaluateComparison(
-            Timestamp.valueOf("1995-01-01 00:00:00"), TimestampType.TIMESTAMP, "1995-01-01 00:00:00", Operator.LESS_THAN));
+            Timestamp.valueOf("1995-01-01 00:00:00"),
+            TimestampType.TIMESTAMP,
+            "1995-01-01 00:00:00",
+            Operator.LESS_THAN));
     // >
     assertTrue(
         locator.evaluateComparison(
             Timestamp.valueOf("1995-01-01 10:00:00"),
-            TimestampType.TIMESTAMP, "1995-01-01 00:00:00",
+            TimestampType.TIMESTAMP,
+            "1995-01-01 00:00:00",
             Operator.GREATER_EQUAL));
     assertFalse(
         locator.evaluateComparison(
-            Timestamp.valueOf("1995-01-01 10:00:00"), TimestampType.TIMESTAMP, "1995-01-01 00:00:00", Operator.LESS_THAN));
+            Timestamp.valueOf("1995-01-01 10:00:00"),
+            TimestampType.TIMESTAMP,
+            "1995-01-01 00:00:00",
+            Operator.LESS_THAN));
     // <
     assertFalse(
         locator.evaluateComparison(
             Timestamp.valueOf("1995-01-01 10:00:00"),
-            TimestampType.TIMESTAMP, "1995-01-02 00:00:00",
+            TimestampType.TIMESTAMP,
+            "1995-01-02 00:00:00",
             Operator.GREATER_EQUAL));
     assertTrue(
         locator.evaluateComparison(
-            Timestamp.valueOf("1995-01-01 10:00:00"), TimestampType.TIMESTAMP, "1995-01-02 00:00:00", Operator.LESS_THAN));
+            Timestamp.valueOf("1995-01-01 10:00:00"),
+            TimestampType.TIMESTAMP,
+            "1995-01-02 00:00:00",
+            Operator.LESS_THAN));
   }
 
   @Test
@@ -70,60 +82,80 @@ public class PartitionLocatorTest {
         locator.evaluateComparison(
             Date.valueOf("1995-01-01"), DateType.DATE, "1995-01-01", Operator.GREATER_EQUAL));
     assertFalse(
-        locator.evaluateComparison(Date.valueOf("1995-01-01"), DateType.DATE, "1995-01-01", Operator.LESS_THAN));
+        locator.evaluateComparison(
+            Date.valueOf("1995-01-01"), DateType.DATE, "1995-01-01", Operator.LESS_THAN));
     // >
     assertTrue(
         locator.evaluateComparison(
             Date.valueOf("1995-02-01"), DateType.DATE, "1995-01-01", Operator.GREATER_EQUAL));
     assertFalse(
-        locator.evaluateComparison(Date.valueOf("1995-02-01"), DateType.DATE, "1995-01-01", Operator.LESS_THAN));
+        locator.evaluateComparison(
+            Date.valueOf("1995-02-01"), DateType.DATE, "1995-01-01", Operator.LESS_THAN));
     // <
     assertFalse(
         locator.evaluateComparison(
             Date.valueOf("1995-01-01"), DateType.DATE, "1995-02-01", Operator.GREATER_EQUAL));
     assertTrue(
-        locator.evaluateComparison(Date.valueOf("1995-01-01"), DateType.DATE, "1995-02-01", Operator.LESS_THAN));
+        locator.evaluateComparison(
+            Date.valueOf("1995-01-01"), DateType.DATE, "1995-02-01", Operator.LESS_THAN));
   }
 
   @Test
   public void testShort() {
     RangePartitionLocator locator = new RangePartitionLocator();
     // =
-    assertTrue(locator.evaluateComparison((short) 56, IntegerType.SMALLINT, "56", Operator.GREATER_EQUAL));
-    assertFalse(locator.evaluateComparison((short) 56, IntegerType.SMALLINT, "56", Operator.LESS_THAN));
+    assertTrue(
+        locator.evaluateComparison((short) 56, IntegerType.SMALLINT, "56", Operator.GREATER_EQUAL));
+    assertFalse(
+        locator.evaluateComparison((short) 56, IntegerType.SMALLINT, "56", Operator.LESS_THAN));
     // >
-    assertTrue(locator.evaluateComparison((short) 119, IntegerType.SMALLINT, "56", Operator.GREATER_EQUAL));
-    assertFalse(locator.evaluateComparison((short) 119, IntegerType.SMALLINT, "56", Operator.LESS_THAN));
+    assertTrue(
+        locator.evaluateComparison(
+            (short) 119, IntegerType.SMALLINT, "56", Operator.GREATER_EQUAL));
+    assertFalse(
+        locator.evaluateComparison((short) 119, IntegerType.SMALLINT, "56", Operator.LESS_THAN));
     // <
-    assertFalse(locator.evaluateComparison((short) 56, IntegerType.SMALLINT, "119", Operator.GREATER_EQUAL));
-    assertTrue(locator.evaluateComparison((short) 56, IntegerType.SMALLINT, "119", Operator.LESS_THAN));
+    assertFalse(
+        locator.evaluateComparison(
+            (short) 56, IntegerType.SMALLINT, "119", Operator.GREATER_EQUAL));
+    assertTrue(
+        locator.evaluateComparison((short) 56, IntegerType.SMALLINT, "119", Operator.LESS_THAN));
   }
 
   @Test
   public void testLong() {
     RangePartitionLocator locator = new RangePartitionLocator();
     // =
-    assertTrue(locator.evaluateComparison((long) 56, IntegerType.BIGINT, "56", Operator.GREATER_EQUAL));
-    assertFalse(locator.evaluateComparison((long) 56, IntegerType.BIGINT, "56", Operator.LESS_THAN));
+    assertTrue(
+        locator.evaluateComparison((long) 56, IntegerType.BIGINT, "56", Operator.GREATER_EQUAL));
+    assertFalse(
+        locator.evaluateComparison((long) 56, IntegerType.BIGINT, "56", Operator.LESS_THAN));
     // >
-    assertTrue(locator.evaluateComparison((long) 119, IntegerType.BIGINT, "56", Operator.GREATER_EQUAL));
-    assertFalse(locator.evaluateComparison((long) 119, IntegerType.BIGINT, "56", Operator.LESS_THAN));
+    assertTrue(
+        locator.evaluateComparison((long) 119, IntegerType.BIGINT, "56", Operator.GREATER_EQUAL));
+    assertFalse(
+        locator.evaluateComparison((long) 119, IntegerType.BIGINT, "56", Operator.LESS_THAN));
     // <
-    assertFalse(locator.evaluateComparison((long) 56, IntegerType.BIGINT, "119", Operator.GREATER_EQUAL));
-    assertTrue(locator.evaluateComparison((long) 56, IntegerType.BIGINT, "119", Operator.LESS_THAN));
+    assertFalse(
+        locator.evaluateComparison((long) 56, IntegerType.BIGINT, "119", Operator.GREATER_EQUAL));
+    assertTrue(
+        locator.evaluateComparison((long) 56, IntegerType.BIGINT, "119", Operator.LESS_THAN));
   }
 
   @Test
   public void testString() {
     RangePartitionLocator locator = new RangePartitionLocator();
     // =
-    assertTrue(locator.evaluateComparison("long", StringType.VARCHAR, "long", Operator.GREATER_EQUAL));
+    assertTrue(
+        locator.evaluateComparison("long", StringType.VARCHAR, "long", Operator.GREATER_EQUAL));
     assertFalse(locator.evaluateComparison("long", StringType.VARCHAR, "long", Operator.LESS_THAN));
     // >
-    assertTrue(locator.evaluateComparison("long", StringType.VARCHAR, "loNg", Operator.GREATER_EQUAL));
+    assertTrue(
+        locator.evaluateComparison("long", StringType.VARCHAR, "loNg", Operator.GREATER_EQUAL));
     assertFalse(locator.evaluateComparison("long", StringType.VARCHAR, "long", Operator.LESS_THAN));
     // <
-    assertFalse(locator.evaluateComparison("LoNg", StringType.VARCHAR, "loNg", Operator.GREATER_EQUAL));
+    assertFalse(
+        locator.evaluateComparison("LoNg", StringType.VARCHAR, "loNg", Operator.GREATER_EQUAL));
     assertTrue(locator.evaluateComparison("LoNg", StringType.VARCHAR, "loNg", Operator.LESS_THAN));
   }
 
@@ -131,13 +163,22 @@ public class PartitionLocatorTest {
   public void testByte() {
     RangePartitionLocator locator = new RangePartitionLocator();
     // =
-    assertTrue(locator.evaluateComparison("long".getBytes(), BytesType.BLOB, "long", Operator.GREATER_EQUAL));
-    assertFalse(locator.evaluateComparison("long".getBytes(), BytesType.BLOB, "long", Operator.LESS_THAN));
+    assertTrue(
+        locator.evaluateComparison(
+            "long".getBytes(), BytesType.BLOB, "long", Operator.GREATER_EQUAL));
+    assertFalse(
+        locator.evaluateComparison("long".getBytes(), BytesType.BLOB, "long", Operator.LESS_THAN));
     // >
-    assertTrue(locator.evaluateComparison("long".getBytes(), BytesType.BLOB, "loNg", Operator.GREATER_EQUAL));
-    assertFalse(locator.evaluateComparison("long".getBytes(), BytesType.BLOB, "long", Operator.LESS_THAN));
+    assertTrue(
+        locator.evaluateComparison(
+            "long".getBytes(), BytesType.BLOB, "loNg", Operator.GREATER_EQUAL));
+    assertFalse(
+        locator.evaluateComparison("long".getBytes(), BytesType.BLOB, "long", Operator.LESS_THAN));
     // <
-    assertFalse(locator.evaluateComparison("LoNg".getBytes(), BytesType.BLOB, "loNg", Operator.GREATER_EQUAL));
-    assertTrue(locator.evaluateComparison("LoNg".getBytes(), BytesType.BLOB, "loNg", Operator.LESS_THAN));
+    assertFalse(
+        locator.evaluateComparison(
+            "LoNg".getBytes(), BytesType.BLOB, "loNg", Operator.GREATER_EQUAL));
+    assertTrue(
+        locator.evaluateComparison("LoNg".getBytes(), BytesType.BLOB, "loNg", Operator.LESS_THAN));
   }
 }


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

In https://github.com/pingcap/tispark/pull/2524, TiSpark supports new collation.
According to [Range column partition](https://dev.mysql.com/doc/refman/5.7/en/partitioning-columns-range.html#:~:text=Range%20columns%20partitioning%20is%20similar,types%20other%20than%20integer%20types), partitioning also needs to obey the sort orders of collation.

### What is changed and how it works?

- For range column partition,  using different sort orders according to collation

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

Related changes

 - Need to update the documentation
 - Need to be included in the release note
