### PR TITLE
Support fallback when resolveLockAsync

### DIFF
--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - master
+      - release-**
 
 jobs:
   check-license:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
+    branches: [ master,release-** ]
 
 jobs:
   fmt:

--- a/core/src/main/scala/com/pingcap/tispark/safepoint/ServiceSafePoint.scala
+++ b/core/src/main/scala/com/pingcap/tispark/safepoint/ServiceSafePoint.scala
@@ -1,3 +1,21 @@
+/*
+ *
+ * Copyright 2022 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package com.pingcap.tispark.safepoint
 
 import com.pingcap.tikv.TiSession

--- a/tikv-client/src/main/java/com/pingcap/tikv/exception/NonAsyncCommitLockException.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/exception/NonAsyncCommitLockException.java
@@ -1,0 +1,8 @@
+package com.pingcap.tikv.exception;
+
+public class NonAsyncCommitLockException extends RuntimeException {
+
+  public NonAsyncCommitLockException(String msg) {
+    super(msg);
+  }
+}

--- a/tikv-client/src/main/java/com/pingcap/tikv/exception/NonAsyncCommitLockException.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/exception/NonAsyncCommitLockException.java
@@ -1,3 +1,21 @@
+/*
+ *
+ * Copyright 2022 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package com.pingcap.tikv.exception;
 
 public class NonAsyncCommitLockException extends RuntimeException {

--- a/tikv-client/src/main/java/com/pingcap/tikv/region/RegionStoreClient.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/region/RegionStoreClient.java
@@ -421,7 +421,7 @@ public class RegionStoreClient extends AbstractRegionStoreClient {
       long startTs,
       long lockTTL)
       throws TiClientInternalException, KeyException, RegionException {
-    this.prewrite(backOffer, primary, mutations, startTs, lockTTL, false, false, null);
+    this.prewrite(backOffer, primary, mutations, startTs, lockTTL, false, false, null, false);
   }
 
   /**
@@ -437,7 +437,8 @@ public class RegionStoreClient extends AbstractRegionStoreClient {
       long ttl,
       boolean skipConstraintCheck,
       boolean useAsyncCommit,
-      Iterable<ByteString> secondaries)
+      Iterable<ByteString> secondaries,
+      boolean fallbackTest)
       throws TiClientInternalException, KeyException, RegionException {
     boolean forWrite = true;
     while (true) {
@@ -462,6 +463,10 @@ public class RegionStoreClient extends AbstractRegionStoreClient {
 
               if (secondaries != null) {
                 builder.addAllSecondaries(secondaries);
+              }
+              // just for test
+              if (fallbackTest) {
+                builder.setMaxCommitTs(1);
               }
             }
             return builder.build();

--- a/tikv-client/src/main/java/com/pingcap/tikv/txn/AsyncResolveData.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/txn/AsyncResolveData.java
@@ -19,6 +19,7 @@
 package com.pingcap.tikv.txn;
 
 import com.google.protobuf.ByteString;
+import com.pingcap.tikv.exception.NonAsyncCommitLockException;
 import com.pingcap.tikv.exception.ResolveLockException;
 import java.util.ArrayList;
 import java.util.List;
@@ -113,6 +114,10 @@ public class AsyncResolveData {
               String.format(
                   "unexpected timestamp, expected: %d, found: %d",
                   startTs, lockInfo.getLockVersion()));
+        }
+        if (!lockInfo.getUseAsyncCommit()) {
+          LOG.info("non-async commit lock found in async commit recovery");
+          throw new NonAsyncCommitLockException("non-async commit lock found");
         }
         if (!this.missingLock && lockInfo.getMinCommitTs() > this.commitTs) {
           this.commitTs = lockInfo.getMinCommitTs();

--- a/tikv-client/src/test/java/com/pingcap/tikv/txn/LockResolverTest.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/txn/LockResolverTest.java
@@ -129,7 +129,8 @@ abstract class LockResolverTest {
       long startTS,
       String primaryKey,
       long ttl,
-      Iterable<ByteString> secondaries) {
+      Iterable<ByteString> secondaries,
+      boolean fallback) {
     Mutation m =
         Mutation.newBuilder()
             .setKey(ByteString.copyFromUtf8(key))
@@ -143,11 +144,12 @@ abstract class LockResolverTest {
         ByteString.copyFromUtf8(primaryKey),
         ttl,
         true,
-        secondaries);
+        secondaries,
+        fallback);
   }
 
   boolean prewriteString(List<Mutation> mutations, long startTS, String primary, long ttl) {
-    return prewrite(mutations, startTS, ByteString.copyFromUtf8(primary), ttl, false, null);
+    return prewrite(mutations, startTS, ByteString.copyFromUtf8(primary), ttl, false, null, false);
   }
 
   boolean prewrite(
@@ -156,7 +158,8 @@ abstract class LockResolverTest {
       ByteString primary,
       long ttl,
       boolean useAsyncCommit,
-      Iterable<ByteString> secondaries) {
+      Iterable<ByteString> secondaries,
+      boolean fallback) {
     if (mutations.size() == 0) return true;
     BackOffer backOffer = ConcreteBackOffer.newCustomBackOff(1000);
 
@@ -173,7 +176,8 @@ abstract class LockResolverTest {
               ttl,
               false,
               useAsyncCommit,
-              secondaries);
+              secondaries,
+              fallback);
           break;
         } catch (RegionException e) {
           backOffer.doBackOff(BackOffFunction.BackOffFuncType.BoRegionMiss, e);


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

If we does not fallback in the resolveLockAsync. TiSpark may commit the txn which should be rollback.

### What is changed and how it works?

refer to client-go  https://github.com/tikv/client-go/blob/daddf73a0706d78c9e980c91c97cc9ed100f1919/txnkv/txnlock/lock_resolver.go#L341

When we checkSecondaries and find the lock did not use AsyncCommit. Just throw an exception. resolveLockAsync will fallback when it catches the exception