### PR TITLE
Fix StatisticsManagerSuite

### DIFF
--- a/core/src/test/scala/org/apache/spark/sql/statistics/StatisticsManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/statistics/StatisticsManagerSuite.scala
@@ -26,6 +26,8 @@ class StatisticsManagerSuite extends BaseTiSparkTest {
 
   // fix issue: https://github.com/pingcap/tispark/issues/2573
   test("Physical Plan should print EstimatedCount") {
+    // analyze table to avoid stats not be loaded
+    tidbStmt.execute("analyze table tpch_test.LINEITEM")
     val df = spark
       .sql("""select * from tidb_catalog.tpch_test.LINEITEM
           |""".stripMargin)


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix StatisticsManagerSuite may fail sometimes


### What is changed and how it works?

Statistics may be delayed for one minute.
The test may fail because the Statistics are not loaded in time, So just add analyze to trigger the load of Statistics