### PR TITLE
Add agg mode to fix read tifalsh fail

### DIFF
--- a/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/IssueTestSuite.scala
@@ -28,8 +28,7 @@ class IssueTestSuite extends BaseTiSparkTest {
     }
     val dbTable = "test.tiflash_not_null"
     tidbStmt.execute(s"drop table if exists $dbTable")
-    tidbStmt.execute(
-      s"CREATE TABLE $dbTable (`a` int NOT NULL)")
+    tidbStmt.execute(s"CREATE TABLE $dbTable (`a` int NOT NULL)")
     tidbStmt.execute(s"ALTER TABLE $dbTable SET TIFLASH REPLICA 1")
 
     Thread.sleep(5 * 1000)

--- a/tikv-client/scripts/proto.sh
+++ b/tikv-client/scripts/proto.sh
@@ -22,7 +22,7 @@ kvproto_hash=4d69c6f95e683dfb5859277563bf896aca06ec34
 
 raft_rs_hash=b9891b673573fad77ebcf9bbe0969cf945841926
 
-tipb_hash=45e60c77588fefe421d0f6f29426a36b5b15171d
+tipb_hash=29e23c62eeace5912f696d1b184b63d5dc3edcce
 
 if [ -d "kvproto" ]; then
 	cd kvproto; git fetch -p; git checkout ${kvproto_hash}; cd ..

--- a/tikv-client/src/main/java/com/pingcap/tikv/expression/visitor/ProtoConverter.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/expression/visitor/ProtoConverter.java
@@ -16,6 +16,7 @@
 
 package com.pingcap.tikv.expression.visitor;
 
+import static com.pingcap.tidb.tipb.AggFunctionMode.Partial1Mode;
 import static java.util.Objects.requireNonNull;
 
 import com.google.common.collect.ImmutableMap;
@@ -350,6 +351,7 @@ public class ProtoConverter extends Visitor<Expr, Object> {
     }
 
     builder.setFieldType(toPBFieldType(getType(node)));
+    builder.setAggFuncMode(Partial1Mode);
     return builder.build();
   }
 


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

reproduce step:

1. create table test.t(id int not null);
2. alter table test.t set tiflash replica 1;
3. Execute tispark
```
spark.conf.set("spark.tispark.isolation_read_engines", "tiflash")
spark.sql("select max(id) from tidb_catalog.test.t").show()
```
4. output error

```
can not convert NULL value to non-Nullable type
```

### What is changed and how it works?

update tipb proto and set AggFunctionMode to Partial1Mode

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `tidb-ansible` repository
 - Need to be included in the release note
