### PR TITLE
Try to fix proto

### DIFF
--- a/.github/workflows/TLS-test.yml
+++ b/.github/workflows/TLS-test.yml
@@ -27,6 +27,12 @@ jobs:
           distribution: ${{ matrix.distribution }}
           cache: maven
 
+      - name: set up docker compose
+        uses: KengoTODA/actions-setup-docker-compose@v1
+        with:
+          version: '2.14.2' # the full version of `docker-compose` command
+
+
       - name: add host and copy properties
         run: |
           echo -e "127.0.0.1   pd \n127.0.0.1   tikv" | sudo tee -a /etc/hosts

--- a/tikv-client/BUILD
+++ b/tikv-client/BUILD
@@ -27,7 +27,7 @@ filegroup(
     name = "protos",
     srcs = glob([
          "kvproto/proto/*.proto",
-	      "kvproto/_vendor/src/github.com/gogo/protobuf/gogoproto/*.proto",
+	      "kvproto/_vendor/src/github.com/gogo/protobuf/tree/master/gogoproto/*.proto",
 	      "tipb/proto/*.proto",
     ]),
 )

--- a/tikv-client/BUILD
+++ b/tikv-client/BUILD
@@ -27,7 +27,7 @@ filegroup(
     name = "protos",
     srcs = glob([
          "kvproto/proto/*.proto",
-	      "kvproto/_vendor/src/github.com/gogo/protobuf/tree/master/gogoproto/*.proto",
+	      "kvproto/_vendor/src/github.com/gogo/protobuf/gogoproto/*.proto",
 	      "tipb/proto/*.proto",
     ]),
 )

--- a/tikv-client/scripts/proto.sh
+++ b/tikv-client/scripts/proto.sh
@@ -18,7 +18,7 @@ CURRENT_DIR=`pwd`
 TISPARK_HOME="$(cd "`dirname "$0"`"/../..; pwd)"
 cd $TISPARK_HOME/tikv-client
 
-tipb_hash=07c1d4cf43236a98d6299afbe864b628b52c0eae
+tipb_hash=29e23c62eeace5912f696d1b184b63d5dc3edcce
 
 if [ -d "tipb" ]; then
 	cd tipb; git fetch -p; git checkout ${tipb_hash}; cd ..

--- a/tikv-client/scripts/proto.sh
+++ b/tikv-client/scripts/proto.sh
@@ -18,7 +18,7 @@ CURRENT_DIR=`pwd`
 TISPARK_HOME="$(cd "`dirname "$0"`"/../..; pwd)"
 cd $TISPARK_HOME/tikv-client
 
-tipb_hash=4d69c6f95e683dfb5859277563bf896aca06ec34
+tipb_hash=07c1d4cf43236a98d6299afbe864b628b52c0eae
 
 if [ -d "tipb" ]; then
 	cd tipb; git fetch -p; git checkout ${tipb_hash}; cd ..


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

![image](https://github.com/user-attachments/assets/79bc7eea-8c95-40ac-8185-e4185a903ea0)



### What is changed and how it works?

1. The tipb commit 4d69c6f95e683dfb5859277563bf896aca06ec34 used by TiSpark is not exist(I think it is a typo before). Thus, tispark will use the master of tipb
2. https://github.com/pingcap/tipb/pull/347 add some proto option which can not be recognized by the proto version used by tispark. This pr is included in the tipb master.

in conclusion, we can fix by 
1. upgrade the proto vesion used by tispark (need to check which dependency is responsible for parsing proto)
2. use old commit of tipb

This PR use the second method and use commit 29e23c62eeace5912f696d1b184b63d5dc3edcce,because
- this pr needs this commit: https://github.com/pingcap/tispark/pull/2793




### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `tidb-ansible` repository
 - Need to be included in the release note
