### PR TITLE
[Draft] Support List partition pruning

### DIFF
--- a/core/src/test/scala/org/apache/spark/sql/ListPartitionPruningSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/ListPartitionPruningSuite.scala
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2020 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql
+
+import com.pingcap.tikv.meta.{TiDAGRequest, TiPartitionDef}
+import org.apache.spark.sql.catalyst.plans.BasePlanTest
+
+import java.util.List
+
+class ListPartitionPruningSuite extends BasePlanTest {
+
+  test("list partition") {
+    val table = "employees"
+    tidbStmt.execute(s"DROP TABLE IF EXISTS $table")
+    tidbStmt.execute(s"""
+                       CREATE TABLE $table (
+                       |    id INT NOT NULL,
+                       |    store_id INT
+                       |)
+                       |PARTITION BY LIST (store_id) (
+                       |    PARTITION p1 VALUES IN (1, 2, 3, 4, 5),
+                       |    PARTITION p2 VALUES IN (6, 7, 8, 9, 10),
+                       |    PARTITION p3 VALUES IN (11, 12, 13, 14, 15),
+                       |    PARTITION p4 VALUES IN (16, 17, 18, 19, 20)
+                       |);
+                     """.stripMargin)
+
+    var defs = extractDAGReqPrunedParts(spark.sql(s"select * from $table where store_id=1"))
+    assert(defs.size() == 1 && defs.get(0).getName.equals("p1"))
+
+    defs =
+      extractDAGReqPrunedParts(spark.sql(s"select * from $table where store_id=5 or store_id=12"))
+    assert(
+      defs.size() == 2 && defs.get(0).getName.equals("p1") && defs.get(1).getName.equals("p3"))
+
+    defs = extractDAGReqPrunedParts(
+      spark.sql(s"select * from $table where store_id > 5 and store_id < 16"))
+    assert(
+      defs.size() == 2 && defs.get(0).getName.equals("p2") && defs.get(1).getName.equals("p3"))
+
+    defs = extractDAGReqPrunedParts(spark.sql(s"select * from $table where store_id = 21"))
+    assert(defs.size() == 0)
+  }
+
+  test("list partition with year function") {
+    val table = "list_year"
+    tidbStmt.execute(s"DROP TABLE IF EXISTS $table")
+    tidbStmt.execute(s"""
+                       CREATE TABLE $table (
+                        |    id INT NOT NULL,
+                        |    date datetime
+                        |)
+                        |PARTITION BY LIST (year(date)) (
+                        |    PARTITION p1 VALUES IN (1990, 1991),
+                        |    PARTITION p2 VALUES IN (2000, 2001),
+                        |    PARTITION p3 VALUES IN (2020, 2021,2022),
+                        |    PARTITION p4 VALUES IN (2023)
+                        |);
+                     """.stripMargin)
+
+    println(s"""
+                       CREATE TABLE $table (
+               |    id INT NOT NULL,
+               |    date datetime
+               |)
+               |PARTITION BY LIST (year(date)) (
+               |    PARTITION p1 VALUES IN (1990, 1991),
+               |    PARTITION p2 VALUES IN (2000, 2001),
+               |    PARTITION p3 VALUES IN (2020, 2021,2022),
+               |    PARTITION p4 VALUES IN (2023)
+               |);
+                     """.stripMargin)
+
+    var defs =
+      extractDAGReqPrunedParts(spark.sql(s"select * from $table where date='1990-01-01'"))
+    assert(defs.size() == 1 && defs.get(0).getName.equals("p1"))
+
+    defs = extractDAGReqPrunedParts(
+      spark.sql(s"select * from $table where date='1991-01-01' or date='2020-01-01'"))
+    assert(
+      defs.size() == 2 && defs.get(0).getName.equals("p1") && defs.get(1).getName.equals("p3"))
+
+    defs = extractDAGReqPrunedParts(
+      spark.sql(s"select * from $table where date > '1991-01-01' and date < '2023-01-02'"))
+    assert(
+      defs.size() == 2 && defs.get(0).getName.equals("p2") && defs.get(1).getName.equals("p3"))
+
+    defs = extractDAGReqPrunedParts(spark.sql(s"select * from $table where date = '1888-01-01'"))
+    assert(defs.size() == 0)
+  }
+
+  test("list column partition with mutil column") {
+    val table = "mutil_column"
+    tidbStmt.execute(s"DROP TABLE IF EXISTS $table")
+    tidbStmt.execute(s"""
+                       CREATE TABLE $table (
+                         |    ID int,
+                         |    NAME varchar(10)
+                         |)
+                         |PARTITION BY LIST COLUMNS(ID,NAME) (
+                         |     partition p0 values IN ((1,'a'),(2,'b')),
+                         |     partition p1 values IN ((3,'c'),(4,'d')),
+                         |     partition p2 values IN ((5,'e'),(6,'f'))
+                         |);
+                     """.stripMargin)
+
+    var defs = extractDAGReqPrunedParts(spark.sql(s"select * from $table where id=3"))
+    assert(defs.size() == 1 && defs.get(0).getName.equals("p1"))
+
+    defs = extractDAGReqPrunedParts(spark.sql(s"select * from $table where name = 'a'"))
+    assert(defs.size() == 1 && defs.get(0).getName.equals("p0"))
+
+    defs = extractDAGReqPrunedParts(spark.sql(s"select * from $table where id > 2"))
+    assert(
+      defs.size() == 2 && defs.get(0).getName.equals("p1") && defs.get(1).getName.equals("p2"))
+
+    defs = extractDAGReqPrunedParts(spark.sql(s"select * from $table where name > 'c'"))
+    assert(
+      defs.size() == 2 && defs.get(0).getName.equals("p1") && defs.get(1).getName.equals("p2"))
+
+    defs = extractDAGReqPrunedParts(spark.sql(s"select * from $table where id > 2 and name >'d'"))
+    assert(defs.size() == 1 && defs.get(0).getName.equals("p2"))
+
+    defs = extractDAGReqPrunedParts(spark.sql(s"select * from $table where id > 2 and name <'e'"))
+    assert(defs.size() == 1 && defs.get(0).getName.equals("p1"))
+
+    defs = extractDAGReqPrunedParts(spark.sql(s"select * from $table where id > 1 and name <'e'"))
+    assert(
+      defs.size() == 2 && defs.get(0).getName.equals("p0") && defs.get(1).getName.equals("p1"))
+
+    defs =
+      extractDAGReqPrunedParts(spark.sql(s"select * from $table where id > 2 and name = 'a'"))
+    assert(defs.size() == 0)
+
+  }
+
+  private def extractDAGReqPrunedParts(df: DataFrame): List[TiPartitionDef] = {
+    val dag = extractDAGRequests(df)
+    if (dag.isEmpty) {
+      return new java.util.ArrayList[TiPartitionDef]()
+    }
+    dag.head.getPrunedParts
+  }
+
+}

--- a/tikv-client/src/main/java/com/pingcap/tikv/expression/ListColumnPartitionPruner.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/expression/ListColumnPartitionPruner.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2023 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pingcap.tikv.expression;
+
+import static com.pingcap.tikv.expression.PartitionPruner.extractLogicalOrComparisonExpr;
+
+import com.pingcap.tikv.expression.visitor.DefaultVisitor;
+import com.pingcap.tikv.expression.visitor.PrunedPartitionBuilder;
+import com.pingcap.tikv.key.TypedKey;
+import com.pingcap.tikv.meta.TiPartitionDef;
+import com.pingcap.tikv.meta.TiPartitionInfo;
+import com.pingcap.tikv.meta.TiTableInfo;
+import com.pingcap.tikv.parser.TiParser;
+import com.pingcap.tikv.predicates.PredicateUtils;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.tikv.shade.com.google.common.collect.ImmutableSet;
+import org.tikv.shade.com.google.common.collect.RangeSet;
+import org.tikv.shade.com.google.common.collect.TreeRangeSet;
+
+public class ListColumnPartitionPruner
+    extends DefaultVisitor<Set<Integer>, LogicalBinaryExpression> {
+
+  private final TiPartitionInfo partInfo;
+  private final Map<String, List<Expression>> partExprsPerColumnRef;
+
+  ListColumnPartitionPruner(TiTableInfo tableInfo) {
+    this.partExprsPerColumnRef = new HashMap<>();
+    this.partInfo = tableInfo.getPartitionInfo();
+    TiParser parser = new TiParser(tableInfo);
+    for (int i = 0; i < partInfo.getColumns().size(); i++) {
+      String colRefName = partInfo.getColumns().get(i);
+      List<Expression> partExprs =
+          PartitionPruner.generateListExprs(partInfo, parser, colRefName, i);
+      partExprsPerColumnRef.put(colRefName, partExprs);
+    }
+  }
+
+  public List<TiPartitionDef> prune(List<Expression> filters) {
+    filters = extractLogicalOrComparisonExpr(filters);
+    Expression cnfExpr = PredicateUtils.mergeCNFExpressions(filters);
+    if (cnfExpr == null) {
+      return partInfo.getDefs();
+    }
+    Set<Integer> partsIdx = cnfExpr.accept(this, null);
+    List<TiPartitionDef> pDefs = new ArrayList<>();
+    for (int i = 0; i < partInfo.getDefs().size(); i++) {
+      if (partsIdx.contains(i)) {
+        // part range is empty indicates this partition can be pruned.
+        pDefs.add(partInfo.getDefs().get(i));
+      }
+    }
+    return pDefs;
+  }
+
+  @Override
+  protected Set<Integer> visit(LogicalBinaryExpression node, LogicalBinaryExpression parent) {
+    Expression left = node.getLeft();
+    Expression right = node.getRight();
+    Set<Integer> partsIsCoveredByLeft = left.accept(this, node);
+    Set<Integer> partsIsCoveredByRight = right.accept(this, node);
+    switch (node.getCompType()) {
+      case OR:
+        partsIsCoveredByLeft.addAll(partsIsCoveredByRight);
+        return partsIsCoveredByLeft;
+      case AND:
+        Set<Integer> partsIsCoveredByBoth = new HashSet<>();
+        for (int i = 0; i < partInfo.getDefs().size(); i++) {
+          if (partsIsCoveredByLeft.contains(i) && partsIsCoveredByRight.contains(i)) {
+            partsIsCoveredByBoth.add(i);
+          }
+        }
+        return partsIsCoveredByBoth;
+    }
+
+    throw new UnsupportedOperationException("cannot access here");
+  }
+
+  @Override
+  protected Set<Integer> visit(ComparisonBinaryExpression node, LogicalBinaryExpression parent) {
+    ComparisonBinaryExpression.NormalizedPredicate predicate = node.normalize();
+    if (predicate == null) {
+      throw new UnsupportedOperationException(
+          String.format("ComparisonBinaryExpression %s cannot be normalized", node));
+    }
+    String colRefName = predicate.getColumnRef().getName();
+    List<Expression> partExprs = partExprsPerColumnRef.get(colRefName);
+    Set<Integer> partDefs = new HashSet<>();
+    // For filter with column which is not partitioned columns, we can't locate the physical table,
+    // so we just return all partitionDefs.
+    if (partExprs == null) {
+      for (int i = 0; i < partInfo.getDefs().size(); i++) {
+        partDefs.add(i);
+      }
+      return partDefs;
+    }
+    PrunedPartitionBuilder rangeBuilder =
+        new PrunedPartitionBuilder(ImmutableSet.of(predicate.getColumnRef()));
+    for (int i = 0; i < partInfo.getDefs().size(); i++) {
+      RangeSet<TypedKey> partExprRange = rangeBuilder.buildRange(partExprs.get(i));
+      RangeSet<TypedKey> filterRange = rangeBuilder.buildRange(node);
+      RangeSet<TypedKey> copy = TreeRangeSet.create(partExprRange);
+      copy.removeAll(filterRange.complement());
+      // part expr and filter is connected
+      if (!copy.isEmpty()) {
+        partDefs.add(i);
+      }
+    }
+    return partDefs;
+  }
+}

--- a/tikv-client/src/main/java/com/pingcap/tikv/expression/ListPartitionPruner.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/expression/ListPartitionPruner.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2023 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pingcap.tikv.expression;
+
+import static com.pingcap.tikv.expression.PartitionPruner.extractLogicalOrComparisonExpr;
+
+import com.pingcap.tikv.expression.visitor.PartAndFilterExprRewriter;
+import com.pingcap.tikv.expression.visitor.PrunedPartitionBuilder;
+import com.pingcap.tikv.key.TypedKey;
+import com.pingcap.tikv.meta.TiPartitionDef;
+import com.pingcap.tikv.meta.TiPartitionInfo;
+import com.pingcap.tikv.meta.TiTableInfo;
+import com.pingcap.tikv.parser.TiParser;
+import com.pingcap.tikv.predicates.PredicateUtils;
+import java.util.ArrayList;
+import java.util.List;
+import org.tikv.shade.com.google.common.collect.RangeSet;
+
+public class ListPartitionPruner {
+
+  private final TiPartitionInfo partInfo;
+  private final Expression partExpr;
+  private List<Expression> partExprs;
+  private PrunedPartitionBuilder rangeBuilder;
+  private boolean foundUnsupportedPartExpr = false;
+
+  ListPartitionPruner(TiTableInfo tableInfo) {
+    this.partInfo = tableInfo.getPartitionInfo();
+    TiParser parser = new TiParser(tableInfo);
+    String partExprStr = partInfo.getExpr();
+
+    this.partExpr = parser.parseExpression(partExprStr);
+    if (partExpr == null) {
+      // add log here
+      foundUnsupportedPartExpr = true;
+      return;
+    }
+
+    this.partExprs = PartitionPruner.generateListExprs(partInfo, parser, partExprStr, 0);
+    this.rangeBuilder =
+        new PrunedPartitionBuilder(PredicateUtils.extractColumnRefFromExpression(partExpr));
+  }
+
+  public List<TiPartitionDef> prune(List<Expression> filters) {
+    filters = extractLogicalOrComparisonExpr(filters);
+    Expression cnfExpr = PredicateUtils.mergeCNFExpressions(filters);
+    if (foundUnsupportedPartExpr || cnfExpr == null) {
+      return this.partInfo.getDefs();
+    }
+
+    // we need rewrite filter expression if partition expression is a Year expression.
+    // This step is designed to deal with y < '1995-10-10'(in filter condition and also a part of
+    // partition expression) where y is a date type.
+    // Rewriting only applies partition expression on the constant part, resulting y < 1995.
+    PartAndFilterExprRewriter expressionRewriter = new PartAndFilterExprRewriter(partExpr);
+    cnfExpr = expressionRewriter.rewrite(cnfExpr);
+    // TODO
+    // if we find an unsupported partition function, we downgrade to scan all partitions.
+    if (expressionRewriter.isUnsupportedPartFnFound()) {
+      return partInfo.getDefs();
+    }
+    RangeSet<TypedKey> filterRange = rangeBuilder.buildRange(cnfExpr);
+
+    List<TiPartitionDef> pDefs = new ArrayList<>();
+    for (int i = 0; i < partExprs.size(); i++) {
+      Expression partExpr = partExprs.get(i);
+      // when we build range, we still need rewrite partition expression.
+      // If we have a year(purchased) < 1995 which cannot be normalized, we need
+      // to rewrite it into purchased < 1995 to let RangeSetBuilder be happy.
+      RangeSet<TypedKey> partRange = rangeBuilder.buildRange(expressionRewriter.rewrite(partExpr));
+      partRange.removeAll(filterRange.complement());
+      if (!partRange.isEmpty()) {
+        // part range is empty indicates this partition can be pruned.
+        pDefs.add(partInfo.getDefs().get(i));
+      }
+    }
+    return pDefs;
+  }
+}

--- a/tikv-client/src/main/java/com/pingcap/tikv/meta/TiPartitionDef.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/meta/TiPartitionDef.java
@@ -30,6 +30,7 @@ public class TiPartitionDef implements Serializable {
   private final long id;
   private final String name;
   private final List<String> lessThan;
+  private final List<List<String>> inValues;
   private final String comment;
 
   @VisibleForTesting
@@ -38,6 +39,7 @@ public class TiPartitionDef implements Serializable {
       @JsonProperty("id") long id,
       @JsonProperty("name") CIStr name,
       @JsonProperty("less_than") List<String> lessThan,
+      @JsonProperty("in_values") List<List<String>> inValues,
       @JsonProperty("comment") String comment) {
     this.id = id;
     this.name = name.getL();
@@ -45,6 +47,11 @@ public class TiPartitionDef implements Serializable {
       this.lessThan = new ArrayList<>();
     } else {
       this.lessThan = ImmutableList.copyOf(lessThan);
+    }
+    if (inValues == null || inValues.isEmpty()) {
+      this.inValues = new ArrayList<>();
+    } else {
+      this.inValues = ImmutableList.copyOf(inValues);
     }
     this.comment = comment;
   }
@@ -59,5 +66,9 @@ public class TiPartitionDef implements Serializable {
 
   public List<String> getLessThan() {
     return lessThan;
+  }
+
+  public List<List<String>> getInValues() {
+    return inValues;
   }
 }

--- a/tikv-client/src/main/java/com/pingcap/tikv/predicates/PredicateUtils.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/predicates/PredicateUtils.java
@@ -17,6 +17,7 @@
 package com.pingcap.tikv.predicates;
 
 import static com.pingcap.tikv.expression.LogicalBinaryExpression.and;
+import static com.pingcap.tikv.expression.LogicalBinaryExpression.or;
 import static java.util.Objects.requireNonNull;
 
 import com.pingcap.tikv.expression.ColumnRef;
@@ -45,6 +46,14 @@ public class PredicateUtils {
     if (exprs.size() == 1) return exprs.get(0);
 
     return and(exprs.get(0), mergeCNFExpressions(exprs.subList(1, exprs.size())));
+  }
+
+  public static Expression mergeExpressionsWithOr(List<Expression> exprs) {
+    requireNonNull(exprs, "Expression list is null");
+    if (exprs.size() == 0) return null;
+    if (exprs.size() == 1) return exprs.get(0);
+
+    return or(exprs.get(0), mergeExpressionsWithOr(exprs.subList(1, exprs.size())));
   }
 
   public static Set<ColumnRef> extractColumnRefFromExpression(Expression expr) {

--- a/tikv-client/src/test/java/com/pingcap/tikv/parser/TiParserTest.java
+++ b/tikv-client/src/test/java/com/pingcap/tikv/parser/TiParserTest.java
@@ -147,10 +147,18 @@ public class TiParserTest {
 
   private TiTableInfo createTaleInfoWithParts() {
     List<TiPartitionDef> partDefs = new ArrayList<>();
-    partDefs.add(new TiPartitionDef(1L, CIStr.newCIStr("p0"), ImmutableList.of("5"), ""));
-    partDefs.add(new TiPartitionDef(2L, CIStr.newCIStr("p1"), ImmutableList.of("10"), ""));
-    partDefs.add(new TiPartitionDef(3L, CIStr.newCIStr("p2"), ImmutableList.of("15"), ""));
-    partDefs.add(new TiPartitionDef(4L, CIStr.newCIStr("p3"), ImmutableList.of("MAXVALUE"), ""));
+    partDefs.add(
+        new TiPartitionDef(
+            1L, CIStr.newCIStr("p0"), ImmutableList.of("5"), ImmutableList.of(), ""));
+    partDefs.add(
+        new TiPartitionDef(
+            2L, CIStr.newCIStr("p1"), ImmutableList.of("10"), ImmutableList.of(), ""));
+    partDefs.add(
+        new TiPartitionDef(
+            3L, CIStr.newCIStr("p2"), ImmutableList.of("15"), ImmutableList.of(), ""));
+    partDefs.add(
+        new TiPartitionDef(
+            4L, CIStr.newCIStr("p3"), ImmutableList.of("MAXVALUE"), ImmutableList.of(), ""));
     return new MetaUtils.TableBuilder()
         .name("rcx")
         .addColumn("a", IntegerType.INT, true)


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

Support List partition pruning.

### What is changed and how it works?

This pr is a draft. Things missing:
- design doc and user doc
- partition pruning with `IN` expression
- forbid partition pruning in some expressions (like `>`,`<`) when there have functions in partition expression. For example, we can not perform partition pruning when the partition expression is year(column) and the predicate is column > '2000-01-01'. because we will rewrite as year(column) > 2000, however year('2000-01-02') is also 2000. This may cause the error when choosing the partition. (TiDB also does not support)
- fully tests (including different expression and different data type)
- Optimize the code. There are some codes copied from the range partition pruning, I think we can reuse them ; I think we can also combine the logical of list partition pruning and list column partition pruning.
 
I currently don't have time to work on this any further for at least a couple of weeks. but feel free to use this pr as the basis for proper implementation.

