### PR TITLE
Fix test MultiColumnClusterIndexDataSuite00 fail

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ For English users, go to [TiDB internals](https://internals.tidb.io).
 
 For Chinese users, go to [AskTUG](https://asktug.com).
 
+
 ## License
 
 TiSpark is under the Apache 2.0 license. See the [LICENSE](./LICENSE) file for details.

--- a/README.md
+++ b/README.md
@@ -84,7 +84,6 @@ For English users, go to [TiDB internals](https://internals.tidb.io).
 
 For Chinese users, go to [AskTUG](https://asktug.com).
 
-
 ## License
 
 TiSpark is under the Apache 2.0 license. See the [LICENSE](./LICENSE) file for details.

--- a/core/src/test/scala/org/apache/spark/sql/types/pk/MultiColumnClusterIndexDataSuite00.scala
+++ b/core/src/test/scala/org/apache/spark/sql/types/pk/MultiColumnClusterIndexDataSuite00.scala
@@ -22,9 +22,8 @@ class MultiColumnClusterIndexDataSuite00 extends MultiColumnPKDataTypeSuites {
 
   override def currentTest: Seq[(Int, Int)] = tests(getId)
 
-  if (!supportClusteredIndex) {
-    cancel("currently tidb instance does not support clustered index")
+  if (supportClusteredIndex) {
+    generateClusterIndexScanTestCases()
   }
-  generateClusterIndexScanTestCases()
 
 }


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

MultiColumnClusterIndexDataSuite00 will fail in release-4.0.

Because using cancel in the suite will make the test framework quit unexpectedly. cancel should be used in each test rather than the whole suite.


### What is changed and how it works?

delete cancel
