### PR TITLE
Optimize region not find

### DIFF
--- a/tikv-client/src/main/java/com/pingcap/tikv/region/RegionManager.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/region/RegionManager.java
@@ -183,6 +183,10 @@ public class RegionManager {
     cache.invalidateRegion(region);
   }
 
+  public void invalidateRange(ByteString startKey, ByteString endKey) {
+    cache.invalidateRange(startKey,endKey);
+  }
+
   public static class RegionCache {
     // private final Map<Long, TiRegion> regionCache;
     private final Map<Long, Store> storeCache;
@@ -247,19 +251,26 @@ public class RegionManager {
 
     private synchronized void invalidateRange(ByteString startKey, ByteString endKey) {
       regionCache.remove(makeRange(startKey, endKey));
+      if (logger.isDebugEnabled()) {
+        logger.debug(String.format("invalidateRange success, startKey[%s], endKey[%s]", startKey, endKey));
+      }
     }
 
     /** Removes region associated with regionId from regionCache. */
     public synchronized void invalidateRegion(TiRegion region) {
       try {
         if (logger.isDebugEnabled()) {
-          logger.debug(String.format("invalidateRegion ID[%s]", region.getId()));
+          logger.debug(String.format("invalidateRegion ID[%s] start", region.getId()));
         }
         TiRegion oldRegion = regionCache.get(getEncodedKey(region.getStartKey()));
         if (oldRegion != null && oldRegion.equals(region)) {
           regionCache.remove(makeRange(region.getStartKey(), region.getEndKey()));
+          if (logger.isDebugEnabled()) {
+            logger.debug(String.format("invalidateRegion ID[%s] success", region.getId()));
+          }
         }
-      } catch (Exception ignore) {
+      } catch (Exception e) {
+        logger.warn("invalidateRegion failed", e);
       }
     }
 

--- a/tikv-client/src/main/java/com/pingcap/tikv/region/RegionStoreClient.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/region/RegionStoreClient.java
@@ -710,9 +710,9 @@ public class RegionStoreClient extends AbstractRegionStoreClient {
       backOffer.doBackOff(
           BackOffFunction.BackOffFuncType.BoRegionMiss, new GrpcException(regionError.toString()));
       logger.warn("Re-splitting region task due to region error:" + regionError.getMessage());
-      // we need to invalidate cache
-      // Do we need to invalidateAllRegion? Do we need to invalidate store cache?
+      // we need to invalidate cache when region not find
       if (regionError.hasRegionNotFound()) {
+        logger.info("invalidateRange when Re-splitting region task because of region not find.");
         this.regionManager.invalidateRange(region.getStartKey(),region.getEndKey());
       }
       // Split ranges

--- a/tikv-client/src/main/java/com/pingcap/tikv/region/RegionStoreClient.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/region/RegionStoreClient.java
@@ -713,7 +713,7 @@ public class RegionStoreClient extends AbstractRegionStoreClient {
       // we need to invalidate cache
       // Do we need to invalidateAllRegion? Do we need to invalidate store cache?
       if (regionError.hasRegionNotFound()) {
-        this.regionManager.onRegionStale(region);
+        this.regionManager.invalidateRange(region.getStartKey(),region.getEndKey());
       }
       // Split ranges
       return RangeSplitter.newSplitter(this.regionManager).splitRangeByRegion(ranges, storeType);

--- a/tikv-client/src/main/java/com/pingcap/tikv/region/RegionStoreClient.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/region/RegionStoreClient.java
@@ -678,7 +678,7 @@ public class RegionStoreClient extends AbstractRegionStoreClient {
             forWrite);
     Coprocessor.Response resp =
         callWithRetry(backOffer, TikvGrpc.getCoprocessorMethod(), reqToSend, handler);
-    return handleCopResponse(backOffer, resp, ranges, responseQueue, startTs);
+    return handleCopResponse(backOffer, resp, ranges, responseQueue, startTs, region);
   }
 
   // handleCopResponse checks coprocessor Response for region split and lock,
@@ -690,7 +690,8 @@ public class RegionStoreClient extends AbstractRegionStoreClient {
       Coprocessor.Response response,
       List<Coprocessor.KeyRange> ranges,
       Queue<SelectResponse> responseQueue,
-      long startTs) {
+      long startTs,
+      TiRegion region) {
     boolean forWrite = false;
     if (response == null) {
       // Send request failed, reasons may:
@@ -709,6 +710,11 @@ public class RegionStoreClient extends AbstractRegionStoreClient {
       backOffer.doBackOff(
           BackOffFunction.BackOffFuncType.BoRegionMiss, new GrpcException(regionError.toString()));
       logger.warn("Re-splitting region task due to region error:" + regionError.getMessage());
+      // we need to invalidate cache
+      // Do we need to invalidateAllRegion? Do we need to invalidate store cache?
+      if (regionError.hasRegionNotFound()) {
+        this.regionManager.onRegionStale(region);
+      }
       // Split ranges
       return RangeSplitter.newSplitter(this.regionManager).splitRangeByRegion(ranges, storeType);
     }


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

`Region not find` when TiSpark request TiKV.

It may be because we forget to invalidate the cache when the region split.
