### PR TITLE
provide invalidate region cache api 

### DIFF
--- a/tikv-client/src/main/java/com/pingcap/tikv/region/RegionManager.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/region/RegionManager.java
@@ -317,13 +317,8 @@ public class RegionManager {
           String.format(
               "clean all regions and stores, cache store size is %d, cache region size is %d",
               storeCache.size(), regionCache.asMapOfRanges().size()));
-      for (Iterator<Map.Entry<Long, Store>> storeEntry = storeCache.entrySet().iterator();
-          storeEntry.hasNext(); ) {
-        Map.Entry<Long, Store> store = storeEntry.next();
-        logger.debug(String.format("clean store %d", store.getKey()));
-        invalidateAllRegionForStore(store.getKey());
-        storeEntry.remove();
-      }
+      storeCache.clear();
+      regionCache.clear();
     }
 
     public synchronized Store getStoreById(long id, BackOffer backOffer) {

--- a/tikv-client/src/main/java/com/pingcap/tikv/region/RegionManager.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/region/RegionManager.java
@@ -317,10 +317,12 @@ public class RegionManager {
           String.format(
               "clean all regions and stores, cache store size is %d, cache region size is %d",
               storeCache.size(), regionCache.asMapOfRanges().size()));
-      for (Long storeId : storeCache.keySet()) {
-        logger.debug(String.format("clean store %d", storeId));
-        invalidateAllRegionForStore(storeId);
-        storeCache.remove(storeId);
+      for (Iterator<Map.Entry<Long, Store>> storeEntry = storeCache.entrySet().iterator();
+          storeEntry.hasNext(); ) {
+        Map.Entry<Long, Store> store = storeEntry.next();
+        logger.debug(String.format("clean store %d", store.getKey()));
+        invalidateAllRegionForStore(store.getKey());
+        storeEntry.remove();
       }
     }
 

--- a/tikv-client/src/main/java/com/pingcap/tikv/region/RegionManager.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/region/RegionManager.java
@@ -67,7 +67,7 @@ public class RegionManager {
   }
 
   public synchronized void setCacheInvalidateCallback(
-          Function<CacheInvalidateEvent, Void> cacheInvalidateCallback) {
+      Function<CacheInvalidateEvent, Void> cacheInvalidateCallback) {
     this.cacheInvalidateCallback = cacheInvalidateCallback;
   }
 
@@ -190,12 +190,16 @@ public class RegionManager {
     cache.invalidateStore(storeId);
   }
 
+  public void invalidateAllStoreAndRegion() {
+    cache.invalidateAllStoreAndRegion();
+  }
+
   public void invalidateRegion(TiRegion region) {
     cache.invalidateRegion(region);
   }
 
   public void invalidateRange(ByteString startKey, ByteString endKey) {
-    cache.invalidateRange(startKey,endKey);
+    cache.invalidateRange(startKey, endKey);
   }
 
   public static class RegionCache {
@@ -263,7 +267,8 @@ public class RegionManager {
     private synchronized void invalidateRange(ByteString startKey, ByteString endKey) {
       regionCache.remove(makeRange(startKey, endKey));
       if (logger.isDebugEnabled()) {
-        logger.debug(String.format("invalidateRange success, startKey[%s], endKey[%s]", startKey, endKey));
+        logger.debug(
+            String.format("invalidateRange success, startKey[%s], endKey[%s]", startKey, endKey));
       }
     }
 
@@ -288,6 +293,7 @@ public class RegionManager {
     public synchronized void invalidateAllRegionForStore(long storeId) {
       List<TiRegion> regionToRemove = new ArrayList<>();
       for (TiRegion r : regionCache.asMapOfRanges().values()) {
+        logger.debug(String.format("clean region %d", r.getId()));
         if (r.getLeader().getStoreId() == storeId) {
           if (logger.isDebugEnabled()) {
             logger.debug(String.format("invalidateAllRegionForStore Region[%s]", r));
@@ -304,6 +310,18 @@ public class RegionManager {
 
     public synchronized void invalidateStore(long storeId) {
       storeCache.remove(storeId);
+    }
+
+    public synchronized void invalidateAllStoreAndRegion() {
+      logger.info(
+          String.format(
+              "clean all regions and stores, cache store size is %d, cache region size is %d",
+              storeCache.size(), regionCache.asMapOfRanges().size()));
+      for (Long storeId : storeCache.keySet()) {
+        logger.debug(String.format("clean store %d", storeId));
+        invalidateAllRegionForStore(storeId);
+        storeCache.remove(storeId);
+      }
     }
 
     public synchronized Store getStoreById(long id, BackOffer backOffer) {


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
close #2809 


### What is changed and how it works?
Provide invalidate region cache api 
User can invalidate region cache use this code:

import com.pingcap.tikv.TiConfiguration
val tiConf = TiConfiguration.createDefault(spark.conf.get("spark.tispark.pd.addresses"))
com.pingcap.tikv.TiSession.getInstance(tiConf).getRegionManager().invalidateAllStoreAndRegion()
 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `tidb-ansible` repository
 - Need to be included in the release note
