### PR TITLE
Fix escape for StringRegExpression

### DIFF
--- a/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
@@ -22,6 +22,17 @@ import org.apache.spark.sql.functions.{col, sum}
 
 class IssueTestSuite extends BaseTiSparkTest {
 
+  test("test like escape") {
+    val dbTable = "tispark_test.like_escape"
+    tidbStmt.execute(s"drop table if exists $dbTable")
+    tidbStmt.execute(
+      s"CREATE TABLE $dbTable (`name` varchar(64) NOT NULL)")
+    tidbStmt.execute(s"insert into $dbTable values('ab%H')")
+    val df = spark.sql("select count(*) from test.t where name like '%\\%H%'")
+    assert(df.collect().head.get(0) == 1)
+
+  }
+
   test("test tiflash overflow in unsigned bigint") {
     if (!enableTiFlashTest) {
       cancel("tiflash test not enabled")

--- a/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
@@ -27,7 +27,7 @@ class IssueTestSuite extends BaseTiSparkTest {
     tidbStmt.execute(s"drop table if exists $dbTable")
     tidbStmt.execute(s"CREATE TABLE $dbTable (`name` varchar(64) NOT NULL)")
     tidbStmt.execute(s"insert into $dbTable values('ab%H')")
-    val df = spark.sql("select count(*) from test.t where name like '%\\%H%'")
+    val df = spark.sql(s"select count(*) from $dbTable where name like '%\\%H%'")
     assert(df.collect().head.get(0) == 1)
 
   }

--- a/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
@@ -25,8 +25,7 @@ class IssueTestSuite extends BaseTiSparkTest {
   test("test like escape") {
     val dbTable = "tispark_test.like_escape"
     tidbStmt.execute(s"drop table if exists $dbTable")
-    tidbStmt.execute(
-      s"CREATE TABLE $dbTable (`name` varchar(64) NOT NULL)")
+    tidbStmt.execute(s"CREATE TABLE $dbTable (`name` varchar(64) NOT NULL)")
     tidbStmt.execute(s"insert into $dbTable values('ab%H')")
     val df = spark.sql("select count(*) from test.t where name like '%\\%H%'")
     assert(df.collect().head.get(0) == 1)

--- a/tikv-client/src/main/java/com/pingcap/tikv/expression/StringRegExpression.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/expression/StringRegExpression.java
@@ -86,10 +86,8 @@ public class StringRegExpression extends Expression {
 
   @Override
   public List<Expression> getChildren() {
-    // For LIKE statement, an extra ESCAPE parameter is required as the third parameter for
-    // ScalarFunc.
-    // However in Spark ESCAPE is not supported so we simply set this value to zero.
-    return ImmutableList.of(left, reg, Constant.create(0, IntegerType.BIGINT));
+    // LIKE statement use '\' as escape character because Spark use it as escape character too.
+    return ImmutableList.of(left, reg, Constant.create(92, IntegerType.BIGINT));
   }
 
   @Override


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

TiSpark does not support escape in like expression before.


### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `tidb-ansible` repository
 - Need to be included in the release note
