### PR TITLE
Check transaction start_ts < gc_safe_point

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/TiContext.scala
+++ b/core/src/main/scala/org/apache/spark/sql/TiContext.scala
@@ -54,6 +54,7 @@ class TiContext(val sparkSession: SparkSession) extends Serializable with Loggin
     override def onApplicationEnd(applicationEnd: SparkListenerApplicationEnd): Unit = {
       if (tiSession != null) {
         try {
+          println("------------")
           tiSession.close()
         } catch {
           case e: Throwable => logWarning("fail to close TiSession!", e)

--- a/core/src/test/scala/org/apache/spark/sql/TransactionCheckSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/TransactionCheckSuite.scala
@@ -1,0 +1,42 @@
+package org.apache.spark.sql
+
+import com.pingcap.tispark.TiConfigConst
+import org.scalatest.Matchers.{message, the}
+
+class TransactionCheckSuite extends BaseTiSparkTest {
+  private val table = "transaction_check_test"
+
+  // 2* (gc_life_time+1) = 22 min
+  val intervalExceed: Int = 22 * 60 * 1000
+  // gc_life_time -1 = 9min
+  val intervalPass: Int = 9 * 60 * 1000
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    tidbStmt.execute(s"drop table if exists $table")
+    tidbStmt.execute(s"create table $table (c int)")
+  }
+
+  // use stale read to test if TiSpark will throw exception when start_ts < gc_safe_point
+  test("transaction check throw exception when start_ts < gc_safe_point") {
+    spark.conf.set(TiConfigConst.STALE_READ, System.currentTimeMillis() - intervalExceed)
+    try {
+      val exception = the[Exception] thrownBy {
+        spark.sql(s"select * from $table").show()
+      }
+      assert(exception.getCause.getMessage.contains("start_ts < gc_safe_point"))
+    } finally {
+      spark.conf.unset(TiConfigConst.STALE_READ)
+    }
+  }
+
+  test("pass transaction check when start_ts >= gc_safe_point") {
+    spark.conf.set(TiConfigConst.STALE_READ, System.currentTimeMillis() - intervalPass)
+    try {
+      spark.sql(s"select * from $table").show()
+    } finally {
+      spark.conf.unset(TiConfigConst.STALE_READ)
+    }
+  }
+
+}

--- a/core/src/test/scala/org/apache/spark/sql/TransactionCheckSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/TransactionCheckSuite.scala
@@ -6,13 +6,12 @@ import org.scalatest.Matchers.{message, the}
 class TransactionCheckSuite extends BaseTiSparkTest {
   private val table = "transaction_check_test"
 
-  // 2* (gc_life_time+1) = 22 min
-  val intervalExceed: Int = 22 * 60 * 1000
+  val intervalExceed: Int = 40 * 60 * 1000
   // gc_life_time -1 = 9min
   val intervalPass: Int = 9 * 60 * 1000
 
-  override def beforeAll(): Unit = {
-    super.beforeAll()
+  override def beforeEach(): Unit = {
+    super.beforeEach()
     tidbStmt.execute(s"drop table if exists $table")
     tidbStmt.execute(s"create table $table (c int)")
   }

--- a/docs/stale_read.md
+++ b/docs/stale_read.md
@@ -12,7 +12,7 @@
 
 TiSpark support stale read with a new configuration `spark.tispark.stale_read`
 - The configurations accept timestamp (ms) which is Long type
-- The configuration better meet this condition `${now} - ${spark.tispark.stale_read} + ${sql execution time}) < ${GC lifetime}`, or you may get unexception data
+- The configuration better meet this condition `${now} - ${spark.tispark.stale_read} + ${sql execution time}) < ${GC lifetime}`. TiSpark will throw an exception once start_ts < gc safe point. See [GC Overview](https://docs.pingcap.com/tidb/dev/garbage-collection-overview#gc-overview) to learn about them. 
 
 ## Limitation
 

--- a/tikv-client/src/main/java/com/pingcap/tikv/ReadOnlyPDClient.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/ReadOnlyPDClient.java
@@ -67,4 +67,6 @@ public interface ReadOnlyPDClient {
   Future<Store> getStoreAsync(BackOffer backOffer, long storeId);
 
   List<Store> getAllStores(BackOffer backOffer);
+
+  Long getGCSafePoint(BackOffer backOffer);
 }

--- a/tikv-client/src/main/java/com/pingcap/tikv/region/RegionManager.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/region/RegionManager.java
@@ -191,7 +191,7 @@ public class RegionManager {
   }
 
   public void invalidateRange(ByteString startKey, ByteString endKey) {
-    cache.invalidateRange(startKey,endKey);
+    cache.invalidateRange(startKey, endKey);
   }
 
   public static class RegionCache {
@@ -259,7 +259,8 @@ public class RegionManager {
     private synchronized void invalidateRange(ByteString startKey, ByteString endKey) {
       regionCache.remove(makeRange(startKey, endKey));
       if (logger.isDebugEnabled()) {
-        logger.debug(String.format("invalidateRange success, startKey[%s], endKey[%s]", startKey, endKey));
+        logger.debug(
+            String.format("invalidateRange success, startKey[%s], endKey[%s]", startKey, endKey));
       }
     }
 

--- a/tikv-client/src/main/java/com/pingcap/tikv/region/RegionStoreClient.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/region/RegionStoreClient.java
@@ -1213,7 +1213,7 @@ public class RegionStoreClient extends AbstractRegionStoreClient {
     Long safePoint = pdClient.getGCSafePoint(bo);
     if (startTs < safePoint) {
       throw new GrpcException(
-          "start_ts < gc_safe_point. Please ensure the execute time is less than the tidb_gc_life_time https://docs.pingcap.com/tidb/stable/system-variables#tidb_gc_life_time-new-in-v50. Or you may get the unexpected data.");
+          "start_ts < gc_safe_point. To avoid this, you can set the tidb_gc_life_time https://docs.pingcap.com/tidb/stable/system-variables#tidb_gc_life_time-new-in-v50 bigger than TiSpark execute time");
     }
   }
 

--- a/tikv-client/src/main/java/com/pingcap/tikv/region/RegionStoreClient.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/region/RegionStoreClient.java
@@ -1207,7 +1207,7 @@ public class RegionStoreClient extends AbstractRegionStoreClient {
     }
   }
 
-  // checkStartTs will check the start_ts > gc_safe_point to ensure read correctly
+  // checkStartTs will check the start_ts >= gc_safe_point to ensure read correctly
   public void checkStartTs(long startTs) {
     BackOffer bo = ConcreteBackOffer.newCustomBackOff(BackOffer.PD_INFO_BACKOFF);
     Long safePoint = pdClient.getGCSafePoint(bo);

--- a/tikv-client/src/main/java/com/pingcap/tikv/region/RegionStoreClient.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/region/RegionStoreClient.java
@@ -1212,8 +1212,8 @@ public class RegionStoreClient extends AbstractRegionStoreClient {
     BackOffer bo = ConcreteBackOffer.newCustomBackOff(BackOffer.PD_INFO_BACKOFF);
     Long safePoint = pdClient.getGCSafePoint(bo);
     if (startTs < safePoint) {
-      throw new GrpcException(
-          "start_ts < gc_safe_point. To avoid this, you can set the tidb_gc_life_time https://docs.pingcap.com/tidb/stable/system-variables#tidb_gc_life_time-new-in-v50 bigger than TiSpark execute time");
+      throw new TiClientInternalException(
+          "You may access obsolete data due to start_ts < gc_safe_point. To avoid this, set the tidb_gc_life_time https://docs.pingcap.com/tidb/stable/system-variables#tidb_gc_life_time-new-in-v50 bigger than TiSpark execute time");
     }
   }
 


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

https://github.com/tikv/client-java/issues/721

### What is changed and how it works?

Add a check after all the transaction requests, but before they handle the response.
In this way: once transaction start_ts < gc_safe_point, it will throw the ` start_ts < gc_safe_point` exception first even if it has other error returned by TiKV.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code
