### PR TITLE
Fix when user has SelectPriv, use can visit db.table (#2799)

### DIFF
--- a/core/src/main/scala/com/pingcap/tispark/auth/TiAuthorization.scala
+++ b/core/src/main/scala/com/pingcap/tispark/auth/TiAuthorization.scala
@@ -191,6 +191,7 @@ case class TiAuthorization private (parameters: Map[String, String], tiConf: TiC
   def visible(db: String, table: String): Boolean = {
     // Account who has ShowDBPriv is able to see all databases and tables regardless of revokes.
     if (globalPrivs.get().contains(MySQLPriv.AllPriv) || globalPrivs
+        .get().contains(MySQLPriv.SelectPriv) || globalPrivs
         .get()
         .contains(MySQLPriv.ShowDBPriv)) {
       return true


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
#2799

### What is changed and how it works?
when user has select priviledge, user can visit table.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

Code changes

 - Has exported function/method change

Side effects
No side effects.

Related changes
No related changes.
