### PR TITLE
Resolve the problem of the generating of BroadcastJoin in physical plan

### DIFF
--- a/core/src/main/scala/com/pingcap/tispark/v2/TiDBTable.scala
+++ b/core/src/main/scala/com/pingcap/tispark/v2/TiDBTable.scala
@@ -105,7 +105,7 @@ case class TiDBTable(
   def tableName: String = tableRef.tableName
 
   override def newScanBuilder(options: CaseInsensitiveStringMap): ScanBuilder =
-    () => () => schema
+    new TiDBTableScanBuilder(this.tableRef,this.schema)
 
   override def name(): String = tableRef.quoted
 

--- a/core/src/main/scala/com/pingcap/tispark/v2/TiDBTableScan.scala
+++ b/core/src/main/scala/com/pingcap/tispark/v2/TiDBTableScan.scala
@@ -22,6 +22,7 @@ case class TiDBTableScan(
       }
 
       override def numRows(): OptionalLong = OptionalLong.empty()
+
     }
   }
 }

--- a/core/src/main/scala/com/pingcap/tispark/v2/TiDBTableScan.scala
+++ b/core/src/main/scala/com/pingcap/tispark/v2/TiDBTableScan.scala
@@ -1,0 +1,26 @@
+package com.pingcap.tispark.v2
+
+import com.pingcap.tispark.TiTableReference
+import org.apache.spark.sql.connector.read.{Scan, Statistics, SupportsReportStatistics}
+import org.apache.spark.sql.types.StructType
+
+import java.util.OptionalLong
+
+case class TiDBTableScan(
+     tableRef: TiTableReference,
+     schema: StructType)
+  extends Scan
+    with SupportsReportStatistics {
+
+  override def readSchema(): StructType = schema
+
+  override def estimateStatistics(): Statistics = {
+    new Statistics {
+      override def sizeInBytes(): OptionalLong = {
+        val size = tableRef.sizeInBytes
+        OptionalLong.of(size)
+      }
+      override def numRows(): OptionalLong = OptionalLong.empty()
+    }
+  }
+}

--- a/core/src/main/scala/com/pingcap/tispark/v2/TiDBTableScan.scala
+++ b/core/src/main/scala/com/pingcap/tispark/v2/TiDBTableScan.scala
@@ -20,6 +20,7 @@ case class TiDBTableScan(
         val size = tableRef.sizeInBytes
         OptionalLong.of(size)
       }
+
       override def numRows(): OptionalLong = OptionalLong.empty()
     }
   }

--- a/core/src/main/scala/com/pingcap/tispark/v2/TiDBTableScanBuilder.scala
+++ b/core/src/main/scala/com/pingcap/tispark/v2/TiDBTableScanBuilder.scala
@@ -1,0 +1,14 @@
+package com.pingcap.tispark.v2
+
+import com.pingcap.tispark.TiTableReference
+import org.apache.spark.sql.connector.read.{Scan, ScanBuilder}
+import org.apache.spark.sql.types.StructType
+
+class TiDBTableScanBuilder(
+    tableRef: TiTableReference,
+    schema: StructType
+    ) extends ScanBuilder {
+  override def build(): Scan = {
+    TiDBTableScan(tableRef,schema)
+  }
+}


### PR DESCRIPTION

### What problem does this PR solve? <!--add issue link with summary if exists-->

A small table can not be generated  BroadcastJoin Physical Plan. 

The table size is less than default value of 'spark.sql.autoBroadcastJoinThreshold' . 

And although TableSizeEstimator.estimatedTableSize < 'spark.sql.autoBroadcastJoinThreshold' , the physical plan is not still BroadcastJoin.

In some cases, this will reduce the execution efficiency of tispark, for example, when the user sets 'spark.sql.adaptive.enabled=false', the table will never be brocast

### What is changed and how it works?

This PR create the 'TiDBTableScan' class to provide 'sizeInBytes' of table when generate physical plan, which can be used to determined whether to broadcast a table. And Scan class is common in other file formats such as parquet，orc and so on.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

```
//create a table in tidb
CREATE TABLE person (id INT(11),name VARCHAR(255),birthday DATE);
INSERT INTO person VALUES(1,'tom','20170912');
INSERT INTO person VALUES(2,'tom','20170912');
INSERT INTO person VALUES(3,'tom','20170912');
INSERT INTO person VALUES(4,'tom','20170912');
INSERT INTO person VALUES(5,'tom','20170912');
INSERT INTO person VALUES(6,'tom','20170912');
INSERT INTO person VALUES(7,'tom','20170912');
INSERT INTO person VALUES(8,'tom','20170912');
INSERT INTO person VALUES(9,'tom','20170912');
```
```
SparkSession spark = SparkSession.builder().master("local[*]")
            .config("spark.sql.extensions","org.apache.spark.sql.TiExtensions")
            .config("spark.sql.catalog.tidb_catalog","org.apache.spark.sql.catalyst.catalog.TiCatalog")
            .config("spark.tispark.pd.addresses","127.0.0.1:2379")
            .config("spark.sql.catalog.tidb_catalog.pd.addresses","127.0.0.1:2379")
            .config("spark.sql.adaptive.enabled","false")
            .getOrCreate();
Dataset<Row> dataset = spark.sql("select * from tidb_catalog.test.person t1 left join tidb_catalog.test.person t2 on t1.id = t2.id");
     dataset.explain(true);
```
```
===========================result:physical plan before modification==============================

*(5) SortMergeJoin [id#6L], [id#9L], LeftOuter
:- *(2) Sort [id#6L ASC NULLS FIRST], false, 0
:     +- Exchange hashpartitioning(id#6L, 200), ENSURE_REQUIREMENTS, [id=#27]
:       +- *(1) ColumnarToRow
:         +- TiKV CoprocessorRDD{[table: person] TableReader, Columns: id@LONG, name@VARCHAR(255)....
+- *(4) Sort [id#9L ASC NULLS FIRST], false, 0
      +- Exchange hashpartitioning(id#9L, 200), ENSURE_REQUIREMENTS, [id=#35]
        +- *(3) ColumnarToRow
          +- TiKV CoprocessorRDD{[table: person] TableReader, Columns: id@LONG, name@VARCHAR(255)....

===========================result:physical plan after modification==============================

*(2) BroadcastHashJoin [id#6L], [id#9L], LeftOuter, BuildRight, false
:- *(2) ColumnarToRow
:    +- TiKV CoprocessorRDD{[table: person] TableReader, Columns: id@LONG, name@VARCHAR(255).....
+- BroadcastExchange HashedRelationBroadcastMode(List(input[0, bigint, true]),false), [id=#22]
     +- *(1) ColumnarToRow
        +- TiKV CoprocessorRDD{[table: person] TableReader, Columns: id@LONG, name@VARCHAR(255)...
```

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `tidb-ansible` repository
 - Need to be included in the release note
