### PR TITLE
optimize ttl

### DIFF
--- a/tikv-client/src/main/java/com/pingcap/tikv/allocator/RowIDAllocator.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/allocator/RowIDAllocator.java
@@ -63,6 +63,7 @@ public final class RowIDAllocator implements Serializable {
   private long end;
   private final long autoRandomPartition;
   private final RowIDAllocatorType allocatorType;
+  private final long RowIDAllocatorTTL = 10000;
 
   private static final Logger LOG = LoggerFactory.getLogger(RowIDAllocator.class);
 
@@ -199,7 +200,7 @@ public final class RowIDAllocator implements Serializable {
       return;
     }
     TiSession session = ClientSession.getInstance(conf).getTiKVSession();
-    TwoPhaseCommitter twoPhaseCommitter = new TwoPhaseCommitter(session, timestamp.getVersion());
+    TwoPhaseCommitter twoPhaseCommitter = new TwoPhaseCommitter(session, timestamp.getVersion(),RowIDAllocatorTTL);
     BytePairWrapper primaryPair = iterator.next();
     twoPhaseCommitter.prewritePrimaryKey(
         ConcreteBackOffer.newCustomBackOff(TiConfiguration.PREWRITE_MAX_BACKOFF),

--- a/tikv-client/src/main/java/com/pingcap/tikv/allocator/RowIDAllocator.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/allocator/RowIDAllocator.java
@@ -200,7 +200,8 @@ public final class RowIDAllocator implements Serializable {
       return;
     }
     TiSession session = ClientSession.getInstance(conf).getTiKVSession();
-    TwoPhaseCommitter twoPhaseCommitter = new TwoPhaseCommitter(session, timestamp.getVersion(),RowIDAllocatorTTL);
+    TwoPhaseCommitter twoPhaseCommitter =
+        new TwoPhaseCommitter(session, timestamp.getVersion(), RowIDAllocatorTTL);
     BytePairWrapper primaryPair = iterator.next();
     twoPhaseCommitter.prewritePrimaryKey(
         ConcreteBackOffer.newCustomBackOff(TiConfiguration.PREWRITE_MAX_BACKOFF),


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

when RowIDAllocator uses 2pc to write with the TTL=3600s. Once it failed and leaves the lock, TiSpark can not resolve the lock until 3600s later for the lock is not expired.

For example, read may push the min_commit_ts, causing the RowIDAllocator 2pc to fail with `commit_ts_expired`. Then the retry can not success for lock ttl is too long.


### What is changed and how it works?

just set ttl to 10s

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `tidb-ansible` repository
 - Need to be included in the release note
