### PR TITLE
add load table on 2.3.17.5

### DIFF
--- a/core/src/main/scala/com/pingcap/tispark/TiConfigConst.scala
+++ b/core/src/main/scala/com/pingcap/tispark/TiConfigConst.scala
@@ -58,4 +58,8 @@ object TiConfigConst {
 
   // preferred locations
   val PREFERRED_LOCATIONS = "spark.tispark.preferred_locations"
+
+  // cache load
+  val LOAD_TABLES: String = "spark.tispark.load_tables"
+  val DEFAULT_LOAD_TABLES: Boolean = true
 }

--- a/core/src/main/scala/com/pingcap/tispark/utils/TiUtil.scala
+++ b/core/src/main/scala/com/pingcap/tispark/utils/TiUtil.scala
@@ -138,6 +138,9 @@ object TiUtil {
       tiConf.setPreferredLocations(conf.get(TiConfigConst.PREFERRED_LOCATIONS))
     }
 
+    tiConf.setLoadTables(
+      conf.get(TiConfigConst.LOAD_TABLES, TiConfigConst.DEFAULT_LOAD_TABLES.toString).toBoolean)
+
     tiConf
   }
 

--- a/tikv-client/src/main/java/com/pingcap/tikv/TiConfiguration.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/TiConfiguration.java
@@ -96,6 +96,8 @@ public class TiConfiguration implements Serializable {
 
   private String preferredLocations = "";
 
+  private boolean loadTables = true;
+
   public static TiConfiguration createDefault(String pdAddrsStr) {
     Objects.requireNonNull(pdAddrsStr, "pdAddrsStr is null");
     TiConfiguration conf = new TiConfiguration();
@@ -366,5 +368,13 @@ public class TiConfiguration implements Serializable {
 
   public String getPreferredLocations() {
     return this.preferredLocations;
+  }
+
+  public void setLoadTables(boolean loadTables) {
+    this.loadTables = loadTables;
+  }
+
+  public boolean getLoadTables() {
+    return loadTables;
   }
 }

--- a/tikv-client/src/main/java/com/pingcap/tikv/TiSession.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/TiSession.java
@@ -138,7 +138,7 @@ public class TiSession implements AutoCloseable {
     if (res == null) {
       synchronized (this) {
         if (catalog == null) {
-          catalog = new Catalog(this::createSnapshot, conf.ifShowRowId(), conf.getDBPrefix(), getConf().getLoadTables());
+          catalog = new Catalog(this::createSnapshot, conf.ifShowRowId(), conf.getDBPrefix(), conf.getLoadTables());
         }
         res = catalog;
       }

--- a/tikv-client/src/main/java/com/pingcap/tikv/TiSession.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/TiSession.java
@@ -138,7 +138,7 @@ public class TiSession implements AutoCloseable {
     if (res == null) {
       synchronized (this) {
         if (catalog == null) {
-          catalog = new Catalog(this::createSnapshot, conf.ifShowRowId(), conf.getDBPrefix());
+          catalog = new Catalog(this::createSnapshot, conf.ifShowRowId(), conf.getDBPrefix(), getConf().getLoadTables());
         }
         res = catalog;
       }

--- a/tikv-client/src/main/java/com/pingcap/tikv/catalog/Catalog.java
+++ b/tikv-client/src/main/java/com/pingcap/tikv/catalog/Catalog.java
@@ -40,13 +40,15 @@ public class Catalog implements AutoCloseable {
   private final Supplier<Snapshot> snapshotProvider;
   private CatalogCache metaCache;
   private static final AtomicLong lastUpdateTime = new AtomicLong(0);
+  private final boolean loadTables;
 
-  public Catalog(Supplier<Snapshot> snapshotProvider, boolean showRowId, String dbPrefix) {
+  public Catalog(Supplier<Snapshot> snapshotProvider, boolean showRowId, String dbPrefix, boolean loadTables) {
     this.snapshotProvider = Objects.requireNonNull(snapshotProvider, "Snapshot Provider is null");
     this.showRowId = showRowId;
     this.dbPrefix = dbPrefix;
-    metaCache = new CatalogCache(new CatalogTransaction(snapshotProvider.get()), dbPrefix, false);
-    reloadCache(true);
+    this.loadTables = loadTables;
+    metaCache =
+            new CatalogCache(new CatalogTransaction(snapshotProvider.get()), dbPrefix, loadTables);
   }
 
   @Override
@@ -77,7 +79,7 @@ public class Catalog implements AutoCloseable {
 
   public List<TiTableInfo> listTables(TiDBInfo database) {
     Objects.requireNonNull(database, "database is null");
-    reloadCache(true);
+    reloadCache(loadTables);
     if (showRowId) {
       return metaCache
           .listTables(database)
@@ -147,7 +149,7 @@ public class Catalog implements AutoCloseable {
   public TiTableInfo getTable(TiDBInfo database, String tableName) {
     Objects.requireNonNull(database, "database is null");
     Objects.requireNonNull(tableName, "tableName is null");
-    reloadCache(true);
+    reloadCache(loadTables);
     TiTableInfo table = metaCache.getTable(database, tableName);
     if (showRowId && table != null) {
       return table.copyTableWithRowId();


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
close #2813 

### What is changed and how it works?
copy code from master 
Add spark.tispark.load_tables conf on 2.3.17.5
User can add this conf to disable table catalog load when job start

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `tidb-ansible` repository
 - Need to be included in the release note
