### PR TITLE
Support server safe point

### DIFF
--- a/core/src/main/scala/com/pingcap/tispark/savepoint/ServerSavePoint.scala
+++ b/core/src/main/scala/com/pingcap/tispark/savepoint/ServerSavePoint.scala
@@ -1,0 +1,50 @@
+package com.pingcap.tispark.savepoint
+
+import com.pingcap.tikv.TiSession
+import com.pingcap.tikv.exception.TiInternalException
+import com.pingcap.tikv.util.{BackOffer, ConcreteBackOffer}
+import org.slf4j.LoggerFactory
+
+import java.util.concurrent.{Executors, ScheduledExecutorService, TimeUnit}
+
+case class ServerSavePoint (serverId: String, ttl: Long, tiSession: TiSession){
+
+  private final val logger = LoggerFactory.getLogger(getClass.getName)
+  private var minStartTs = Long.MaxValue
+  val service: ScheduledExecutorService = Executors.newSingleThreadScheduledExecutor()
+  service.scheduleAtFixedRate(
+    ()=>{
+      if (minStartTs != Long.MaxValue){
+        val savePoint = tiSession.getPDClient.UpdateServiceGCSafePoint(serverId,ttl,minStartTs,ConcreteBackOffer.newCustomBackOff(BackOffer.PD_INFO_BACKOFF))
+        if (savePoint > minStartTs){
+          println("x")
+          logger.error(s"Failed to register server GC safe point because the current minimum safe point $savePoint is newer than what we assume $minStartTs. Maybe you delete the TiSpark safe point in PD")
+        }else{
+          println("x")
+          logger.info(s"register server GC safe point $minStartTs success.")
+        }
+      }
+    },
+    0,
+    1,
+    TimeUnit.MINUTES
+  )
+
+  def updateStartTs(starTs:Long): Unit = {
+    if (starTs < minStartTs){
+      minStartTs = starTs
+      checkServerSafePoint()
+    }
+  }
+
+  def checkServerSafePoint(): Unit = {
+   val savePoint = tiSession.getPDClient.UpdateServiceGCSafePoint(serverId,ttl,minStartTs,ConcreteBackOffer.newCustomBackOff(BackOffer.PD_INFO_BACKOFF))
+   if (savePoint > minStartTs){
+     throw new TiInternalException(s"Failed to register server GC safe point because the current minimum safe point $savePoint is newer than what we assume $minStartTs")
+   }
+  }
+
+  def stopRegisterSavePoint(): Unit = {
+    service.shutdownNow()
+  }
+}

--- a/spark-wrapper/spark-3.0/src/main/scala/org/apache/spark/sql/extensions/TiStrategy.scala
+++ b/spark-wrapper/spark-3.0/src/main/scala/org/apache/spark/sql/extensions/TiStrategy.scala
@@ -107,6 +107,7 @@ case class TiStrategy(getOrCreateTiContext: SparkSession => TiContext)(sparkSess
     } else {
       tiContext.tiSession.getSnapshotTimestamp
     }
+    tiContext.serverSavePoint.updateStartTs(ts.getVersion)
 
     if (plan.isStreaming) {
       // We should use a new timestamp for next batch execution.

--- a/spark-wrapper/spark-3.1/src/main/scala/org/apache/spark/sql/extensions/TiStrategy.scala
+++ b/spark-wrapper/spark-3.1/src/main/scala/org/apache/spark/sql/extensions/TiStrategy.scala
@@ -110,6 +110,8 @@ case class TiStrategy(getOrCreateTiContext: SparkSession => TiContext)(sparkSess
     } else {
       tiContext.tiSession.getSnapshotTimestamp
     }
+    tiContext.serverSavePoint.updateStartTs(ts.getVersion)
+
     if (plan.isStreaming) {
       // We should use a new timestamp for next batch execution.
       // Otherwise Spark Structure Streaming will not see new data in TiDB.

--- a/spark-wrapper/spark-3.2/src/main/scala/org/apache/spark/sql/extensions/TiStrategy.scala
+++ b/spark-wrapper/spark-3.2/src/main/scala/org/apache/spark/sql/extensions/TiStrategy.scala
@@ -110,6 +110,7 @@ case class TiStrategy(getOrCreateTiContext: SparkSession => TiContext)(sparkSess
     } else {
       tiContext.tiSession.getSnapshotTimestamp
     }
+    tiContext.serverSavePoint.updateStartTs(ts.getVersion)
 
     if (plan.isStreaming) {
       // We should use a new timestamp for next batch execution.

--- a/spark-wrapper/spark-3.3/src/main/scala/org/apache/spark/sql/extensions/TiStrategy.scala
+++ b/spark-wrapper/spark-3.3/src/main/scala/org/apache/spark/sql/extensions/TiStrategy.scala
@@ -110,6 +110,7 @@ case class TiStrategy(getOrCreateTiContext: SparkSession => TiContext)(sparkSess
     } else {
       tiContext.tiSession.getSnapshotTimestamp
     }
+    tiContext.serverSavePoint.updateStartTs(ts.getVersion)
 
     if (plan.isStreaming) {
       // We should use a new timestamp for next batch execution.

--- a/tikv-client/src/main/java/com/pingcap/tikv/ReadOnlyPDClient.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/ReadOnlyPDClient.java
@@ -67,4 +67,6 @@ public interface ReadOnlyPDClient {
   Future<Store> getStoreAsync(BackOffer backOffer, long storeId);
 
   List<Store> getAllStores(BackOffer backOffer);
+
+  Long UpdateServiceGCSafePoint(String serverId, long ttl, long savePoint, BackOffer backOffer);
 }

--- a/tikv-client/src/main/java/com/pingcap/tikv/region/RegionManager.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/region/RegionManager.java
@@ -191,7 +191,7 @@ public class RegionManager {
   }
 
   public void invalidateRange(ByteString startKey, ByteString endKey) {
-    cache.invalidateRange(startKey,endKey);
+    cache.invalidateRange(startKey, endKey);
   }
 
   public static class RegionCache {
@@ -259,7 +259,8 @@ public class RegionManager {
     private synchronized void invalidateRange(ByteString startKey, ByteString endKey) {
       regionCache.remove(makeRange(startKey, endKey));
       if (logger.isDebugEnabled()) {
-        logger.debug(String.format("invalidateRange success, startKey[%s], endKey[%s]", startKey, endKey));
+        logger.debug(
+            String.format("invalidateRange success, startKey[%s], endKey[%s]", startKey, endKey));
       }
     }
 

--- a/tikv-client/src/main/java/com/pingcap/tikv/region/RegionStoreClient.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/region/RegionStoreClient.java
@@ -713,7 +713,7 @@ public class RegionStoreClient extends AbstractRegionStoreClient {
       // we need to invalidate cache when region not find
       if (regionError.hasRegionNotFound()) {
         logger.info("invalidateRange when Re-splitting region task because of region not find.");
-        this.regionManager.invalidateRange(region.getStartKey(),region.getEndKey());
+        this.regionManager.invalidateRange(region.getStartKey(), region.getEndKey());
       }
       // Split ranges
       return RangeSplitter.newSplitter(this.regionManager).splitRangeByRegion(ranges, storeType);

--- a/tikv-client/src/main/java/com/pingcap/tikv/util/BackOffer.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/util/BackOffer.java
@@ -37,6 +37,7 @@ public interface BackOffer {
   int BATCH_COMMIT_BACKOFF = 10 * seconds;
   int PD_INFO_BACKOFF = 5 * seconds;
   int ROW_ID_ALLOCATOR_BACKOFF = 40 * seconds;
+  int PD_UPDATE_SAFE_POINT_BACKOFF = 60 * seconds;
 
   /**
    * doBackOff sleeps a while base on the BackOffType and records the error message. Will stop until


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

TiSpark does not have a mechanism to check GC. So, you may get the wrong data if your transaction's start_ts behind safe_point

### What is changed and how it works?

This PR introduced the server safe point in TiSpark. TiKV will use the min server safe point among all servers (including TiDB).

TiSpark will generate a new serverId for every spark session. Every spark session will register the min start_ts as its' server safe point to PD. Thus, the safe point will not exceed the min start_ts among all spark applications.


### Test

It is hard to write IT. Here are the results I test locally.

1. PD logs show TiSpark register server safe point successfully

<img width="1096" alt="image" src="https://user-images.githubusercontent.com/52435083/221527192-ea716fd9-a2d4-47a2-86dc-2919b44b21d8.png">

2. TiKV metric shows TiSpark server safe point can pause the safe point: TiSpark register 439743565061947392 (17:02:55) as safe point. This makes the GC safe point turns from 16:57:39 to 17:02:55 rather than 17:07:39

<img width="608" alt="image" src="https://user-images.githubusercontent.com/52435083/221527566-4c6f9076-f5b6-4105-ac63-7312cf52d109.png">

3.  TiKV metric shows safe point will recovery after the TiSpark finished: The GC safe point turns from 17:02:55 to 17:18:39. which means TiSpark will not block it anymore.

<img width="622" alt="image" src="https://user-images.githubusercontent.com/52435083/221528534-d2eda190-5950-4415-8aa2-7dde9dc17770.png">

4. When the start_ts have already less than the current safe point. TiSpark will throw exceptions directly

![3MUDaPC8Vq](https://user-images.githubusercontent.com/52435083/221528770-908f1de1-4a16-4b32-bd07-8d34349d321c.jpg)



 
