### PR TITLE
Support partition pruning with to_days function

### DIFF
--- a/core/src/test/scala/com/pingcap/tispark/partition/PartitionPruningSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/partition/PartitionPruningSuite.scala
@@ -1,0 +1,8 @@
+package com.pingcap.tispark.partition
+
+import org.apache.spark.sql.catalyst.plans.BasePlanTest
+
+class PartitionPruningSuite extends BasePlanTest{
+
+
+}

--- a/core/src/test/scala/com/pingcap/tispark/partition/PartitionPruningSuite.scala
+++ b/core/src/test/scala/com/pingcap/tispark/partition/PartitionPruningSuite.scala
@@ -1,8 +1,0 @@
-package com.pingcap.tispark.partition
-
-import org.apache.spark.sql.catalyst.plans.BasePlanTest
-
-class PartitionPruningSuite extends BasePlanTest{
-
-
-}

--- a/core/src/test/scala/org/apache/spark/sql/PartitionTableSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/PartitionTableSuite.scala
@@ -411,7 +411,7 @@ class PartitionTableSuite extends BasePlanTest {
 
   test("part pruning on to_days function and date type") {
     enablePartitionForTiDB()
-    tidbStmt.execute("DROP TABLE IF EXISTS `pt_todays`")
+    tidbStmt.execute("DROP TABLE IF EXISTS `pt_todays_date`")
     // to_days('2005-01-02') = 732313
     val s = ("""
                |CREATE TABLE `pt_todays_date` (
@@ -517,9 +517,9 @@ class PartitionTableSuite extends BasePlanTest {
         |  index `idx_id`(`id`)
         |) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin
         |PARTITION BY RANGE (to_days(purchased)) (
-        |  PARTITION p0 VALUES LESS THAN (to_days('1995-01-01')),
-        |  PARTITION p1 VALUES LESS THAN (to_days('1995-01-02')),
-        |  PARTITION p2 VALUES LESS THAN (to_days('1995-01-03')),
+        |  PARTITION p0 VALUES LESS THAN (to_days('1969-12-31')),
+        |  PARTITION p1 VALUES LESS THAN (to_days('1970-01-01')),
+        |  PARTITION p2 VALUES LESS THAN (to_days('1970-01-02')),
         |  PARTITION p3 VALUES LESS THAN (MAXVALUE)
         |)
                      """.stripMargin)
@@ -528,7 +528,7 @@ class PartitionTableSuite extends BasePlanTest {
       val pDef = extractDAGReq(
         spark
         // expected part info only contains one part which is p0.
-          .sql("select * from pt_todays_datetime where purchased = '1994-12-31 00:00:00'")).getPrunedParts
+          .sql("select * from pt_todays_datetime where purchased = '1969-12-30 00:00:00'")).getPrunedParts
       pDef.size() == 1 && pDef.get(0).getName == "p0"
     }
 
@@ -536,7 +536,7 @@ class PartitionTableSuite extends BasePlanTest {
       val pDef = extractDAGReq(
         spark
         // expected part info only contains one part which is p1.
-          .sql("select * from pt_todays_datetime where purchased = '1995-01-01 00:00:01'")).getPrunedParts
+          .sql("select * from pt_todays_datetime where purchased = '1969-12-31 00:00:01'")).getPrunedParts
       pDef.size() == 1 && pDef.get(0).getName == "p1"
     }
 
@@ -544,7 +544,7 @@ class PartitionTableSuite extends BasePlanTest {
       val pDef = extractDAGReq(
         spark
         // expected part info only contains one part which is p2.
-          .sql("select * from pt_todays_datetime where purchased = '1995-01-02 00:01:00'")).getPrunedParts
+          .sql("select * from pt_todays_datetime where purchased = '1970-01-01 00:01:00'")).getPrunedParts
       pDef.size() == 1 && pDef.get(0).getName == "p2"
     }
 
@@ -552,7 +552,7 @@ class PartitionTableSuite extends BasePlanTest {
       val pDef = extractDAGReq(
         spark
         // expected part info only contains one part which is p3.
-          .sql("select * from pt_todays_datetime where purchased = '1995-01-03 01:00:00'")).getPrunedParts
+          .sql("select * from pt_todays_datetime where purchased = '1970-01-02 01:00:00'")).getPrunedParts
       pDef.size() == 1 && pDef.get(0).getName == "p3"
     }
 
@@ -560,7 +560,7 @@ class PartitionTableSuite extends BasePlanTest {
       val pDef = extractDAGReq(
         spark
         // expected part info only contains one part which is p2,p3
-          .sql("select * from pt_todays_datetime where purchased >= '1995-01-02 01:00:00'")).getPrunedParts
+          .sql("select * from pt_todays_datetime where purchased >= '1970-01-01 01:00:00'")).getPrunedParts
       pDef.size() == 2 && pDef.get(0).getName == "p2" && pDef.get(1).getName == "p3"
     }
   }

--- a/core/src/test/scala/org/apache/spark/sql/PartitionTableSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/PartitionTableSuite.scala
@@ -363,13 +363,13 @@ class PartitionTableSuite extends BasePlanTest {
     assert(
       extractDAGReq(
         spark
-          // expected part info only contains one part which is p.
+        // expected part info only contains one part which is p.
           .sql("select * from pt3 where purchased = date'1994-10-10'")).getPrunedParts
         .get(0)
         .getName == "p0")
 
     assert(extractDAGReq(spark
-      // expected part info only contains one part which is p1.
+    // expected part info only contains one part which is p1.
       .sql(
         "select * from pt3 where purchased > date'1996-10-10' and purchased < date'2000-10-10'")).getPrunedParts
       .get(0)
@@ -378,14 +378,14 @@ class PartitionTableSuite extends BasePlanTest {
     assert {
       val pDef = extractDAGReq(
         spark
-          // expected part info only contains two parts which are p0 and p1.
+        // expected part info only contains two parts which are p0 and p1.
           .sql("select * from pt3 where purchased < date'2000-10-10'")).getPrunedParts
       pDef.size() == 2 && pDef.get(0).getName == "p0" && pDef.get(1).getName == "p1"
     }
 
     assert {
       val pDef = extractDAGReq(spark
-        // expected part info only contains one part which is p1.
+      // expected part info only contains one part which is p1.
         .sql(
           "select * from pt3 where purchased < date'2005-10-10' and purchased > date'2000-10-10'")).getPrunedParts
       pDef.size() == 1 && pDef.get(0).getName == "p2"
@@ -394,7 +394,7 @@ class PartitionTableSuite extends BasePlanTest {
     assert {
       val pDef = extractDAGReq(
         spark
-          // or with an unrelated column. All parts should be accessed.
+        // or with an unrelated column. All parts should be accessed.
           .sql("select * from pt3 where id < 4 or purchased < date'1995-10-10'")).getPrunedParts
       pDef.size() == 4
     }
@@ -408,7 +408,6 @@ class PartitionTableSuite extends BasePlanTest {
       pDef.size() == 4
     }
   }
-
 
   test("part pruning on to_days function and date type") {
     enablePartitionForTiDB()
@@ -443,44 +442,44 @@ class PartitionTableSuite extends BasePlanTest {
                        |)
                      """.stripMargin)
 
-    assert{
+    assert {
       val pDef = extractDAGReq(
         spark
-          // expected part info only contains one part which is p0.
+        // expected part info only contains one part which is p0.
           .sql("select * from pt_todays_date where purchased = '1994-10-10'")).getPrunedParts
       pDef.size() == 1 && pDef.get(0).getName == "p0"
     }
 
-    assert{
-      val pDef = extractDAGReq(spark
-      // expected part info only contains one part which is p1.
-      .sql(
-        "select * from pt_todays_date where purchased >= '2000-01-01 00:00:00' and purchased < '2000-01-02 23:59:59'")).getPrunedParts
+    assert {
+      val pDef = extractDAGReq(
+        spark
+        // expected part info only contains one part which is p1.
+          .sql(
+            "select * from pt_todays_date where purchased >= '2000-01-01 00:00:00' and purchased < '2000-01-02 23:59:59'")).getPrunedParts
       pDef.size() == 1 && pDef.get(0).getName == "p1"
     }
 
-    assert{
-      val pDef = extractDAGReq(spark
+    assert {
+      val pDef = extractDAGReq(
+        spark
         // expected part info only contains one part which is p2.
-        .sql(
-          "select * from pt_todays_date where purchased = '2005-01-01'")).getPrunedParts
+          .sql("select * from pt_todays_date where purchased = '2005-01-01'")).getPrunedParts
       pDef.size() == 1 && pDef.get(0).getName == "p2"
     }
 
-    assert{
-      val pDef = extractDAGReq(spark
+    assert {
+      val pDef = extractDAGReq(
+        spark
         // expected part info only contains one part which is p3.
-        .sql(
-          "select * from pt_todays_date where purchased = '2005-01-02'")).getPrunedParts
+          .sql("select * from pt_todays_date where purchased = '2005-01-02'")).getPrunedParts
       pDef.size() == 1 && pDef.get(0).getName == "p3"
     }
-
 
     // more than one part is pruned
     assert {
       val pDef = extractDAGReq(
         spark
-          // expected part info only contains two parts which are p0 and p1.
+        // expected part info only contains two parts which are p0 and p1.
           .sql("select * from pt_todays_date where purchased < '2000-01-02'")).getPrunedParts
       pDef.size() == 2 && pDef.get(0).getName == "p0" && pDef.get(1).getName == "p1"
     }
@@ -488,16 +487,19 @@ class PartitionTableSuite extends BasePlanTest {
     assert {
       val pDef = extractDAGReq(
         spark
-          // expected part info only contains two parts which are p0 p2 and p3.
-          .sql("select * from pt_todays_date where purchased = '1995-01-01' or purchased >= '2005-01-01' ")).getPrunedParts
-      pDef.size() == 3 && pDef.get(0).getName == "p0" && pDef.get(1).getName == "p2" && pDef.get(2).getName == "p3"
+        // expected part info only contains two parts which are p0 p2 and p3.
+          .sql(
+            "select * from pt_todays_date where purchased = '1995-01-01' or purchased >= '2005-01-01' ")).getPrunedParts
+      pDef.size() == 3 && pDef.get(0).getName == "p0" && pDef.get(1).getName == "p2" && pDef
+        .get(2)
+        .getName == "p3"
     }
 
     // not supported
     assert {
       val pDef = extractDAGReq(
         spark
-          // or with an unrelated column. All parts should be accessed.
+        // or with an unrelated column. All parts should be accessed.
           .sql("select * from pt_todays_date where id < 4 or purchased < date'1995-10-10'")).getPrunedParts
       pDef.size() == 4
     }
@@ -507,8 +509,7 @@ class PartitionTableSuite extends BasePlanTest {
   test("part pruning on to_days function and datetime type") {
     enablePartitionForTiDB()
     tidbStmt.execute("DROP TABLE IF EXISTS `pt_todays_datetime`")
-    tidbStmt.execute(
-      """
+    tidbStmt.execute("""
         |CREATE TABLE `pt_todays_datetime` (
         |  `id` int(11) DEFAULT NULL,
         |  `name` varchar(50) DEFAULT NULL,
@@ -523,47 +524,46 @@ class PartitionTableSuite extends BasePlanTest {
         |)
                      """.stripMargin)
 
-    assert{
+    assert {
       val pDef = extractDAGReq(
         spark
-          // expected part info only contains one part which is p0.
+        // expected part info only contains one part which is p0.
           .sql("select * from pt_todays_datetime where purchased = '1994-12-31 00:00:00'")).getPrunedParts
       pDef.size() == 1 && pDef.get(0).getName == "p0"
     }
 
-    assert{
+    assert {
       val pDef = extractDAGReq(
         spark
-          // expected part info only contains one part which is p1.
+        // expected part info only contains one part which is p1.
           .sql("select * from pt_todays_datetime where purchased = '1995-01-01 00:00:01'")).getPrunedParts
       pDef.size() == 1 && pDef.get(0).getName == "p1"
     }
 
-    assert{
+    assert {
       val pDef = extractDAGReq(
         spark
-          // expected part info only contains one part which is p2.
+        // expected part info only contains one part which is p2.
           .sql("select * from pt_todays_datetime where purchased = '1995-01-02 00:01:00'")).getPrunedParts
       pDef.size() == 1 && pDef.get(0).getName == "p2"
     }
 
-    assert{
+    assert {
       val pDef = extractDAGReq(
         spark
-          // expected part info only contains one part which is p3.
+        // expected part info only contains one part which is p3.
           .sql("select * from pt_todays_datetime where purchased = '1995-01-03 01:00:00'")).getPrunedParts
       pDef.size() == 1 && pDef.get(0).getName == "p3"
     }
 
-    assert{
+    assert {
       val pDef = extractDAGReq(
         spark
-          // expected part info only contains one part which is p2,p3
+        // expected part info only contains one part which is p2,p3
           .sql("select * from pt_todays_datetime where purchased >= '1995-01-02 01:00:00'")).getPrunedParts
       pDef.size() == 2 && pDef.get(0).getName == "p2" && pDef.get(1).getName == "p3"
     }
   }
-
 
   test("adding part pruning test when index is on partitioned column") {
     enablePartitionForTiDB()

--- a/core/src/test/scala/org/apache/spark/sql/PartitionTableSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/PartitionTableSuite.scala
@@ -414,6 +414,20 @@ class PartitionTableSuite extends BasePlanTest {
     enablePartitionForTiDB()
     tidbStmt.execute("DROP TABLE IF EXISTS `pt_todays`")
     // to_days('2005-01-02') = 732313
+    val s = ("""
+               |CREATE TABLE `pt_todays_date` (
+               |  `id` int(11) DEFAULT NULL,
+               |  `name` varchar(50) DEFAULT NULL,
+               |  `purchased` date DEFAULT NULL,
+               |  index `idx_id`(`id`)
+               |) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin
+               |PARTITION BY RANGE (to_days(purchased)) (
+               |  PARTITION p0 VALUES LESS THAN (to_days('1995-01-02')),
+               |  PARTITION p1 VALUES LESS THAN (to_days('2000-01-02')),
+               |  PARTITION p2 VALUES LESS THAN (732313),
+               |  PARTITION p3 VALUES LESS THAN (MAXVALUE)
+               |)
+                     """.stripMargin)
     tidbStmt.execute("""
                        |CREATE TABLE `pt_todays_date` (
                        |  `id` int(11) DEFAULT NULL,

--- a/core/src/test/scala/org/apache/spark/sql/PartitionTableSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/PartitionTableSuite.scala
@@ -273,7 +273,7 @@ class PartitionTableSuite extends BasePlanTest {
         .size() == 3)
   }
 
-  test("part pruning on year function") {
+  test("part pruning on year function and date type") {
     enablePartitionForTiDB()
     tidbStmt.execute("DROP TABLE IF EXISTS `pt3`")
     tidbStmt.execute("""
@@ -340,6 +340,216 @@ class PartitionTableSuite extends BasePlanTest {
       pDef.size() == 4
     }
   }
+
+  test("part pruning on year function and datetime type") {
+    enablePartitionForTiDB()
+    tidbStmt.execute("DROP TABLE IF EXISTS `pt3`")
+    tidbStmt.execute("""
+                       |CREATE TABLE `pt3` (
+                       |  `id` int(11) DEFAULT NULL,
+                       |  `name` varchar(50) DEFAULT NULL,
+                       |  `purchased` datetime DEFAULT NULL,
+                       |  index `idx_id`(`id`)
+                       |) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin
+                       |PARTITION BY RANGE (year(purchased)) (
+                       |  PARTITION p0 VALUES LESS THAN (1995),
+                       |  PARTITION p1 VALUES LESS THAN (2000),
+                       |  PARTITION p2 VALUES LESS THAN (2005),
+                       |  PARTITION p3 VALUES LESS THAN (MAXVALUE)
+                       |)
+                     """.stripMargin)
+    refreshConnections()
+
+    assert(
+      extractDAGReq(
+        spark
+          // expected part info only contains one part which is p.
+          .sql("select * from pt3 where purchased = date'1994-10-10'")).getPrunedParts
+        .get(0)
+        .getName == "p0")
+
+    assert(extractDAGReq(spark
+      // expected part info only contains one part which is p1.
+      .sql(
+        "select * from pt3 where purchased > date'1996-10-10' and purchased < date'2000-10-10'")).getPrunedParts
+      .get(0)
+      .getName == "p1")
+
+    assert {
+      val pDef = extractDAGReq(
+        spark
+          // expected part info only contains two parts which are p0 and p1.
+          .sql("select * from pt3 where purchased < date'2000-10-10'")).getPrunedParts
+      pDef.size() == 2 && pDef.get(0).getName == "p0" && pDef.get(1).getName == "p1"
+    }
+
+    assert {
+      val pDef = extractDAGReq(spark
+        // expected part info only contains one part which is p1.
+        .sql(
+          "select * from pt3 where purchased < date'2005-10-10' and purchased > date'2000-10-10'")).getPrunedParts
+      pDef.size() == 1 && pDef.get(0).getName == "p2"
+    }
+
+    assert {
+      val pDef = extractDAGReq(
+        spark
+          // or with an unrelated column. All parts should be accessed.
+          .sql("select * from pt3 where id < 4 or purchased < date'1995-10-10'")).getPrunedParts
+      pDef.size() == 4
+    }
+
+    assert {
+      val pDef = extractDAGReq(
+        // for complicated expression, we do not support for now.
+        // this will be improved later.
+        spark
+          .sql("select * from pt3 where year(purchased) < 1995")).getPrunedParts
+      pDef.size() == 4
+    }
+  }
+
+
+  test("part pruning on to_days function and date type") {
+    enablePartitionForTiDB()
+    tidbStmt.execute("DROP TABLE IF EXISTS `pt_todays`")
+    // to_days('2005-01-02') = 732313
+    tidbStmt.execute("""
+                       |CREATE TABLE `pt_todays_date` (
+                       |  `id` int(11) DEFAULT NULL,
+                       |  `name` varchar(50) DEFAULT NULL,
+                       |  `purchased` date DEFAULT NULL,
+                       |  index `idx_id`(`id`)
+                       |) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin
+                       |PARTITION BY RANGE (to_days(purchased)) (
+                       |  PARTITION p0 VALUES LESS THAN (to_days('1995-01-02')),
+                       |  PARTITION p1 VALUES LESS THAN (to_days('2000-01-02')),
+                       |  PARTITION p2 VALUES LESS THAN (732313),
+                       |  PARTITION p3 VALUES LESS THAN (MAXVALUE)
+                       |)
+                     """.stripMargin)
+
+    assert{
+      val pDef = extractDAGReq(
+        spark
+          // expected part info only contains one part which is p0.
+          .sql("select * from pt_todays_date where purchased = '1994-10-10'")).getPrunedParts
+      pDef.size() == 1 && pDef.get(0).getName == "p0"
+    }
+
+    assert{
+      val pDef = extractDAGReq(spark
+      // expected part info only contains one part which is p1.
+      .sql(
+        "select * from pt_todays_date where purchased >= '2000-01-01 00:00:00' and purchased < '2000-01-02 23:59:59'")).getPrunedParts
+      pDef.size() == 1 && pDef.get(0).getName == "p1"
+    }
+
+    assert{
+      val pDef = extractDAGReq(spark
+        // expected part info only contains one part which is p2.
+        .sql(
+          "select * from pt_todays_date where purchased = '2005-01-01'")).getPrunedParts
+      pDef.size() == 1 && pDef.get(0).getName == "p2"
+    }
+
+    assert{
+      val pDef = extractDAGReq(spark
+        // expected part info only contains one part which is p3.
+        .sql(
+          "select * from pt_todays_date where purchased = '2005-01-02'")).getPrunedParts
+      pDef.size() == 1 && pDef.get(0).getName == "p3"
+    }
+
+
+    // more than one part is pruned
+    assert {
+      val pDef = extractDAGReq(
+        spark
+          // expected part info only contains two parts which are p0 and p1.
+          .sql("select * from pt_todays_date where purchased < '2000-01-02'")).getPrunedParts
+      pDef.size() == 2 && pDef.get(0).getName == "p0" && pDef.get(1).getName == "p1"
+    }
+
+    assert {
+      val pDef = extractDAGReq(
+        spark
+          // expected part info only contains two parts which are p0 p2 and p3.
+          .sql("select * from pt_todays_date where purchased = '1995-01-01' or purchased >= '2005-01-01' ")).getPrunedParts
+      pDef.size() == 3 && pDef.get(0).getName == "p0" && pDef.get(1).getName == "p2" && pDef.get(2).getName == "p3"
+    }
+
+    // not supported
+    assert {
+      val pDef = extractDAGReq(
+        spark
+          // or with an unrelated column. All parts should be accessed.
+          .sql("select * from pt_todays_date where id < 4 or purchased < date'1995-10-10'")).getPrunedParts
+      pDef.size() == 4
+    }
+
+  }
+
+  test("part pruning on to_days function and datetime type") {
+    enablePartitionForTiDB()
+    tidbStmt.execute("DROP TABLE IF EXISTS `pt_todays_datetime`")
+    tidbStmt.execute(
+      """
+        |CREATE TABLE `pt_todays_datetime` (
+        |  `id` int(11) DEFAULT NULL,
+        |  `name` varchar(50) DEFAULT NULL,
+        |  `purchased` datetime DEFAULT NULL,
+        |  index `idx_id`(`id`)
+        |) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin
+        |PARTITION BY RANGE (to_days(purchased)) (
+        |  PARTITION p0 VALUES LESS THAN (to_days('1995-01-01')),
+        |  PARTITION p1 VALUES LESS THAN (to_days('1995-01-02')),
+        |  PARTITION p2 VALUES LESS THAN (to_days('1995-01-03')),
+        |  PARTITION p3 VALUES LESS THAN (MAXVALUE)
+        |)
+                     """.stripMargin)
+
+    assert{
+      val pDef = extractDAGReq(
+        spark
+          // expected part info only contains one part which is p0.
+          .sql("select * from pt_todays_datetime where purchased = '1994-12-31 00:00:00'")).getPrunedParts
+      pDef.size() == 1 && pDef.get(0).getName == "p0"
+    }
+
+    assert{
+      val pDef = extractDAGReq(
+        spark
+          // expected part info only contains one part which is p1.
+          .sql("select * from pt_todays_datetime where purchased = '1995-01-01 00:00:01'")).getPrunedParts
+      pDef.size() == 1 && pDef.get(0).getName == "p1"
+    }
+
+    assert{
+      val pDef = extractDAGReq(
+        spark
+          // expected part info only contains one part which is p2.
+          .sql("select * from pt_todays_datetime where purchased = '1995-01-02 00:01:00'")).getPrunedParts
+      pDef.size() == 1 && pDef.get(0).getName == "p2"
+    }
+
+    assert{
+      val pDef = extractDAGReq(
+        spark
+          // expected part info only contains one part which is p3.
+          .sql("select * from pt_todays_datetime where purchased = '1995-01-03 01:00:00'")).getPrunedParts
+      pDef.size() == 1 && pDef.get(0).getName == "p3"
+    }
+
+    assert{
+      val pDef = extractDAGReq(
+        spark
+          // expected part info only contains one part which is p2,p3
+          .sql("select * from pt_todays_datetime where purchased >= '1995-01-02 01:00:00'")).getPrunedParts
+      pDef.size() == 2 && pDef.get(0).getName == "p2" && pDef.get(1).getName == "p3"
+    }
+  }
+
 
   test("adding part pruning test when index is on partitioned column") {
     enablePartitionForTiDB()

--- a/docs/userguide_3.0.md
+++ b/docs/userguide_3.0.md
@@ -385,15 +385,13 @@ TiSpark reads the range and hash partition table from TiDB.
 
 Currently, TiSpark doesn't support a MySQL/TiDB partition table syntax `select col_name from table_name partition(partition_name)`, but you can still use `where` condition to filter the partitions.
 
-TiSpark decides whether to apply partition pruning according to the partition type and the partition expression associated with the table.
-
-Currently, TiSpark partially apply partition pruning on range partition.
+TiSpark decides whether to apply partition pruning according to the partition type and the partition expression associated with the table. Currently, TiSpark partially apply partition pruning on range partition.
 
 The partition pruning is applied when the partition expression of the range partition is one of the following:
 
 + column expression
-+ `YEAR($argument)` where the argument is a column and its type is datetime or string literal
-  that can be parsed as datetime.
++ `YEAR(col)` and its type is datetime/string/date literal that can be parsed as datetime.
++ `TO_DAYS(col)` and its type is datetime/string/date literal that can be parsed as datetime.
 
 If partition pruning is not applied, TiSpark's reading is equivalent to doing a table scan over all partitions.
 

--- a/docs/userguide_3.0.md
+++ b/docs/userguide_3.0.md
@@ -391,7 +391,7 @@ The partition pruning is applied when the partition expression of the range part
 
 + column expression
 + `YEAR(col)` and its type is datetime/string/date literal that can be parsed as datetime.
-+ `TO_DAYS(col)` and its type is datetime/string/date literal that can be parsed as datetime. The col need to bigger than 1970-01-01.
++ `TO_DAYS(col)` and its type is datetime/string/date literal that can be parsed as datetime.
 
 If partition pruning is not applied, TiSpark's reading is equivalent to doing a table scan over all partitions.
 

--- a/docs/userguide_3.0.md
+++ b/docs/userguide_3.0.md
@@ -391,7 +391,7 @@ The partition pruning is applied when the partition expression of the range part
 
 + column expression
 + `YEAR(col)` and its type is datetime/string/date literal that can be parsed as datetime.
-+ `TO_DAYS(col)` and its type is datetime/string/date literal that can be parsed as datetime.
++ `TO_DAYS(col)` and its type is datetime/string/date literal that can be parsed as datetime. The col need to bigger than 1970-01-01.
 
 If partition pruning is not applied, TiSpark's reading is equivalent to doing a table scan over all partitions.
 

--- a/tikv-client/src/main/java/com/pingcap/tikv/expression/FuncCallExpr.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/expression/FuncCallExpr.java
@@ -56,7 +56,7 @@ public class FuncCallExpr extends Expression {
   private String getFuncString() {
     if (funcTp == Type.YEAR) {
       return "year";
-    } else if(funcTp == Type.TO_DAYS){
+    } else if (funcTp == Type.TO_DAYS) {
       return "to_days";
     }
     return "";

--- a/tikv-client/src/main/java/com/pingcap/tikv/expression/FuncCallExpr.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/expression/FuncCallExpr.java
@@ -56,6 +56,8 @@ public class FuncCallExpr extends Expression {
   private String getFuncString() {
     if (funcTp == Type.YEAR) {
       return "year";
+    } else if(funcTp == Type.TO_DAYS){
+      return "to_days";
     }
     return "";
   }
@@ -95,6 +97,7 @@ public class FuncCallExpr extends Expression {
   }
 
   public enum Type {
-    YEAR
+    YEAR,
+    TO_DAYS
   }
 }

--- a/tikv-client/src/main/java/com/pingcap/tikv/expression/FuncCallExprEval.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/expression/FuncCallExprEval.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
 import org.joda.time.DateTime;
+import org.joda.time.Days;
 
 public class FuncCallExprEval {
 
@@ -82,10 +83,7 @@ public class FuncCallExprEval {
   }
 
   private static int dateTime2ToDays(DateTime date) {
-    // the number of day from 0000-00-00 to 1970-01-01
-    int var1 = 719528;
-    // the number of day from 1970-01-01 to `date` parameter
-    long var2 = date.getMillis() / 1000 / 3600 / 24;
-    return var1 + (int) var2;
+      DateTime start = DateTime.parse("0000-01-01");
+      return Days.daysBetween(start.toLocalDate(), date.toLocalDate()).getDays();
   }
 }

--- a/tikv-client/src/main/java/com/pingcap/tikv/expression/FuncCallExprEval.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/expression/FuncCallExprEval.java
@@ -22,10 +22,6 @@ import com.pingcap.tikv.types.DateTimeType;
 import com.pingcap.tikv.types.DateType;
 import com.pingcap.tikv.types.IntegerType;
 import com.pingcap.tikv.types.StringType;
-
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
@@ -49,31 +45,31 @@ public class FuncCallExprEval {
             DateTime date = new DateTime(literal.getValue());
             return Constant.create(date.getYear(), IntegerType.INT);
           } else if (type instanceof DateTimeType) {
-              // literal can be java.sql.Timestamp, use new DateTime() to avoid convert error
-              DateTime date = new DateTime(literal.getValue());
+            // literal can be java.sql.Timestamp, use new DateTime() to avoid convert error
+            DateTime date = new DateTime(literal.getValue());
             return Constant.create(date.getYear(), IntegerType.INT);
           }
           throw new UnsupportedOperationException(
               String.format("cannot apply year on %s", type.getName()));
         });
 
-      evalMap.put(
-              Type.TO_DAYS,
-              literal -> {
-                  DataType type = literal.getDataType();
-                  if (type instanceof StringType) {
-                      DateTime date = DateTime.parse((String) literal.getValue());
-                      return Constant.create(dateTime2ToDays(date), IntegerType.INT);
-                  } else if (type instanceof DateType) {
-                      DateTime date = new DateTime(literal.getValue());
-                      return Constant.create(dateTime2ToDays(date), IntegerType.INT);
-                  } else if (type instanceof DateTimeType) {
-                      DateTime date = new DateTime(literal.getValue());
-                      return Constant.create(dateTime2ToDays(date), IntegerType.INT);
-                  }
-                  throw new UnsupportedOperationException(
-                          String.format("cannot apply to_days on %s", type.getName()));
-              });
+    evalMap.put(
+        Type.TO_DAYS,
+        literal -> {
+          DataType type = literal.getDataType();
+          if (type instanceof StringType) {
+            DateTime date = DateTime.parse((String) literal.getValue());
+            return Constant.create(dateTime2ToDays(date), IntegerType.INT);
+          } else if (type instanceof DateType) {
+            DateTime date = new DateTime(literal.getValue());
+            return Constant.create(dateTime2ToDays(date), IntegerType.INT);
+          } else if (type instanceof DateTimeType) {
+            DateTime date = new DateTime(literal.getValue());
+            return Constant.create(dateTime2ToDays(date), IntegerType.INT);
+          }
+          throw new UnsupportedOperationException(
+              String.format("cannot apply to_days on %s", type.getName()));
+        });
 
     // for newly adding type, please also adds the corresponding logic here.
   }
@@ -85,11 +81,11 @@ public class FuncCallExprEval {
     return null;
   }
 
-    private static int dateTime2ToDays(DateTime date) {
-        // the number of day from 0000-00-00 to 1970-01-01
-        int var1 = 719528;
-        // the number of day from 1970-01-01 to `date` parameter
-        long var2 = date.getMillis() / 1000 / 3600 / 24;
-        return var1 + (int) var2;
-    }
+  private static int dateTime2ToDays(DateTime date) {
+    // the number of day from 0000-00-00 to 1970-01-01
+    int var1 = 719528;
+    // the number of day from 1970-01-01 to `date` parameter
+    long var2 = date.getMillis() / 1000 / 3600 / 24;
+    return var1 + (int) var2;
+  }
 }

--- a/tikv-client/src/main/java/com/pingcap/tikv/expression/FuncCallExprEval.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/expression/FuncCallExprEval.java
@@ -83,7 +83,7 @@ public class FuncCallExprEval {
   }
 
   private static int dateTime2ToDays(DateTime date) {
-      DateTime start = DateTime.parse("0000-01-01");
-      return Days.daysBetween(start.toLocalDate(), date.toLocalDate()).getDays();
+    DateTime start = DateTime.parse("0000-01-01");
+    return Days.daysBetween(start.toLocalDate(), date.toLocalDate()).getDays();
   }
 }

--- a/tikv-client/src/main/java/com/pingcap/tikv/expression/RangePartitionPruner.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/expression/RangePartitionPruner.java
@@ -47,6 +47,7 @@ public class RangePartitionPruner {
   RangePartitionPruner(TiTableInfo tableInfo) {
     this.partInfo = tableInfo.getPartitionInfo();
     try {
+      // convert partExprStr to Expression with AstBuilder
       this.partExprs = generateRangePartExprs(tableInfo);
       this.rangeBuilder = new PrunedPartitionBuilder(partExprColRefs);
     } catch (UnsupportedSyntaxException | UnsupportedPartitionExprException e) {

--- a/tikv-client/src/main/java/com/pingcap/tikv/expression/visitor/PartAndFilterExprRewriter.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/expression/visitor/PartAndFilterExprRewriter.java
@@ -53,7 +53,8 @@ public class PartAndFilterExprRewriter extends DefaultVisitor<Expression, Void> 
   }
 
   private boolean isToDays() {
-    return partExpr instanceof FuncCallExpr && ((FuncCallExpr) partExpr).getFuncTp() == Type.TO_DAYS;
+    return partExpr instanceof FuncCallExpr
+        && ((FuncCallExpr) partExpr).getFuncTp() == Type.TO_DAYS;
   }
 
   private boolean isColumnRef() {
@@ -106,11 +107,11 @@ public class PartAndFilterExprRewriter extends DefaultVisitor<Expression, Void> 
         FuncCallExpr year = new FuncCallExpr(predicate.getValue(), Type.YEAR);
         Constant newLiteral = year.eval(predicate.getValue());
         return new ComparisonBinaryExpression(node.getComparisonType(), node.getLeft(), newLiteral);
-      } else if (isToDays()){
+      } else if (isToDays()) {
         FuncCallExpr toDays = new FuncCallExpr(predicate.getValue(), Type.TO_DAYS);
         Constant newLiteral = toDays.eval(predicate.getValue());
         return new ComparisonBinaryExpression(node.getComparisonType(), node.getLeft(), newLiteral);
-      }else if (isColumnRef()) {
+      } else if (isColumnRef()) {
         return node;
       }
       unsupportedPartFnFound = true;

--- a/tikv-client/src/main/java/com/pingcap/tikv/expression/visitor/PartAndFilterExprRewriter.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/expression/visitor/PartAndFilterExprRewriter.java
@@ -52,6 +52,10 @@ public class PartAndFilterExprRewriter extends DefaultVisitor<Expression, Void> 
     return partExpr instanceof FuncCallExpr && ((FuncCallExpr) partExpr).getFuncTp() == Type.YEAR;
   }
 
+  private boolean isToDays() {
+    return partExpr instanceof FuncCallExpr && ((FuncCallExpr) partExpr).getFuncTp() == Type.TO_DAYS;
+  }
+
   private boolean isColumnRef() {
     return partExpr instanceof ColumnRef;
   }
@@ -73,6 +77,9 @@ public class PartAndFilterExprRewriter extends DefaultVisitor<Expression, Void> 
   @Override
   public Expression visit(FuncCallExpr node, Void context) {
     if (node.getFuncTp() == Type.YEAR) {
+      return node.getExpression();
+    }
+    if (node.getFuncTp() == Type.TO_DAYS) {
       return node.getExpression();
     }
     // other's is not supported right now.
@@ -99,7 +106,11 @@ public class PartAndFilterExprRewriter extends DefaultVisitor<Expression, Void> 
         FuncCallExpr year = new FuncCallExpr(predicate.getValue(), Type.YEAR);
         Constant newLiteral = year.eval(predicate.getValue());
         return new ComparisonBinaryExpression(node.getComparisonType(), node.getLeft(), newLiteral);
-      } else if (isColumnRef()) {
+      } else if (isToDays()){
+        FuncCallExpr toDays = new FuncCallExpr(predicate.getValue(), Type.TO_DAYS);
+        Constant newLiteral = toDays.eval(predicate.getValue());
+        return new ComparisonBinaryExpression(node.getComparisonType(), node.getLeft(), newLiteral);
+      }else if (isColumnRef()) {
         return node;
       }
       unsupportedPartFnFound = true;

--- a/tikv-client/src/main/java/com/pingcap/tikv/parser/AstBuilder.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/parser/AstBuilder.java
@@ -88,6 +88,10 @@ public class AstBuilder extends MySqlParserBaseVisitor<Expression> {
         Expression args = visitFunctionArgs(ctx.functionArgs());
         return new FuncCallExpr(args, Type.YEAR);
       }
+      if (fnNameCtx.TO_DAYS() != null) {
+        Expression args = visitFunctionArgs(ctx.functionArgs());
+        return new FuncCallExpr(args, Type.TO_DAYS);
+      }
     }
     return visitChildren(ctx);
   }

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/Converter.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/Converter.java
@@ -263,11 +263,13 @@ public class Converter {
         throw new TypeException(String.format("Error parsing string %s to datetime", val), e);
       }
     } else if (val instanceof Integer) {
+      // when the val is an Integer, it can only be year(date) or to_days(date).
+      // we assume year will not exceed 10000.
       if ((int) val < 10000) {
         return new ExtendedDateTime(new DateTime((int) val, 1, 1, 0, 0));
       } else {
         DateTime start = DateTime.parse("0000-01-01");
-        return new ExtendedDateTime(start.plusDays((int)val));
+        return new ExtendedDateTime(start.plusDays((int) val));
       }
     } else if (val instanceof Long) {
       return new ExtendedDateTime(new DateTime((long) val));
@@ -308,15 +310,15 @@ public class Converter {
         throw new TypeException(String.format("Error parsing string %s to date", val), e);
       }
     } else if (val instanceof Integer) {
-      // when the val is a Integer, it is only have year and to_days part of a Date.
+      // when the val is an Integer, it can only be year(date) or to_days(date).
       // It is a bad design which is hard to extension. We need to refactor it.
 
-      // judge the val is a year or to_days, 719528 is the days from 0000-00-00 to 1970-01-01
+      // we assume year will not exceed 10000
       if ((int) val < 10000) {
         return new Date((Integer) val - 1970, 1, 1);
       } else {
         DateTime start = DateTime.parse("0000-01-01");
-        String end = start.plusDays((int)val).toString("yyyy-MM-dd");
+        String end = start.plusDays((int) val).toString("yyyy-MM-dd");
         return Date.valueOf(end);
       }
     } else if (val instanceof Long) {

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/Converter.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/Converter.java
@@ -263,12 +263,11 @@ public class Converter {
         throw new TypeException(String.format("Error parsing string %s to datetime", val), e);
       }
     } else if (val instanceof Integer) {
-      if ((int) val < 719528) {
+      if ((int) val < 10000) {
         return new ExtendedDateTime(new DateTime((int) val, 1, 1, 0, 0));
       } else {
-        long daysFrom1970 = (Integer) val - 719528;
-        long millis = daysFrom1970 * 24 * 3600 * 1000;
-        return new ExtendedDateTime(new DateTime(millis));
+        DateTime start = DateTime.parse("0000-01-01");
+        return new ExtendedDateTime(start.plusDays((int)val));
       }
     } else if (val instanceof Long) {
       return new ExtendedDateTime(new DateTime((long) val));
@@ -313,12 +312,12 @@ public class Converter {
       // It is a bad design which is hard to extension. We need to refactor it.
 
       // judge the val is a year or to_days, 719528 is the days from 0000-00-00 to 1970-01-01
-      if ((int) val < 719528) {
+      if ((int) val < 10000) {
         return new Date((Integer) val - 1970, 1, 1);
       } else {
-        long daysFrom1970 = (Integer) val - 719528;
-        long millis = daysFrom1970 * 24 * 3600 * 1000;
-        return new Date(millis);
+        DateTime start = DateTime.parse("0000-01-01");
+        String end = start.plusDays((int)val).toString("yyyy-MM-dd");
+        return Date.valueOf(end);
       }
     } else if (val instanceof Long) {
       return new Date((long) val);

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/Converter.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/Converter.java
@@ -262,6 +262,15 @@ public class Converter {
       } catch (Exception e) {
         throw new TypeException(String.format("Error parsing string %s to datetime", val), e);
       }
+    }
+    else if (val instanceof Integer) {
+      if ((int) val < 719528) {
+        return new ExtendedDateTime(new DateTime((int)val,1,1,0,0));
+      } else {
+        long daysFrom1970 = (Integer) val - 719528;
+        long millis = daysFrom1970 * 24 * 3600 * 1000;
+        return new ExtendedDateTime(new DateTime(millis));
+      }
     } else if (val instanceof Long) {
       return new ExtendedDateTime(new DateTime((long) val));
     } else if (val instanceof Timestamp) {
@@ -301,8 +310,17 @@ public class Converter {
         throw new TypeException(String.format("Error parsing string %s to date", val), e);
       }
     } else if (val instanceof Integer) {
-      // when the val is a Integer, it is only have year part of a Date.
-      return new Date((Integer) val - 1970, 1, 1);
+      // when the val is a Integer, it is only have year and to_days part of a Date.
+      // It is a bad design which is hard to extension. We need to refactor it.
+
+      // judge the val is a year or to_days, 719528 is the days from 0000-00-00 to 1970-01-01
+      if ((int) val < 719528) {
+        return new Date((Integer) val - 1970, 1, 1);
+      } else {
+        long daysFrom1970 = (Integer) val - 719528;
+        long millis = daysFrom1970 * 24 * 3600 * 1000;
+        return new Date(millis);
+      }
     } else if (val instanceof Long) {
       return new Date((long) val);
     } else if (val instanceof Timestamp) {
@@ -393,5 +411,12 @@ public class Converter {
           String.format(
               "%s is not a valid format. Either hh:mm:ss.mmm or hh:mm:ss is accepted.", value));
     }
+  }
+  private static int dateTime2ToDays(DateTime date) {
+    // the number of day from 0000-00-00 to 1970-01-01
+    int var1 = 719528;
+    // the number of day from 1970-01-01 to `date` parameter
+    long var2 = date.getMillis() / 1000 / 3600 / 24;
+    return var1 + (int) var2;
   }
 }

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/Converter.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/Converter.java
@@ -411,12 +411,4 @@ public class Converter {
               "%s is not a valid format. Either hh:mm:ss.mmm or hh:mm:ss is accepted.", value));
     }
   }
-
-  private static int dateTime2ToDays(DateTime date) {
-    // the number of day from 0000-00-00 to 1970-01-01
-    int var1 = 719528;
-    // the number of day from 1970-01-01 to `date` parameter
-    long var2 = date.getMillis() / 1000 / 3600 / 24;
-    return var1 + (int) var2;
-  }
 }

--- a/tikv-client/src/main/java/com/pingcap/tikv/types/Converter.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/types/Converter.java
@@ -262,10 +262,9 @@ public class Converter {
       } catch (Exception e) {
         throw new TypeException(String.format("Error parsing string %s to datetime", val), e);
       }
-    }
-    else if (val instanceof Integer) {
+    } else if (val instanceof Integer) {
       if ((int) val < 719528) {
-        return new ExtendedDateTime(new DateTime((int)val,1,1,0,0));
+        return new ExtendedDateTime(new DateTime((int) val, 1, 1, 0, 0));
       } else {
         long daysFrom1970 = (Integer) val - 719528;
         long millis = daysFrom1970 * 24 * 3600 * 1000;
@@ -412,6 +411,7 @@ public class Converter {
               "%s is not a valid format. Either hh:mm:ss.mmm or hh:mm:ss is accepted.", value));
     }
   }
+
   private static int dateTime2ToDays(DateTime date) {
     // the number of day from 0000-00-00 to 1970-01-01
     int var1 = 719528;


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

TiSpark only supports partition pruning with
- column expression
- year (col)

To_DAYS(col) needs to be supported.

The DDL may like this:
```
CREATE TABLE `pt_todays_date` (
  `id` int(11) DEFAULT NULL,
  `name` varchar(50) DEFAULT NULL,
  `purchased` date DEFAULT NULL,
  index `idx_id`(`id`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin
PARTITION BY RANGE (to_days(purchased)) (
  PARTITION p0 VALUES LESS THAN (to_days('1995-01-02')),
  PARTITION p1 VALUES LESS THAN (to_days('2000-01-02')),
  PARTITION p2 VALUES LESS THAN (732313),
  PARTITION p3 VALUES LESS THAN (MAXVALUE)
)
```
### What is changed and how it works?

**Support To_DAYS(col)**
1. Alter `Astbuilder` to support convert partExprStr (contains TO_DAYS) to Expression with AstBuilder
2. Add `TO_DAYS` func in `FuncCallExpr` and add the method to deal with to_days in `FuncCallExprEval.java` (calculate the literal in where clause to the result of to_days)
3. Support `TO_DAYS` in `PartAndFilterExprRewriter.java`
4. Enhancement `Converter.java` to support converting int to date and DateTime. So, TiSpark can judge if the filter condition is included in the partition table. (Bad Design, why don't just use int to judge? I just follow the original design)

 
**Fix the bug that year(col) throw exception when col is datetime type**

- Enhancement `FuncCallExprEval.java` to support converting java.sql.Timestamptimestamp(datetime type in TiDB) to datetime
- Enhancement `Converter.java` to support converting int to dateTime