### PR TITLE
fix statistics

### DIFF
--- a/.github/workflows/alter-primary-key-false-test.yml
+++ b/.github/workflows/alter-primary-key-false-test.yml
@@ -39,4 +39,4 @@ jobs:
         run: mvn clean package -Dmaven.test.skip=true -B
 
       - name: test
-        run: mvn test -am -pl core -Dtest=moo -DwildcardSuites=org.apache.spark.sql.catalyst.plans.logical.LogicalPlanTestSuite,com.pingcap.tispark.datasource.AutoRandomSuite -DfailIfNoTests=false
+        run: mvn test -am -pl core -DtrimStackTrace=false -Dtest=moo -DwildcardSuites=org.apache.spark.sql.catalyst.plans.logical.LogicalPlanTestSuite,com.pingcap.tispark.datasource.AutoRandomSuite -DfailIfNoTests=false

--- a/.github/workflows/alter-primary-key-false-test.yml
+++ b/.github/workflows/alter-primary-key-false-test.yml
@@ -39,4 +39,4 @@ jobs:
         run: mvn clean package -Dmaven.test.skip=true -B
 
       - name: test
-        run: mvn test -am -pl core -DtrimStackTrace=false -Dtest=moo -DwildcardSuites=org.apache.spark.sql.catalyst.plans.logical.LogicalPlanTestSuite,com.pingcap.tispark.datasource.AutoRandomSuite -DfailIfNoTests=false
+        run: mvn test -am -pl core -Dtest=moo -DwildcardSuites=org.apache.spark.sql.catalyst.plans.logical.LogicalPlanTestSuite,com.pingcap.tispark.datasource.AutoRandomSuite -DfailIfNoTests=false

--- a/core/src/main/scala/com/pingcap/tispark/TiConfigConst.scala
+++ b/core/src/main/scala/com/pingcap/tispark/TiConfigConst.scala
@@ -36,6 +36,7 @@ object TiConfigConst {
   val REGION_INDEX_SCAN_DOWNGRADE_THRESHOLD: String =
     "spark.tispark.plan.downgrade.index_threshold"
   val UNSUPPORTED_TYPES: String = "spark.tispark.type.unsupported_mysql_types"
+  val ENABLE_AUTO_LOAD_STATISTICS: String = "spark.tispark.statistics.auto_load"
   val CACHE_EXPIRE_AFTER_ACCESS: String = "spark.tispark.statistics.expire_after_access"
   val SHOW_ROWID: String = "spark.tispark.show_rowid"
   val DB_PREFIX: String = "spark.tispark.db_prefix"

--- a/core/src/main/scala/com/pingcap/tispark/TiTableReference.scala
+++ b/core/src/main/scala/com/pingcap/tispark/TiTableReference.scala
@@ -19,4 +19,4 @@ package com.pingcap.tispark
 case class TiTableReference(
     databaseName: String,
     tableName: String,
-    sizeInBytes: Long = Long.MaxValue)
+    var sizeInBytes: Long = Long.MaxValue)

--- a/core/src/main/scala/org/apache/spark/sql/TiContext.scala
+++ b/core/src/main/scala/org/apache/spark/sql/TiContext.scala
@@ -68,6 +68,8 @@ class TiContext(val sparkSession: SparkSession) extends Serializable with Loggin
   clientSession.injectCallBackFunc(CacheInvalidateListener.getInstance())
   val meta: MetaManager = new MetaManager(clientSession.getCatalog)
   val debug: DebugTool = new DebugTool
+  val autoLoad: Boolean =
+    conf.getBoolean(TiConfigConst.ENABLE_AUTO_LOAD_STATISTICS, defaultValue = true)
 
   // add backtick for table name in case it contains, e.g., a minus sign
   private def getViewName(dbName: String, tableName: String, dbNameAsPrefix: Boolean): String =

--- a/core/src/main/scala/org/apache/spark/sql/TiExtensions.scala
+++ b/core/src/main/scala/org/apache/spark/sql/TiExtensions.scala
@@ -19,7 +19,11 @@ package org.apache.spark.sql
 import com.pingcap.tispark.TiConfigConst.TELEMETRY_ENABEL
 import com.pingcap.tispark.TiSparkInfo
 import com.pingcap.tispark.telemetry.TelemetryRule
-import org.apache.spark.sql.catalyst.rule.{TiAuthRuleFactory, TiAuthorizationRule, TiStatisticsRuleFactory}
+import org.apache.spark.sql.catalyst.rule.{
+  TiAuthRuleFactory,
+  TiAuthorizationRule,
+  TiStatisticsRuleFactory
+}
 import org.apache.spark.sql.catalyst.catalog.TiCatalog
 import org.apache.spark.sql.catalyst.parser.TiParserFactory
 import org.apache.spark.sql.catalyst.planner.TiStrategyFactory

--- a/core/src/main/scala/org/apache/spark/sql/TiExtensions.scala
+++ b/core/src/main/scala/org/apache/spark/sql/TiExtensions.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql
 import com.pingcap.tispark.TiConfigConst.TELEMETRY_ENABEL
 import com.pingcap.tispark.TiSparkInfo
 import com.pingcap.tispark.telemetry.TelemetryRule
-import org.apache.spark.sql.catalyst.analyzer.{TiAuthRuleFactory, TiAuthorizationRule}
+import org.apache.spark.sql.catalyst.rule.{TiAuthRuleFactory, TiAuthorizationRule, TiStatisticsRuleFactory}
 import org.apache.spark.sql.catalyst.catalog.TiCatalog
 import org.apache.spark.sql.catalyst.parser.TiParserFactory
 import org.apache.spark.sql.catalyst.planner.TiStrategyFactory
@@ -36,6 +36,7 @@ class TiExtensions extends (SparkSessionExtensions => Unit) {
 
     e.injectParser(TiParserFactory(getOrCreateTiContext))
     e.injectResolutionRule(new TiAuthRuleFactory(getOrCreateTiContext))
+    e.injectResolutionRule(new TiStatisticsRuleFactory(getOrCreateTiContext))
     e.injectPlannerStrategy(new TiStrategyFactory(getOrCreateTiContext))
     e.injectCheckRule(TelemetryRule)
   }

--- a/core/src/main/scala/org/apache/spark/sql/catalyst/rule/TiAuthRuleFactory.scala
+++ b/core/src/main/scala/org/apache/spark/sql/catalyst/rule/TiAuthRuleFactory.scala
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.spark.sql.catalyst.analyzer
+package org.apache.spark.sql.catalyst.rule
 
 import com.pingcap.tikv.TiConfiguration
 import com.pingcap.tispark.auth.TiAuthorization

--- a/core/src/main/scala/org/apache/spark/sql/catalyst/rule/TiAuthorizationRule.scala
+++ b/core/src/main/scala/org/apache/spark/sql/catalyst/rule/TiAuthorizationRule.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.apache.spark.sql.catalyst.analyzer
+package org.apache.spark.sql.catalyst.rule
 
 import com.pingcap.tispark.auth.TiAuthorization
 import com.pingcap.tispark.v2.TiDBTable

--- a/core/src/main/scala/org/apache/spark/sql/catalyst/rule/TiStatisticsRuleFactory.scala
+++ b/core/src/main/scala/org/apache/spark/sql/catalyst/rule/TiStatisticsRuleFactory.scala
@@ -1,0 +1,47 @@
+package org.apache.spark.sql.catalyst.rule
+
+import com.pingcap.tispark.statistics.StatisticsManager
+import com.pingcap.tispark.v2.TiDBTable
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
+import org.apache.spark.sql.{SparkSession, TiContext, TiExtensions}
+import org.slf4j.LoggerFactory
+
+class TiStatisticsRuleFactory(getOrCreateTiContext: SparkSession => TiContext)
+    extends (SparkSession => Rule[LogicalPlan]) {
+  private val logger = LoggerFactory.getLogger(getClass.getName)
+
+  override def apply(sparkSession: SparkSession): Rule[LogicalPlan] = {
+    TiExtensions.validateCatalog(sparkSession)
+    TiStatisticsRule(getOrCreateTiContext)(sparkSession)
+  }
+}
+
+case class TiStatisticsRule(getOrCreateTiContext: SparkSession => TiContext)(
+    sparkSession: SparkSession)
+    extends Rule[LogicalPlan] {
+  private val tiContext = getOrCreateTiContext(sparkSession)
+  private lazy val autoLoad = tiContext.autoLoad
+
+  protected def loadStatistics: PartialFunction[LogicalPlan, LogicalPlan] = {
+    case dr@DataSourceV2Relation(
+    tiTable@TiDBTable(_, _, _, _, _),
+    _,
+    _,
+    _,
+    _) =>
+      if (autoLoad) {
+        StatisticsManager.loadStatisticsInfo(tiTable.table)
+      }
+      val sizeInBytes = StatisticsManager.estimateTableSize(tiTable.table)
+      tiTable.tableRef.sizeInBytes = sizeInBytes
+      dr
+  }
+
+  override def apply(plan: LogicalPlan): LogicalPlan =
+    plan match {
+      case _ =>
+        plan transformUp loadStatistics
+    }
+}

--- a/core/src/main/scala/org/apache/spark/sql/catalyst/rule/TiStatisticsRuleFactory.scala
+++ b/core/src/main/scala/org/apache/spark/sql/catalyst/rule/TiStatisticsRuleFactory.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.spark.sql.catalyst.rule
 
 import com.pingcap.tispark.statistics.StatisticsManager

--- a/core/src/main/scala/org/apache/spark/sql/catalyst/rule/TiStatisticsRuleFactory.scala
+++ b/core/src/main/scala/org/apache/spark/sql/catalyst/rule/TiStatisticsRuleFactory.scala
@@ -41,12 +41,7 @@ case class TiStatisticsRule(getOrCreateTiContext: SparkSession => TiContext)(
   private lazy val autoLoad = tiContext.autoLoad
 
   protected def loadStatistics: PartialFunction[LogicalPlan, LogicalPlan] = {
-    case dr@DataSourceV2Relation(
-    tiTable@TiDBTable(_, _, _, _, _),
-    _,
-    _,
-    _,
-    _) =>
+    case dr @ DataSourceV2Relation(tiTable @ TiDBTable(_, _, _, _, _), _, _, _, _) =>
       if (autoLoad) {
         StatisticsManager.loadStatisticsInfo(tiTable.table)
       }

--- a/core/src/test/scala/org/apache/spark/SharedSparkContext.scala
+++ b/core/src/test/scala/org/apache/spark/SharedSparkContext.scala
@@ -24,6 +24,7 @@ trait SharedSparkContext extends BeforeAndAfterAll with BeforeAndAfterEach { sel
 
   protected var _isAuthEnabled: Boolean = false
   protected var _isHiveEnabled: Boolean = false
+  protected var _isStatisticsEnabled: Boolean = true
   protected var conf: SparkConf = new SparkConf(false)
 
   def sc: SparkContext = _sc

--- a/core/src/test/scala/org/apache/spark/sql/catalyst/plans/logical/LogicalPlanTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/catalyst/plans/logical/LogicalPlanTestSuite.scala
@@ -415,26 +415,19 @@ class LogicalPlanTestSuite extends BasePlanTest {
                        |) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
         """.stripMargin)
     tidbStmt.execute("CREATE INDEX `testIndex` ON `t1` (`a`,`b`)")
-    // IndexScan with Selection and with RangeFilter.
+    // TableRangeScan
     val df1 = spark.sql("SELECT * FROM t1 where a>0 and b > 'aa'")
     val dag1 = extractDAGRequests(df1).head
     val expectation1 =
       "== Physical Plan ==\n" +
         "*(1) ColumnarToRow\n" +
-        "+- TiSpark RegionTaskExec{downgradeThreshold=1000000000,downgradeFilter=[%s]\n" +
-        "   +- RowToColumnar\n" +
-        "      +- TiKV FetchHandleRDD{[table: t1] IndexLookUp, Columns: a@LONG, b@VARCHAR(255), c@VARCHAR(255): " +
-        "{ {IndexRangeScan(Index:testindex(a,b)): { RangeFilter: [%s], Range: [%s] }, " +
-        "Selection: [%s]}; " +
-        "{TableRowIDScan, Selection: [%s]} }, startTs: %s}".trim
-    val downgradeFilter1 = dag1.getDowngradeFilters.toArray.mkString(", ")
+        ("+- TiKV CoprocessorRDD{[table: t1] TableReader, Columns: a@LONG, b@VARCHAR(255), c@VARCHAR(255): " +
+          "{ TableRangeScan: { RangeFilter: [%s], Range: [%s] }, Selection: [%s] }, startTs: %d}").trim
     val rangeFilter1 = dag1.getRangeFilter.toArray.mkString(", ")
     val selection1 = dag1.getFilters.toArray.mkString(", ")
     val myExpectationPlan1 = expectation1.format(
-      downgradeFilter1,
       rangeFilter1,
       stringKeyRangeInDAG(dag1),
-      selection1,
       selection1,
       dag1.getStartTs.getVersion)
     val sparkPhysicalPlan1 =
@@ -485,30 +478,23 @@ class LogicalPlanTestSuite extends BasePlanTest {
       myExpectationPlan3
         .equals(sparkPhysicalPlan3))
 
-    // IndexScan with complex sql statements
+    // TableRangeScan
     val df4 = spark.sql(
       "SELECT max(c) FROM t1 where a>0 and c > 'cc' and c < 'bb' group by c order by(c)")
     val dag4 = extractDAGRequests(df4).head
-    val regionTaskExec4 =
-      extractRegionTaskExecs(df4).head.verboseString(25).trim
+
     val rangeFilter4 = dag4.getRangeFilter.toArray.mkString(", ")
-    val downgradeFilter4 = dag4.getDowngradeFilters.toArray.mkString(", ")
     val selection4 = dag4.getFilters.toArray.mkString(", ")
-    var expectRegionTaskExec4 =
-      ("TiSpark RegionTaskExec{downgradeThreshold=1000000000,downgradeFilter=[%s]")
-    expectRegionTaskExec4 = expectRegionTaskExec4.format(downgradeFilter4)
-    var expectDAG4 = "[table: t1] IndexLookUp, Columns: c@VARCHAR(255), a@LONG: " +
-      "{ {IndexRangeScan(Index:testindex(a,b)): " +
-      "{ RangeFilter: [%s], " +
-      "Range: [%s] }}; " +
-      "{TableRowIDScan, Selection: [%s], Aggregates: Max(c@VARCHAR(255)), First(c@VARCHAR(255)), " +
-      "Group By: [c@VARCHAR(255) ASC]} }, startTs: %d"
+    var expectDAG4 = "[table: t1] TableReader, Columns: c@VARCHAR(255), a@LONG: " +
+      "{ TableRangeScan: { RangeFilter: [%s], Range: [%s] }, " +
+      "Selection: [%s], Aggregates: Max(c@VARCHAR(255)), First(c@VARCHAR(255)), " +
+      "Group By: [c@VARCHAR(255) ASC] }, startTs: %d"
+
     expectDAG4 = expectDAG4.format(
       rangeFilter4,
       stringKeyRangeInDAG(dag4),
       selection4,
       dag4.getStartTs.getVersion)
-    assert(expectRegionTaskExec4.equals(regionTaskExec4))
     assert(expectDAG4.equals(dag4.toString))
 
     // IndexScan with complex sql statements
@@ -590,6 +576,23 @@ class LogicalPlanTestSuite extends BasePlanTest {
       myExpectationPlan2
         .equals(sparkPhysicalPlan2))
 
+    // TableRangeScan
+    val df3 = spark.sql("SELECT sum(a) FROM t1 where  b > 'cc' or b < 'bb' and a>0 limit(10)")
+    val dag3 = extractDAGRequests(df3).head
+    val expectation3 =
+      ("[table: t1] TableReader, Columns: b@VARCHAR(255), a@LONG: " +
+        "{ TableRangeScan: { RangeFilter: [%s], Range: [%s] }, " +
+        "Selection: [%s], " +
+        "Aggregates: Sum(a@LONG) }, startTs: %d").trim
+
+    val rangeFilter3 = dag3.getRangeFilter.toArray.mkString(", ")
+    val selection3 = dag3.getFilters.toArray.mkString(", ")
+    val myExpectation3 = expectation3.format(
+      rangeFilter3,
+      stringKeyRangeInDAG(dag3),
+      selection3,
+      dag3.getStartTs.getVersion)
+    assert(myExpectation3.equals(dag3.toString.trim))
   }
 
   // https://github.com/pingcap/tispark/issues/1498

--- a/core/src/test/scala/org/apache/spark/sql/catalyst/plans/logical/LogicalPlanTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/catalyst/plans/logical/LogicalPlanTestSuite.scala
@@ -34,11 +34,10 @@ import java.util
 class LogicalPlanTestSuite extends BasePlanTest {
 
   // When statistics is enabled, the plan will be different caused by CBO.
+  // In order to get the exact result, we need to disable statistics.
   override def beforeAll(): Unit = {
     _isStatisticsEnabled = false
     super.beforeAll()
-    initializeContext()
-    initializeSparkSession()
   }
 
   override def afterAll(): Unit = {
@@ -54,7 +53,7 @@ class LogicalPlanTestSuite extends BasePlanTest {
     }
   }
 
-    // https://github.com/pingcap/tispark/issues/2328
+  // https://github.com/pingcap/tispark/issues/2328
   test("limit push down fail in df.show") {
     tidbStmt.execute("DROP TABLE IF EXISTS `test_l`")
     tidbStmt.execute(

--- a/core/src/test/scala/org/apache/spark/sql/statistics/StatisticsManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/statistics/StatisticsManagerSuite.scala
@@ -27,8 +27,7 @@ class StatisticsManagerSuite extends BaseTiSparkTest {
   // fix issue: https://github.com/pingcap/tispark/issues/2573
   test("Physical Plan should print EstimatedCount") {
     val df = spark
-      .sql(
-        """select * from tidb_catalog.tpch_test.LINEITEM
+      .sql("""select * from tidb_catalog.tpch_test.LINEITEM
           |""".stripMargin)
       .groupBy("l_linestatus")
       .count()

--- a/core/src/test/scala/org/apache/spark/sql/statistics/StatisticsManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/statistics/StatisticsManagerSuite.scala
@@ -19,5 +19,22 @@
 package org.apache.spark.sql.statistics
 
 import org.apache.spark.sql.BaseTiSparkTest
+import org.apache.spark.sql.execution.SimpleMode
+import org.scalatest.Matchers.{convertToAnyShouldWrapper, include}
 
-class StatisticsManagerSuite extends BaseTiSparkTest {}
+class StatisticsManagerSuite extends BaseTiSparkTest {
+
+  // fix issue: https://github.com/pingcap/tispark/issues/2573
+  test("Physical Plan should print EstimatedCount") {
+    val df = spark
+      .sql(
+        """select * from tidb_catalog.tpch_test.LINEITEM
+          |""".stripMargin)
+      .groupBy("l_linestatus")
+      .count()
+
+    val explainStr = df.queryExecution.explainString(SimpleMode)
+
+    explainStr should include("EstimatedCount:")
+  }
+}

--- a/core/src/test/scala/org/apache/spark/sql/test/SharedSQLContext.scala
+++ b/core/src/test/scala/org/apache/spark/sql/test/SharedSQLContext.scala
@@ -32,7 +32,7 @@ import org.apache.spark.{SharedSparkContext, SparkConf, SparkFunSuite}
 import org.joda.time.DateTimeZone
 import org.scalatest.concurrent.Eventually
 import org.slf4j.Logger
-import org.tikv.common.{StoreVersion, Version}
+import org.tikv.common.Version
 
 import java.io.File
 import java.sql.{Connection, Date, Statement}
@@ -459,6 +459,7 @@ trait SharedSQLContext
       }
       import com.pingcap.tispark.TiConfigConst._
       conf.set(PD_ADDRESSES, pdAddresses)
+      conf.set(ENABLE_AUTO_LOAD_STATISTICS, "true")
       conf.set(ALLOW_INDEX_READ, getFlagOrTrue(_tidbConf, ALLOW_INDEX_READ).toString)
       conf.set("spark.sql.decimalOperations.allowPrecisionLoss", "false")
       conf.set(REQUEST_ISOLATION_LEVEL, SNAPSHOT_ISOLATION_LEVEL)

--- a/core/src/test/scala/org/apache/spark/sql/test/SharedSQLContext.scala
+++ b/core/src/test/scala/org/apache/spark/sql/test/SharedSQLContext.scala
@@ -459,7 +459,9 @@ trait SharedSQLContext
       }
       import com.pingcap.tispark.TiConfigConst._
       conf.set(PD_ADDRESSES, pdAddresses)
-      conf.set(ENABLE_AUTO_LOAD_STATISTICS, "true")
+      if (!_isStatisticsEnabled) {
+        conf.set(ENABLE_AUTO_LOAD_STATISTICS, "false")
+      }
       conf.set(ALLOW_INDEX_READ, getFlagOrTrue(_tidbConf, ALLOW_INDEX_READ).toString)
       conf.set("spark.sql.decimalOperations.allowPrecisionLoss", "false")
       conf.set(REQUEST_ISOLATION_LEVEL, SNAPSHOT_ISOLATION_LEVEL)

--- a/docs/userguide_2.0.md
+++ b/docs/userguide_2.0.md
@@ -277,6 +277,15 @@ See [here](https://github.com/pingcap/docs/blob/master/statistics.md) for more d
 
 Since TiSpark 2.0, statistics information is default to auto-load.
 
+> **Note:**
+>
+> Table statistics is cached in your Spark driver node's memory, so you need to make sure that the memory is large enough for the statistics information.
+Currently, you can adjust these configurations in your `spark.conf` file.
+
+| Property Name | Default | Description
+| --------   | -----:   | :----: |
+| `spark.tispark.statistics.auto_load` | `true` | Whether to load the statistics information automatically during database mapping |
+
 # FAQ
 
 See our wiki [TiSpark FAQ](https://github.com/pingcap/tispark/wiki/TiSpark-FAQ)

--- a/docs/userguide_3.0.md
+++ b/docs/userguide_3.0.md
@@ -437,6 +437,15 @@ See [here](https://github.com/pingcap/docs/blob/master/statistics.md) for more d
 
 Since TiSpark 2.0, statistics information is default to auto-load.
 
+> **Note:**
+>
+> Table statistics is cached in your Spark driver node's memory, so you need to make sure that the memory is large enough for the statistics information.
+Currently, you can adjust these configurations in your `spark.conf` file.
+
+| Property Name | Default | Description
+| --------   | -----:   | :----: |
+| `spark.tispark.statistics.auto_load` | `true` | Whether to load the statistics information automatically during database mapping |
+
 # FAQ
 
 See our wiki [TiSpark FAQ](https://github.com/pingcap/tispark/wiki/TiSpark-FAQ)


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

close #2573
In https://github.com/pingcap/tispark/pull/2259, TiResolutionRule was deleted, which cause statistics would not be collected.
Thus in https://github.com/pingcap/tispark/pull/2300/files, `ENABLE_AUTO_LOAD_STATISTICS` was considered to be useless and deprecated.

### What is changed and how it works?

- add a new ResolutionRule to collect statistics if `ENABLE_AUTO_LOAD_STATISTICS` is true.
- add documents to explain `ENABLE_AUTO_LOAD_STATISTICS`.
- fix the logicalPlan result.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to be included in the release note
