### PR TITLE
Set default value of spark.tispark.telemetry.enable as false

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/TiExtensions.scala
+++ b/core/src/main/scala/org/apache/spark/sql/TiExtensions.scala
@@ -122,14 +122,14 @@ object TiExtensions {
 
   /**
    * check that telemetry is on
-   * default on
+   * default off
    *
    * @param sparkSession
    * @return
    */
   def telemetryEnable(sparkSession: SparkSession): Boolean = {
     sparkSession.sparkContext.conf
-      .get(TELEMETRY_ENABEL, "true")
+      .get(TELEMETRY_ENABEL, "false")
       .toBoolean
   }
 }

--- a/docs/features/telemetry.md
+++ b/docs/features/telemetry.md
@@ -1,6 +1,6 @@
 # Telemetry
-By default, TiSpark collect usage information and share the information with PingCAP. You can close it by configuring
-`spark.tispark.telemetry.enable = false` in `spark-default.conf`.
+By default, TiSpark does not collect usage information and share the information with PingCAP. You can enable it by configuring
+`spark.tispark.telemetry.enable = true` in `spark-default.conf`.
 
 When the telemetry collection feature is enabled, usage information will be shared, including(but not limited to):
 * A randomly generated telemetry ID.


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

Set default value of `spark.tispark.telemetry.enable` as false.

After that, tispark will not collect telemetry messages and send them.

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `tidb-ansible` repository
 - Need to be included in the release note
