### PR TITLE
fix mutil_uniq

### DIFF
--- a/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
@@ -22,6 +22,17 @@ import org.apache.spark.sql.functions.{col, sum}
 
 class IssueTestSuite extends BaseTiSparkTest {
 
+  test("test issue 2649") {
+    val dbTable = "tispark_test.mutil_uniq"
+    tidbStmt.execute(s"drop table if exists $dbTable")
+    tidbStmt.execute(
+      s"CREATE TABLE $dbTable (`a` int(5) NOT NULL,`b` int(5) NOT NULL,UNIQUE KEY `idx_ab` (`a`,`b`))")
+    tidbStmt.execute(s"insert into $dbTable values(0, 0),(1,1)")
+    val df = spark.sql(s"select * from $dbTable where a=1")
+    val row1 = Row(1, 1)
+    checkAnswer(df, Seq(row1))
+  }
+
   //https://github.com/pingcap/tispark/issues/2268
   test("show rowid in commonhandle") {
     spark.sqlContext.setConf(TiConfigConst.SHOW_ROWID, "true")

--- a/tikv-client/src/main/java/com/pingcap/tikv/meta/TiDAGRequest.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/meta/TiDAGRequest.java
@@ -305,6 +305,9 @@ public class TiDAGRequest implements Serializable {
   private void addIndexColsToScanBuilder(
       IndexScan.Builder indexScanBuilder, Map<String, Integer> colOffsetInFieldMap) {
     for (TiIndexColumn indexColumn : indexInfo.getIndexColumns()) {
+      // We can optimize performance by pass unique into index scan.
+      // Refer to
+      // https://github.com/pingcap/tidb/blob/4ae5be190b0017675deedd9af8b80d8868e03f0e/planner/core/plan_to_pb.go#L271 to see if we can pass unique into index scan.
       TiColumnInfo tableInfoColumn = tableInfo.getColumn(indexColumn.getName());
       // already add this col before.
       ColumnInfo.Builder colBuild = ColumnInfo.newBuilder(tableInfoColumn.toProto(tableInfo));

--- a/tikv-client/src/main/java/com/pingcap/tikv/meta/TiDAGRequest.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/meta/TiDAGRequest.java
@@ -304,9 +304,6 @@ public class TiDAGRequest implements Serializable {
 
   private void addIndexColsToScanBuilder(
       IndexScan.Builder indexScanBuilder, Map<String, Integer> colOffsetInFieldMap) {
-    if (indexInfo.isUnique()) {
-      indexScanBuilder.setUnique(true);
-    }
     for (TiIndexColumn indexColumn : indexInfo.getIndexColumns()) {
       TiColumnInfo tableInfoColumn = tableInfo.getColumn(indexColumn.getName());
       // already add this col before.


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

close #2649

### What is changed and how it works?

The behavior of other version/client

1. TiSpark 3.0 does not pass unique in indexscan executor
2. TIDB needs some checks before passing unique https://github.com/pingcap/tidb/blob/4ae5be190b0017675deedd9af8b80d8868e03f0e/planner/core/plan_to_pb.go#L271

TiSpark lacks the necessary information to judge if it can pass unique. So we just delete it.
Lack unique in indexscan only slows the performance but does not influence the correct. See the pr's comment for more details https://github.com/pingcap/tidb/issues/29650
