### PR TITLE
Remove JDK 1.8 specific functions from tikv-client

### DIFF
--- a/tikv-client/pom.xml
+++ b/tikv-client/pom.xml
@@ -38,6 +38,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>1.3.2</version>
+        </dependency>
+        <dependency>
             <groupId>org.antlr</groupId>
             <artifactId>antlr4-runtime</artifactId>
             <version>4.7.1</version>

--- a/tikv-client/src/main/java/com/pingcap/tikv/columnar/TiBlockColumnVector.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/columnar/TiBlockColumnVector.java
@@ -101,17 +101,6 @@ public class TiBlockColumnVector extends TiColumnVector {
    */
   @Override
   public void close() {
-    if (dataAddr != 0) {
-      MemoryUtil.free(data);
-    }
-
-    if (offsetsAddr != 0) {
-      MemoryUtil.free(offsets);
-    }
-
-    if (nullMapAddr != 0) {
-      MemoryUtil.free(nullMap);
-    }
     dataAddr = 0;
     offsetsAddr = 0;
     nullMapAddr = 0;

--- a/tikv-client/src/main/java/com/pingcap/tikv/columnar/datatypes/AutoGrowByteBuffer.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/columnar/datatypes/AutoGrowByteBuffer.java
@@ -51,10 +51,6 @@ public class AutoGrowByteBuffer {
           MemoryUtil.getAddress(buf), MemoryUtil.getAddress(newBuf), buf.position());
       newBuf.position(buf.position());
 
-      if (buf != initBuf) {
-        MemoryUtil.free(buf);
-      }
-
       buf = newBuf;
     }
   }


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
Removes JDK 1.8 specific code.

### What is changed and how it works?
Mostly the change doesn't affect functionality - we pull in javax.annotation-api from Maven which should work for both JDK 1.8 and later versions and remove unused code in MemoryUtil.

The one functionality change is removing MemoryUtil.free calls from TiBlockColumnVector and AutoGrowByteBuffer. This will defer buffer removal from the close() call to the finalize() call on the relevant object, but there doesn't appear to be a clean way independent of JDK versions to do this. I've tested some with Spark and it doesn't appear to have a major impact on memory usage.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
 Most changes are verified by compilation passing. Memory changes have been verified by manually running some Spark jobs.

Code changes

 - Has exported function/method change
Some MemoryUtil methods have been removed, but that's intended to be internal.

Side effects

 - Possible performance regression

Possible that memory usage will change due to free() call removal.

Related changes

None of the above
