### PR TITLE
Fix partition pruning with uppercase column 

### DIFF
--- a/core/src/test/scala/org/apache/spark/sql/PartitionTableSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/PartitionTableSuite.scala
@@ -770,13 +770,11 @@ class PartitionTableSuite extends BasePlanTest {
     assert {
       val pDef = extractDAGReq(
         spark
-          // expected part info only contains one part which is p0.
+        // expected part info only contains one part which is p0.
           .sql("select * from pt_uppercase_column where ACT_DT = '1969-12-30 00:00:00'")).getPrunedParts
       pDef.size() == 1 && pDef.get(0).getName == "p0"
     }
   }
-
-
 
   def enablePartitionForTiDB(): Boolean =
     tidbStmt.execute("set @@tidb_enable_table_partition = 1")

--- a/core/src/test/scala/org/apache/spark/sql/PartitionTableSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/PartitionTableSuite.scala
@@ -750,6 +750,34 @@ class PartitionTableSuite extends BasePlanTest {
     judge("select id from p_t group by id", checkLimit = false)
   }
 
+  test("partition pruning with uppercase column") {
+    tidbStmt.execute("DROP TABLE IF EXISTS `pt_uppercase_column`")
+    tidbStmt.execute("""
+                       |CREATE TABLE `pt_uppercase_column` (
+                       |  `id` int(11) DEFAULT NULL,
+                       |  `name` varchar(50) DEFAULT NULL,
+                       |  `ACT_DT` datetime DEFAULT NULL,
+                       |  index `idx_id`(`id`)
+                       |) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin
+                       |PARTITION BY RANGE (to_days(ACT_DT)) (
+                       |  PARTITION p0 VALUES LESS THAN (to_days('1969-12-31')),
+                       |  PARTITION p1 VALUES LESS THAN (to_days('1970-01-01')),
+                       |  PARTITION p2 VALUES LESS THAN (to_days('1970-01-02')),
+                       |  PARTITION p3 VALUES LESS THAN (MAXVALUE)
+                       |)
+                     """.stripMargin)
+
+    assert {
+      val pDef = extractDAGReq(
+        spark
+          // expected part info only contains one part which is p0.
+          .sql("select * from pt_uppercase_column where ACT_DT = '1969-12-30 00:00:00'")).getPrunedParts
+      pDef.size() == 1 && pDef.get(0).getName == "p0"
+    }
+  }
+
+
+
   def enablePartitionForTiDB(): Boolean =
     tidbStmt.execute("set @@tidb_enable_table_partition = 1")
 }

--- a/tikv-client/src/main/java/com/pingcap/tikv/expression/ColumnRef.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/expression/ColumnRef.java
@@ -133,9 +133,9 @@ public class ColumnRef extends Expression {
   @Override
   public int hashCode() {
     if (isResolved()) {
-      return Objects.hash(this.name, this.dataType);
+      return Objects.hash(this.name.toLowerCase(), this.dataType);
     } else {
-      return Objects.hashCode(name);
+      return Objects.hashCode(name.toLowerCase());
     }
   }
 


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

Partition pruning will invalid with the uppercase column  because of hashcode method is case sensitive.

### What is changed and how it works?

Make hashcode method case insensitive.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `tidb-ansible` repository
 - Need to be included in the release note
